### PR TITLE
feat(mcp): programmatic Vitest runner, new tools, data pipeline improvements

### DIFF
--- a/.changeset/silver-owls-dream.md
+++ b/.changeset/silver-owls-dream.md
@@ -1,0 +1,26 @@
+---
+"vitest-agent-reporter": minor
+---
+
+## Features
+
+- The `run_tests` MCP tool now uses Vitest's programmatic API (`createVitest()` + `start()` from `vitest/node`) instead of `spawnSync`. Tests run in-process, results flow through the full reporter pipeline into SQLite, and stdout/stderr are redirected to a null writable to protect the MCP stdio transport. Closes #23.
+- Added `test_get` MCP tool for single-test drill-down. Returns the test's current state, error messages, classification badge (`[new-failure]`, `[persistent]`, `[flaky]`, `[stable]`, `[recovered]`), and run history.
+- Added `file_coverage` MCP tool for per-file coverage data, returning line, branch, function, and statement percentages along with uncovered line ranges.
+- `run_tests` output now includes classification badges and a Next Steps section after the run completes.
+- Reporter now captures suite hierarchy via `allSuites()`, writes test tags to the `tags` and `test_case_tags` tables, and parses error stacks into structured `stack_frames` rows.
+- Added a `coverage-improvement` skill to the Claude Code plugin with guidance on reading coverage gaps and writing tests to close them.
+
+## Bug Fixes
+
+- Fixed a crash when Vitest's `TestCase.diagnostic()` or `TestCase.result()` returns `undefined` for skipped, pending, or todo tests. Null guards have been added at all call sites in the report builder and reporter.
+- Fixed `note_get` to return a structured response instead of `null` when a note is found.
+- Fixed classification queries passing the wrong `subProject` parameter.
+- Fixed nested suite `parentSuiteId` tracking so suite hierarchies are stored correctly in the database.
+
+## Maintenance
+
+- Status icons in MCP tool output replaced with Unicode symbols.
+- `help.ts` updated to document all 24 current MCP tools.
+- Session-start hook trimmed from 63 lines to 15 lines, removing redundant context.
+- State enum validation added to the `test_list` discovery tool.

--- a/.claude/design/vitest-agent-reporter/architecture.md
+++ b/.claude/design/vitest-agent-reporter/architecture.md
@@ -3,9 +3,9 @@ status: current
 module: vitest-agent-reporter
 category: architecture
 created: 2026-03-20
-updated: 2026-03-25
-last-synced: 2026-03-25
-post-phase5-sync: 2026-03-25
+updated: 2026-04-23
+last-synced: 2026-04-23
+post-phase5-sync: 2026-04-23
 completeness: 95
 related:
   - vitest-agent-reporter/components.md
@@ -30,10 +30,10 @@ only what you need for the task at hand.
 
 | Document | Load when... | Content |
 | -------- | ------------ | ------- |
-| [components.md](./components.md) | Working on specific components, need API details | 26 component descriptions with interfaces and dependencies |
+| [components.md](./components.md) | Working on specific components, need API details | 25 component descriptions with interfaces and dependencies |
 | [decisions.md](./decisions.md) | Need to understand "why" something was built a certain way | 27 architectural decisions, 9 design patterns, constraints/trade-offs |
 | [data-structures.md](./data-structures.md) | Working with schemas, DB schema, output, or data flow | File structure, TypeScript interfaces, SQLite schema, output format, data flow diagrams, integration points |
-| [testing-and-phases.md](./testing-and-phases.md) | Writing tests, reviewing test coverage, or checking phase status | 51 test files, test patterns, Phase 1-5 history |
+| [testing-and-phases.md](./testing-and-phases.md) | Writing tests, reviewing test coverage, or checking phase status | 52 test files, test patterns, Phase 1-5 history |
 
 ---
 
@@ -94,15 +94,16 @@ systems, implemented across five phases:
      replaces three-environment model. 4 built-in formatters: `markdown`,
      `gfm`, `json`, `silent`. `--format` flag on all CLI commands.
    - **5c: MCP server** -- tRPC router with `@modelcontextprotocol/sdk`
-     stdio transport. 21 MCP tools for test status, coverage, history,
-     trends, errors, test-for-file, run_tests, cache health, configure,
-     full note CRUD, and discovery tools (project/test/module/suite/
-     settings listing). `McpLive` composition layer.
+     stdio transport. 24 MCP tools for help, test status, coverage,
+     history, trends, errors, test-for-file, test-get, file-coverage,
+     run_tests, cache health, configure, full note CRUD, and discovery
+     tools (project/test/module/suite/settings listing). `McpLive`
+     composition layer.
    - **5d: Claude Code plugin** -- file-based plugin at `plugin/`
      directory with `.claude-plugin/plugin.json` manifest, `.mcp.json`
      for MCP auto-registration, SessionStart and PostToolUse hooks,
-     3 skills (TDD, debugging, configuration), and 2 commands (setup,
-     configure).
+     4 skills (TDD, debugging, configuration, coverage-improvement),
+     and 2 commands (setup, configure).
 
 The package complements Vitest's built-in `agent` reporter. The built-in
 handles console noise suppression in-process; this package adds persistence
@@ -157,10 +158,11 @@ plugin (NOT a pnpm workspace). The root `vitest.config.ts` imports from
   for JSON encode/decode
 - **Duck-type istanbul** -- structural interface avoids hard peer dependency;
   works with both `v8` and `istanbul` coverage providers
-- **MCP-first agent integration** -- MCP server exposes 21 tools via
+- **MCP-first agent integration** -- MCP server exposes 24 tools via
   tRPC router, giving agents structured access to test data, coverage,
-  history, trends, errors, note management, and discovery queries
-  (project/test/module/suite/settings listing) without parsing CLI output
+  history, trends, errors, per-file coverage, individual test details,
+  note management, and discovery queries (project/test/module/suite/
+  settings listing) without parsing CLI output
 - **CLI-first overview** -- overview/status generated on-demand by CLI, not
   on every test run. Keeps the reporter lean
 - **Three-level coverage model** -- Vitest-native `coverageThresholds`
@@ -262,10 +264,11 @@ plugin (NOT a pnpm workspace). The root `vitest.config.ts` imports from
      |           MCP Server (stdio)                |
      |  (ManagedRuntime + McpLive + tRPC router)   |
      |                                             |
-     |  21 tools via @modelcontextprotocol/sdk:    |
-     |  test_status, test_overview, test_coverage, |
-     |  test_history, test_trends, test_errors,    |
-     |  test_for_file, run_tests, cache_health,    |
+     |  24 tools via @modelcontextprotocol/sdk:    |
+     |  help, test_status, test_overview,          |
+     |  test_coverage, test_history, test_trends,  |
+     |  test_errors, test_for_file, test_get,      |
+     |  file_coverage, run_tests, cache_health,    |
      |  configure, project_list, test_list,        |
      |  module_list, suite_list, settings_list,    |
      |  note_create/list/get/update/delete/search  |
@@ -282,7 +285,8 @@ plugin (NOT a pnpm workspace). The root `vitest.config.ts` imports from
      |  .mcp.json -> auto-registers MCP server     |
      |  hooks/session-start.sh -> context inject   |
      |  hooks/post-test-run.sh -> test detection   |
-     |  skills: TDD, debugging, configuration      |
+     |  skills: TDD, debugging, configuration,     |
+     |          coverage-improvement                |
      |  commands: setup, configure                 |
      +--------------------------------------------+
 ```
@@ -364,7 +368,7 @@ For detailed component descriptions, interfaces, and APIs:
 - Working with data schemas or output format --> [data-structures.md](./data-structures.md)
 - Writing or reviewing tests --> [testing-and-phases.md](./testing-and-phases.md)
 
-**51 test files, 547 tests total.** All coverage metrics above 80%.
+**52 test files, 569 tests total.** All coverage metrics above 80%.
 
 **Document Status:** Current -- reflects Phase 1 through Phase 5
 implementation plus post-Phase-5 refinements (multi-project support,

--- a/.claude/design/vitest-agent-reporter/components.md
+++ b/.claude/design/vitest-agent-reporter/components.md
@@ -3,9 +3,9 @@ status: current
 module: vitest-agent-reporter
 category: architecture
 created: 2026-03-20
-updated: 2026-03-25
-last-synced: 2026-03-25
-post-phase5-sync: 2026-03-25
+updated: 2026-04-23
+last-synced: 2026-04-23
+post-phase5-sync: 2026-04-23
 completeness: 95
 related:
   - vitest-agent-reporter/architecture.md
@@ -386,8 +386,9 @@ test data from SQLite database and project structure. Does not run tests or
 call AI providers. All commands support `--format` flag for output format
 selection.
 
-**Entry point:** `package/src/cli/index.ts` exports `runCli()`. Bin wrapper
-at `package/bin/vitest-agent-reporter.js` is a thin shebang wrapper.
+**Entry point:** `package/src/cli/index.ts` exports `runCli()`. The
+`package.json` `bin` field points directly to `./src/cli/index.ts`;
+build outputs produce `bin/vitest-agent-reporter.js` in `dist/`.
 
 **Commands:**
 
@@ -421,7 +422,7 @@ at `package/bin/vitest-agent-reporter.js` is a thin shebang wrapper.
 - Depends on: `@effect/cli` for command framework, DataReader service,
   ProjectDiscovery service, HistoryTracker service, OutputRenderer service,
   `@effect/platform-node` for NodeRuntime
-- Used by: `package/bin/vitest-agent-reporter.js`
+- Used by: `vitest-agent-reporter` bin entry (package.json)
 
 ---
 
@@ -546,6 +547,8 @@ wrapping.
   compatibility, delegates to markdown formatter)
 - `format-gfm.ts` -- legacy GFM formatter (kept for backward
   compatibility, delegates to gfm formatter)
+- `format-fatal-error.ts` -- formats fatal error output for unhandled
+  reporter errors
 - `build-report.ts` -- AgentReport builder with duck-typed Vitest interfaces
 - `detect-pm.ts` -- package manager detection
 
@@ -743,13 +746,13 @@ database. Replaces CacheReader from Phase 2-4.
 - `getLatestSettings()` -- returns `Option<SettingsRow>` for the most
   recent settings snapshot (used by MCP `configure` tool when no hash
   is specified)
-- `listTests(project?, subProject?, state?, limit?)` -- returns
-  `TestListEntry[]` for test case discovery
-- `listModules(project?, subProject?, state?, limit?)` -- returns
-  `ModuleListEntry[]` for test module discovery
-- `listSuites(project?, subProject?, limit?)` -- returns
+- `listTests(project, subProject, options?: { state?, module?, limit? })`
+  -- returns `TestListEntry[]` for test case discovery
+- `listModules(project, subProject)` -- returns `ModuleListEntry[]` for
+  test module discovery
+- `listSuites(project, subProject, options?: { module? })` -- returns
   `SuiteListEntry[]` for test suite discovery
-- `listSettings(limit?)` -- returns `SettingsListEntry[]` for settings
+- `listSettings()` -- returns `SettingsListEntry[]` for settings
   snapshot discovery
 
 **Key output types:**
@@ -852,7 +855,7 @@ OutputRenderer.render(reports, format, context)
 
 **Status:** COMPLETE (Phase 5c)
 
-**Purpose:** Model Context Protocol server providing 21 tools for agent
+**Purpose:** Model Context Protocol server providing 24 tools for agent
 integration. Uses `@modelcontextprotocol/sdk` with stdio transport and
 tRPC for routing.
 
@@ -863,8 +866,9 @@ creates `ManagedRuntime` with `McpLive(dbPath)`, starts stdio transport.
 
 - `context.ts` -- tRPC context definition with `ManagedRuntime` carrying
   DataReader, DataStore, ProjectDiscovery, OutputRenderer services
-- `router.ts` -- tRPC router aggregating all 21 tool procedures
+- `router.ts` -- tRPC router aggregating all 24 tool procedures
 - `server.ts` -- `startMcpServer()` registers all tools with the MCP SDK
+- `tools/help.ts` -- `help` tool (list all available tools)
 - `tools/status.ts` -- `test_status` tool
 - `tools/overview.ts` -- `test_overview` tool
 - `tools/coverage.ts` -- `test_coverage` tool
@@ -872,20 +876,27 @@ creates `ManagedRuntime` with `McpLive(dbPath)`, starts stdio transport.
 - `tools/trends.ts` -- `test_trends` tool
 - `tools/errors.ts` -- `test_errors` tool
 - `tools/test-for-file.ts` -- `test_for_file` tool
+- `tools/test-get.ts` -- `test_get` tool (single test detail)
+- `tools/file-coverage.ts` -- `file_coverage` tool (per-file coverage)
 - `tools/run-tests.ts` -- `run_tests` tool (executes `vitest run` via
   `spawnSync`)
 - `tools/cache-health.ts` -- `cache_health` tool
 - `tools/configure.ts` -- `configure` tool (view captured settings)
 - `tools/notes.ts` -- `note_create`, `note_list`, `note_get`,
   `note_update`, `note_delete`, `note_search` tools
-- `tools/discovery.ts` -- `project_list`, `test_list`, `module_list`,
-  `suite_list`, `settings_list` tools
+- `tools/project-list.ts` -- `project_list` tool
+- `tools/test-list.ts` -- `test_list` tool
+- `tools/module-list.ts` -- `module_list` tool
+- `tools/suite-list.ts` -- `suite_list` tool
+- `tools/settings-list.ts` -- `settings_list` tool
 
 **Tool categories:**
 
+- **Meta tools** (return markdown): `help`
 - **Read-only query tools** (return markdown): `test_status`,
   `test_overview`, `test_coverage`, `test_history`, `test_trends`,
-  `test_errors`, `test_for_file`, `cache_health`, `configure`
+  `test_errors`, `test_for_file`, `test_get`, `file_coverage`,
+  `cache_health`, `configure`
 - **Discovery tools** (return markdown): `project_list`, `test_list`,
   `module_list`, `suite_list`, `settings_list`
 - **Mutation tools** (return text): `run_tests`
@@ -909,7 +920,7 @@ creates `ManagedRuntime` with `McpLive(dbPath)`, starts stdio transport.
 
 **Status:** COMPLETE (Phase 5c)
 
-**Purpose:** tRPC router aggregating all 21 MCP tool procedures. The context
+**Purpose:** tRPC router aggregating all 24 MCP tool procedures. The context
 carries a `ManagedRuntime` for Effect service access, allowing tRPC
 procedures to call Effect services via `ctx.runtime.runPromise(effect)`.
 
@@ -950,6 +961,7 @@ integration in Claude Code sessions.
 - `skills/tdd/SKILL.md` -- TDD workflow skill
 - `skills/debugging/SKILL.md` -- test debugging skill
 - `skills/configuration/SKILL.md` -- Vitest configuration skill
+- `skills/coverage-improvement/SKILL.md` -- coverage improvement skill
 - `commands/setup.md` -- setup command
 - `commands/configure.md` -- configure command
 
@@ -977,9 +989,10 @@ Replaces the previous `debug` boolean option with fine-grained
 **Configuration:**
 
 - `logLevel` option: `"Debug"`, `"Info"`, `"Warning"`, `"Error"`,
-  `"None"` (default). Case-insensitive via `resolveLogLevel` helper
-  (lowercase "debug" normalized to "Debug")
-- `logFile` option: optional file path for NDJSON log output
+  `"None"` (default). Case-insensitive via `resolveLogLevel()` helper
+  (exported from `LoggerLive.ts`; lowercase "debug" normalized to "Debug")
+- `logFile` option: optional file path for NDJSON log output, resolved
+  via `resolveLogFile()` helper (exported from `LoggerLive.ts`)
 - Environment variable fallback: `VITEST_REPORTER_LOG_LEVEL`,
   `VITEST_REPORTER_LOG_FILE`
 - Uses `Logger.structuredLogger` for NDJSON format

--- a/.claude/design/vitest-agent-reporter/data-structures.md
+++ b/.claude/design/vitest-agent-reporter/data-structures.md
@@ -3,9 +3,9 @@ status: current
 module: vitest-agent-reporter
 category: architecture
 created: 2026-03-20
-updated: 2026-03-25
-last-synced: 2026-03-25
-post-phase5-sync: 2026-03-25
+updated: 2026-04-23
+last-synced: 2026-04-23
+post-phase5-sync: 2026-04-23
 completeness: 95
 related:
   - vitest-agent-reporter/architecture.md
@@ -60,9 +60,10 @@ package/
     mcp/
       index.ts            -- MCP server entry point (resolves DB, starts stdio)
       context.ts          -- tRPC context with ManagedRuntime
-      router.ts           -- tRPC router aggregating 21 tool procedures
+      router.ts           -- tRPC router aggregating 24 tool procedures
       server.ts           -- startMcpServer() registering tools with MCP SDK
       tools/
+        help.ts           -- help tool (list all available tools)
         status.ts         -- test_status tool
         overview.ts       -- test_overview tool
         coverage.ts       -- test_coverage tool
@@ -70,12 +71,17 @@ package/
         trends.ts         -- test_trends tool
         errors.ts         -- test_errors tool
         test-for-file.ts  -- test_for_file tool
+        test-get.ts       -- test_get tool (single test detail)
+        test-list.ts      -- test_list tool
+        file-coverage.ts  -- file_coverage tool (per-file coverage)
         run-tests.ts      -- run_tests tool (vitest run via spawnSync)
         cache-health.ts   -- cache_health tool
         configure.ts      -- configure tool (view captured settings)
         notes.ts          -- note CRUD (create/list/get/update/delete/search)
-        discovery.ts      -- project_list, test_list, module_list,
-                             suite_list, settings_list tools
+        project-list.ts   -- project_list tool
+        module-list.ts    -- module_list tool
+        suite-list.ts     -- suite_list tool
+        settings-list.ts  -- settings_list tool
 
     services/
       DataStore.ts        -- Context.Tag: write to SQLite
@@ -141,16 +147,11 @@ package/
       capture-env.ts      -- captures CI/GitHub/Runner env vars
       capture-settings.ts -- captures Vitest config + computes hash
       classify-test.ts    -- pure test classification function
-      resolve-log-level.ts -- normalizes case-insensitive log level names
-      resolve-log-file.ts -- resolves log file path with env var fallback
       format-console.ts   -- legacy console formatter (delegates to markdown)
       format-gfm.ts       -- legacy GFM formatter (delegates to gfm)
+      format-fatal-error.ts -- formats fatal error output for reporter errors
       build-report.ts     -- pure function: AgentReport builder + duck-typed
                              Vitest interfaces
-
-  bin/
-    vitest-agent-reporter.js      -- shebang wrapper for CLI
-    vitest-agent-reporter-mcp.js  -- shebang wrapper for MCP server
 
 plugin/
   .claude-plugin/
@@ -164,6 +165,7 @@ plugin/
     tdd/SKILL.md          -- TDD workflow skill
     debugging/SKILL.md    -- test debugging skill
     configuration/SKILL.md -- Vitest configuration skill
+    coverage-improvement/SKILL.md -- coverage improvement skill
   commands/
     setup.md              -- setup command
     configure.md          -- configure command
@@ -204,11 +206,11 @@ package/src/
     FormatSelectorLive.test.ts  -- format selection
     DetailResolverLive.test.ts  -- detail level resolution
     OutputRendererLive.test.ts  -- formatter dispatch
+    LoggerLive.test.ts          -- structured logging layer
   mcp/
     router.test.ts          -- tRPC router integration tests
     tools/
       run-tests.test.ts     -- run_tests tool (spawnSync)
-      discovery.test.ts     -- discovery tools (project/test/module/suite/settings)
   migrations/
     0001_initial.test.ts    -- migration schema verification
   schemas/
@@ -238,9 +240,10 @@ package/src/
     split-project.test.ts   -- project name splitting
     capture-env.test.ts     -- env var capture
     capture-settings.test.ts -- settings capture + hash computation
+    format-fatal-error.test.ts -- fatal error formatting
 ```
 
-**51 test files, 547 tests total.** All coverage metrics (statements,
+**52 test files, 569 tests total.** All coverage metrics (statements,
 branches, functions, lines) are above 80%.
 
 ---
@@ -560,39 +563,35 @@ interface PersistentFailure {
   lastErrorMessage: string | null;
 }
 
-// DataReader discovery types (feat/upgrade)
+// DataReader discovery types
 interface TestListEntry {
+  id: number;
   fullName: string;
-  state: "passed" | "failed" | "skipped" | "pending";
-  modulePath: string;
+  state: string;
   duration: number | null;
-  project: string;
-  subProject: string | null;
+  module: string;
+  classification: string | null;
 }
 
 interface ModuleListEntry {
-  filePath: string;
-  state: "passed" | "failed" | "skipped" | "pending";
-  duration: number | null;
+  id: number;
+  file: string;
+  state: string;
   testCount: number;
-  project: string;
-  subProject: string | null;
+  duration: number | null;
 }
 
 interface SuiteListEntry {
+  id: number;
   name: string;
-  fullName: string;
-  state: "passed" | "failed" | "skipped" | "pending";
-  modulePath: string;
-  project: string;
-  subProject: string | null;
+  module: string;
+  state: string;
+  testCount: number;
 }
 
 interface SettingsListEntry {
   hash: string;
-  createdAt: string;
-  pool: string | null;
-  coverageProvider: string | null;
+  capturedAt: string;
 }
 
 // Common schema literals (Phase 5)
@@ -918,7 +917,7 @@ GFM content is appended (not overwritten) to support multiple steps.
 ### Integration 4: Consumer LLM Agents
 
 **MCP pattern (preferred):** Agents connect via MCP stdio transport and
-use the 21 tools for structured data access.
+use the 24 tools for structured data access.
 
 **CLI pattern:** Run `vitest-agent-reporter status` for quick overview,
 `vitest-agent-reporter overview` for test landscape, or
@@ -973,7 +972,7 @@ configuration pointing to `npx vitest-agent-reporter-mcp`
 - `SessionStart` -> `hooks/session-start.sh` (context injection)
 - `PostToolUse` on `Bash` -> `hooks/post-test-run.sh` (test detection)
 
-**Skills:** TDD, debugging, configuration (markdown files)
+**Skills:** TDD, debugging, configuration, coverage-improvement (markdown files)
 
 **Commands:** setup, configure (markdown files)
 

--- a/.claude/design/vitest-agent-reporter/decisions.md
+++ b/.claude/design/vitest-agent-reporter/decisions.md
@@ -3,9 +3,9 @@ status: current
 module: vitest-agent-reporter
 category: architecture
 created: 2026-03-20
-updated: 2026-03-23
-last-synced: 2026-03-23
-post-phase5-sync: 2026-03-23
+updated: 2026-04-23
+last-synced: 2026-04-23
+post-phase5-sync: 2026-04-23
 completeness: 95
 related:
   - vitest-agent-reporter/architecture.md
@@ -353,7 +353,7 @@ layer inline.
 
 ### Decision 19: tRPC for MCP Routing (Phase 5c)
 
-**Context:** The MCP server needs to expose 16 tools. Each tool needs
+**Context:** The MCP server needs to expose 24 tools. Each tool needs
 input validation, type-safe context access, and testable procedure logic.
 
 **Options considered:**

--- a/.claude/design/vitest-agent-reporter/testing-and-phases.md
+++ b/.claude/design/vitest-agent-reporter/testing-and-phases.md
@@ -3,9 +3,9 @@ status: current
 module: vitest-agent-reporter
 category: testing
 created: 2026-03-20
-updated: 2026-03-25
-last-synced: 2026-03-25
-post-phase5-sync: 2026-03-25
+updated: 2026-04-23
+last-synced: 2026-04-23
+post-phase5-sync: 2026-04-23
 completeness: 95
 related:
   - vitest-agent-reporter/architecture.md
@@ -44,6 +44,7 @@ MCP tools are tested via tRPC caller factory.
   objects, tallying, error extraction, omitPassingTests behavior
 - `utils/format-console.test.ts` -- legacy `formatConsoleMarkdown()` tests
 - `utils/format-gfm.test.ts` -- legacy `formatGfm()` tests
+- `utils/format-fatal-error.test.ts` -- fatal error formatting
 - `utils/resolve-thresholds.test.ts` -- `resolveThresholds()` Vitest-native
   format parsing, `100` shorthand, per-glob patterns, `getMinThreshold()`
 - `utils/compute-trend.test.ts` -- `computeTrend()` trend entry computation,
@@ -85,6 +86,7 @@ MCP tools are tested via tRPC caller factory.
 - `layers/FormatSelectorLive.test.ts` -- format selection logic
 - `layers/DetailResolverLive.test.ts` -- detail level resolution
 - `layers/OutputRendererLive.test.ts` -- formatter dispatch
+- `layers/LoggerLive.test.ts` -- structured logging layer
 - `formatters/markdown.test.ts` -- tiered console markdown formatting,
   coverage gaps, trend summaries, CLI hints
 - `formatters/gfm.test.ts` -- GFM formatting, single and multi-project
@@ -96,8 +98,6 @@ MCP tools are tested via tRPC caller factory.
   domain types from row data
 - `mcp/router.test.ts` -- tRPC router integration tests via caller factory
 - `mcp/tools/run-tests.test.ts` -- run_tests tool spawnSync behavior
-- `mcp/tools/discovery.test.ts` -- discovery tools (project_list, test_list,
-  module_list, suite_list, settings_list)
 - `cli/lib/format-status.test.ts` -- status formatting
 - `cli/lib/format-overview.test.ts` -- overview formatting
 - `cli/lib/format-coverage.test.ts` -- coverage formatting with thresholds
@@ -234,8 +234,6 @@ bugs.
 - `package/src/schemas/*.ts`, `package/src/utils/*.ts`
 - `package/src/cli/index.ts`, `package/src/cli/commands/*.ts`,
   `package/src/cli/lib/*.ts`
-- `package/bin/vitest-agent-reporter.js`
-
 **Depends on:** Phase 1 (architecture, data structures, test patterns)
 
 ### Phase 3: Suggested Actions and Failure History -- COMPLETE
@@ -535,11 +533,11 @@ Four sub-phases executed on the `feat/db-mcp` branch:
 
 **Deliverables (all implemented):**
 
-- **tRPC router** (`package/src/mcp/router.ts`) with 21 procedures
+- **tRPC router** (`package/src/mcp/router.ts`) with 24 procedures
   aggregating all MCP tools
 - **MCP server** (`package/src/mcp/server.ts`) using
   `@modelcontextprotocol/sdk` with StdioServerTransport, registers all
-  21 tools with Zod input schemas
+  24 tools with Zod input schemas
 - **tRPC context** (`package/src/mcp/context.ts`) carrying `ManagedRuntime`
   for Effect service access
 - **Entry point** (`package/src/mcp/index.ts`) resolves DB path, creates
@@ -548,17 +546,18 @@ Four sub-phases executed on the `feat/db-mcp` branch:
   DataReaderLive + DataStoreLive + ProjectDiscoveryLive +
   OutputPipelineLive + SqliteClient + Migrator + NodeContext +
   NodeFileSystem
-- **21 MCP tools:**
+- **24 MCP tools:**
+  - Meta (markdown): `help`
   - Read-only (markdown): `test_status`, `test_overview`, `test_coverage`,
     `test_history`, `test_trends`, `test_errors`, `test_for_file`,
-    `cache_health`, `configure`
+    `test_get`, `file_coverage`, `cache_health`, `configure`
   - Discovery (markdown): `project_list`, `test_list`, `module_list`,
     `suite_list`, `settings_list`
   - Mutation (text): `run_tests`
   - Note CRUD (markdown for list/search, JSON for create/get/update/
     delete): `note_create`, `note_list`, `note_get`, `note_update`,
     `note_delete`, `note_search`
-- **12 tool implementation files** in `package/src/mcp/tools/`
+- **19 tool implementation files** in `package/src/mcp/tools/`
 
 **Dependencies added:** `@modelcontextprotocol/sdk`, `@trpc/server`, `zod`
 
@@ -566,14 +565,19 @@ Four sub-phases executed on the `feat/db-mcp` branch:
 
 - `package/src/mcp/context.ts`, `package/src/mcp/router.ts`,
   `package/src/mcp/server.ts`, `package/src/mcp/index.ts`
-- `package/src/mcp/tools/status.ts`, `package/src/mcp/tools/overview.ts`,
-  `package/src/mcp/tools/coverage.ts`, `package/src/mcp/tools/history.ts`,
-  `package/src/mcp/tools/trends.ts`, `package/src/mcp/tools/errors.ts`,
-  `package/src/mcp/tools/test-for-file.ts`,
+- `package/src/mcp/tools/help.ts`, `package/src/mcp/tools/status.ts`,
+  `package/src/mcp/tools/overview.ts`, `package/src/mcp/tools/coverage.ts`,
+  `package/src/mcp/tools/history.ts`, `package/src/mcp/tools/trends.ts`,
+  `package/src/mcp/tools/errors.ts`, `package/src/mcp/tools/test-for-file.ts`,
+  `package/src/mcp/tools/test-get.ts`, `package/src/mcp/tools/test-list.ts`,
+  `package/src/mcp/tools/file-coverage.ts`,
   `package/src/mcp/tools/run-tests.ts`,
   `package/src/mcp/tools/cache-health.ts`,
   `package/src/mcp/tools/configure.ts`, `package/src/mcp/tools/notes.ts`,
-  `package/src/mcp/tools/discovery.ts`
+  `package/src/mcp/tools/project-list.ts`,
+  `package/src/mcp/tools/module-list.ts`,
+  `package/src/mcp/tools/suite-list.ts`,
+  `package/src/mcp/tools/settings-list.ts`
 - `package/src/layers/McpLive.ts`
 
 **New test files:**
@@ -594,10 +598,11 @@ Four sub-phases executed on the `feat/db-mcp` branch:
     context into the Claude Code session via bash
   - `PostToolUse` on `Bash` -> `plugin/hooks/post-test-run.sh` -- detects
     vitest test runs and triggers post-run actions
-- **3 Skills:**
+- **4 Skills:**
   - `plugin/skills/tdd/SKILL.md` -- TDD workflow guidance
   - `plugin/skills/debugging/SKILL.md` -- test debugging workflow
   - `plugin/skills/configuration/SKILL.md` -- Vitest configuration guidance
+  - `plugin/skills/coverage-improvement/SKILL.md` -- coverage improvement
 - **2 Commands:**
   - `plugin/commands/setup.md` -- initial setup instructions
   - `plugin/commands/configure.md` -- configuration management
@@ -616,6 +621,7 @@ build step, or tests.
 - `plugin/skills/tdd/SKILL.md`
 - `plugin/skills/debugging/SKILL.md`
 - `plugin/skills/configuration/SKILL.md`
+- `plugin/skills/coverage-improvement/SKILL.md`
 - `plugin/commands/setup.md`
 - `plugin/commands/configure.md`
 
@@ -714,5 +720,5 @@ complete. These are not a new phase but a set of fixes and enhancements.
 ---
 
 **Document Status:** Current -- reflects Phase 1 through Phase 5
-implementation plus post-Phase-5 refinements. 547 tests across 51 files,
+implementation plus post-Phase-5 refinements. 569 tests across 52 files,
 all coverage metrics above 80%. All phases complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,35 +19,47 @@ commands to the main package, use `--filter='./package'`.
 ## Project Status
 
 `vitest-agent-reporter` is a Vitest reporter and plugin for LLM coding agents.
-Phases 1-3 are complete. Four primary capabilities:
+All phases (1-5) are complete. Six primary capabilities:
 
-1. **`AgentReporter`** -- Vitest Reporter producing structured markdown
-   (console), persistent JSON (disk), and optional GFM (GitHub Actions)
+1. **`AgentReporter`** -- Vitest Reporter (>= 3.2.0) producing formatted
+   output via pluggable formatters, persistent data to SQLite (`data.db`),
+   and optional GFM (GitHub Actions)
 2. **`AgentPlugin`** -- Vitest plugin that injects `AgentReporter` with
-   three-environment detection (agent/CI/human), reporter chain management,
-   cache directory resolution, and coverage threshold extraction
+   four-environment detection (`agent-shell`/`terminal`/`ci-github`/
+   `ci-generic`), reporter chain management, cache directory resolution,
+   and coverage threshold/target extraction
 3. **`vitest-agent-reporter` CLI** -- `@effect/cli`-based bin with `status`,
-   `overview`, `coverage`, and `history` subcommands for on-demand test
-   landscape queries
+   `overview`, `coverage`, `history`, `trends`, `cache`, and `doctor`
+   subcommands. All commands support `--format` flag
 4. **Suggested actions & failure history** -- actionable suggestions in
    console output, per-test failure persistence across runs, and test
    classification (`stable`, `new-failure`, `persistent`, `flaky`,
    `recovered`) for regression vs flake detection
+5. **Coverage thresholds, baselines, and trends** -- Vitest-native
+   `coverageThresholds` format, aspirational `coverageTargets`, and
+   auto-ratcheting baselines with per-project trend tracking
+6. **MCP server & Claude Code plugin** -- 21 MCP tools via tRPC router
+   for structured agent access to test data, plus file-based Claude Code
+   plugin at `plugin/`
 
-Effect service architecture: all I/O encapsulated in six Effect services
-(AgentDetection, CacheWriter, CacheReader, CoverageAnalyzer, ProjectDiscovery,
-HistoryTracker) with live and test layer implementations. All data structures
-use Effect Schema
-definitions (`package/src/schemas/`) with `typeof Schema.Type` for TypeScript
-types and `Schema.decodeUnknown`/`Schema.encodeUnknown` for JSON encode/decode.
-Schemas are part of the public API.
+Effect service architecture: all I/O encapsulated in ten Effect services
+(DataStore, DataReader, EnvironmentDetector, ExecutorResolver,
+FormatSelector, DetailResolver, OutputRenderer, CoverageAnalyzer,
+ProjectDiscovery, HistoryTracker) with live and test layer implementations.
+All data structures use Effect Schema definitions (`package/src/schemas/`)
+with `typeof Schema.Type` for TypeScript types. Schemas are part of the
+public API.
 
 Source layout: `package/src/services/` (Effect tags),
 `package/src/layers/` (live + test),
 `package/src/schemas/` (Effect Schema definitions),
 `package/src/utils/` (pure functions),
 `package/src/cli/` (commands + lib),
-`package/src/errors/` (tagged errors).
+`package/src/errors/` (tagged errors),
+`package/src/formatters/` (markdown, gfm, json, silent),
+`package/src/mcp/` (MCP server + tRPC router + 21 tools),
+`package/src/migrations/` (SQLite schema),
+`package/src/sql/` (row types + assemblers).
 
 **Spec:** [GitHub Issue #1](https://github.com/spencerbeggs/vitest-agent-reporter/issues/1)
 
@@ -207,6 +219,6 @@ workflow. The GitHub Action is at
 
 - **Framework**: [Vitest](https://vitest.dev/) with v8 coverage provider
 - **Pool**: Uses `forks` (not threads) for broader compatibility
-- **Config**: `vitest.config.ts` uses the `VitestConfig.create()` factory from
-  `@savvy-web/vitest`, which supports project-based filtering via `--project`
+- **Config**: `vitest.config.ts` uses plain `defineConfig` from `vitest/config`
+  with project-based filtering via `--project`
 - **CI**: `pnpm run ci:test` sets `CI=true` and enables coverage

--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
 		"typecheck": "turbo run types:check --log-prefix=none --log-order=grouped"
 	},
 	"devDependencies": {
-		"@savvy-web/changesets": "^0.7.3",
-		"@savvy-web/commitlint": "^0.5.1",
-		"@savvy-web/lint-staged": "^0.7.2",
+		"@savvy-web/changesets": "^0.8.0",
+		"@savvy-web/commitlint": "^0.5.2",
+		"@savvy-web/lint-staged": "^1.0.0",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
-		"@vitest/coverage-v8": "^4.1.2",
+		"@vitest/coverage-v8": "^4.1.5",
 		"typescript": "catalog:silk",
-		"vitest": "^4.1.2",
+		"vitest": "^4.1.5",
 		"vitest-agent-reporter": "workspace:*"
 	},
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",

--- a/package/package.json
+++ b/package/package.json
@@ -44,14 +44,15 @@
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@trpc/server": "^11.16.0",
 		"effect": "catalog:silk",
-		"std-env": "^4.0.0",
+		"std-env": "^4.1.0",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
-		"@savvy-web/rslib-builder": "^0.19.1",
-		"@vitest/coverage-v8": "^4.1.2",
-		"vite": "^8.0.3",
-		"vitest": "^4.1.2"
+		"@savvy-web/rslib-builder": "^0.20.2",
+		"@types/node": "catalog:silk",
+		"@vitest/coverage-v8": "^4.1.5",
+		"vite": "^8.0.10",
+		"vitest": "^4.1.5"
 	},
 	"peerDependencies": {
 		"@vitest/coverage-istanbul": ">=4.1.0",

--- a/package/src/layers/DataReaderLive.ts
+++ b/package/src/layers/DataReaderLive.ts
@@ -964,6 +964,50 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 				Effect.mapError((e) => new DataStoreError({ operation: "read", table: "settings", reason: String(e) })),
 			);
 
+		const getTestByFullName = (
+			project: string,
+			subProject: string | null,
+			fullName: string,
+		): Effect.Effect<Option.Option<TestListEntry>, DataStoreError> =>
+			Effect.gen(function* () {
+				yield* Effect.logDebug("getTestByFullName").pipe(Effect.annotateLogs({ project, subProject, fullName }));
+
+				const runs = yield* sql<{ id: number }>`SELECT id FROM test_runs
+					WHERE project = ${project} AND sub_project IS ${subProject}
+					ORDER BY timestamp DESC LIMIT 1`;
+
+				if (runs.length === 0) return Option.none();
+				const runId = runs[0].id;
+
+				const rows = yield* sql<{
+					id: number;
+					full_name: string;
+					state: string;
+					duration: number | null;
+					relative_module_id: string;
+					classification: string | null;
+				}>`SELECT tc.id, tc.full_name, tc.state, tc.duration, f.path as relative_module_id, tc.classification
+					FROM test_cases tc
+					JOIN test_modules tm ON tm.id = tc.module_id
+					JOIN files f ON f.id = tm.file_id
+					WHERE tm.run_id = ${runId} AND tc.full_name = ${fullName}
+					LIMIT 1`;
+
+				if (rows.length === 0) return Option.none();
+				const r = rows[0];
+				return Option.some({
+					id: r.id,
+					fullName: r.full_name,
+					state: r.state,
+					duration: r.duration,
+					module: r.relative_module_id,
+					classification: r.classification,
+				});
+			}).pipe(
+				Effect.annotateLogs("service", "DataReader"),
+				Effect.mapError((e) => new DataStoreError({ operation: "read", table: "test_cases", reason: String(e) })),
+			);
+
 		const listTests = (
 			project: string,
 			subProject: string | null,
@@ -1197,6 +1241,7 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 			getManifest,
 			getSettings,
 			getLatestSettings,
+			getTestByFullName,
 			listTests,
 			listModules,
 			listSuites,

--- a/package/src/layers/DataStoreLive.ts
+++ b/package/src/layers/DataStoreLive.ts
@@ -112,7 +112,19 @@ export const DataStoreLive: Layer.Layer<DataStore, never, SqlClient> = Layer.eff
 				for (const tc of tests) {
 					yield* sql`INSERT INTO test_cases (module_id, suite_id, vitest_id, name, full_name, state, classification, duration, start_time, flaky, slow, retry_count, repeat_count, heap, mode, each, fails, concurrent, shuffle, timeout, skip_note, location_line, location_column) VALUES (${moduleId}, ${tc.suiteId ?? null}, ${tc.vitestId ?? null}, ${tc.name}, ${tc.fullName}, ${tc.state}, ${tc.classification ?? null}, ${tc.duration ?? null}, ${tc.startTime ?? null}, ${boolToInt(tc.flaky)}, ${boolToInt(tc.slow)}, ${tc.retryCount ?? 0}, ${tc.repeatCount ?? 0}, ${tc.heap ?? null}, ${tc.mode ?? null}, ${boolToInt(tc.each)}, ${boolToInt(tc.fails)}, ${boolToInt(tc.concurrent)}, ${boolToInt(tc.shuffle)}, ${tc.timeout ?? null}, ${tc.skipNote ?? null}, ${tc.locationLine ?? null}, ${tc.locationColumn ?? null})`;
 					const rows = yield* sql<{ id: number }>`SELECT last_insert_rowid() as id`;
-					ids.push(rows[0].id);
+					const testCaseId = rows[0].id;
+					ids.push(testCaseId);
+
+					// Write tags for this test case
+					if (tc.tags && tc.tags.length > 0) {
+						for (const tag of tc.tags) {
+							yield* sql`INSERT OR IGNORE INTO tags (name) VALUES (${tag})`;
+							const tagRows = yield* sql<{ id: number }>`SELECT id FROM tags WHERE name = ${tag}`;
+							if (tagRows.length > 0) {
+								yield* sql`INSERT OR IGNORE INTO test_case_tags (test_case_id, tag_id) VALUES (${testCaseId}, ${tagRows[0].id})`;
+							}
+						}
+					}
 				}
 				return ids;
 			}).pipe(
@@ -125,6 +137,23 @@ export const DataStoreLive: Layer.Layer<DataStore, never, SqlClient> = Layer.eff
 				yield* Effect.logDebug("writeErrors").pipe(Effect.annotateLogs({ runId, count: errors.length }));
 				for (const err of errors) {
 					yield* sql`INSERT INTO test_errors (run_id, test_case_id, test_suite_id, module_id, scope, name, message, diff, actual, expected, stack, cause_error_id, ordinal) VALUES (${runId}, ${err.testCaseId ?? null}, ${err.testSuiteId ?? null}, ${err.moduleId ?? null}, ${err.scope}, ${err.name ?? null}, ${err.message}, ${err.diff ?? null}, ${err.actual ?? null}, ${err.expected ?? null}, ${err.stack ?? null}, ${err.causeErrorId ?? null}, ${err.ordinal ?? 0})`;
+
+					// Parse stack trace into structured frames
+					if (err.stack) {
+						const errorIdRows = yield* sql<{ id: number }>`SELECT last_insert_rowid() as id`;
+						const errorId = errorIdRows[0].id;
+						const framePattern = /at\s+(?:(.+?)\s+)?\(?(.+?):(\d+):(\d+)\)?/g;
+						const frames = [...err.stack.matchAll(framePattern)];
+						for (let frameOrdinal = 0; frameOrdinal < frames.length; frameOrdinal++) {
+							const m = frames[frameOrdinal];
+							const method = m[1] ?? null;
+							const filePath = m[2];
+							const line = Number.parseInt(m[3], 10);
+							const col = Number.parseInt(m[4], 10);
+							const fileId = yield* ensureFile(filePath);
+							yield* sql`INSERT INTO stack_frames (error_id, ordinal, method, file_id, line, col) VALUES (${errorId}, ${frameOrdinal}, ${method}, ${fileId}, ${line}, ${col})`;
+						}
+					}
 				}
 			}).pipe(
 				Effect.annotateLogs("service", "DataStore"),

--- a/package/src/mcp/router.test.ts
+++ b/package/src/mcp/router.test.ts
@@ -276,4 +276,39 @@ describe("MCP Router", () => {
 		expect(result).toContain("Settings");
 		expect(result).toContain("Hash");
 	});
+
+	it("test_get returns test details for known test", async () => {
+		const caller = createTestCaller();
+		const result = await caller.test_get({ fullName: "utils > adds numbers", project: "default" });
+		expect(typeof result).toBe("string");
+		expect(result).toContain("utils > adds numbers");
+		expect(result).toContain("## Details");
+		expect(result).toContain("passed");
+		expect(result).toContain("src/utils.test.ts");
+	});
+
+	it("test_get returns not found for unknown test", async () => {
+		const caller = createTestCaller();
+		const result = await caller.test_get({ fullName: "nonexistent > test", project: "default" });
+		expect(result).toContain("Test not found");
+		expect(result).toContain("test_list");
+	});
+
+	it("file_coverage returns coverage data for tracked file", async () => {
+		const caller = createTestCaller();
+		const result = await caller.file_coverage({ filePath: "src/utils.ts", project: "default" });
+		expect(typeof result).toBe("string");
+		expect(result).toContain("src/utils.ts");
+		// File is in lowCoverage (branches at 70% below typical threshold)
+		// or shows project totals if not in lowCoverage list
+		expect(result).toMatch(/Metrics|Coverage Totals/);
+	});
+
+	it("file_coverage returns fallback for unknown file", async () => {
+		const caller = createTestCaller();
+		const result = await caller.file_coverage({ filePath: "nonexistent.ts", project: "default" });
+		expect(typeof result).toBe("string");
+		expect(result).toContain("nonexistent.ts");
+		expect(result).toContain("not in the low-coverage list");
+	});
 });

--- a/package/src/mcp/router.test.ts
+++ b/package/src/mcp/router.test.ts
@@ -165,17 +165,19 @@ describe("MCP Router", () => {
 
 		// Read
 		const note = await caller.note_get({ id });
-		expect(note?.title).toBe("Test Note");
+		expect(note.found).toBe(true);
+		if (note.found) expect(note.note.title).toBe("Test Note");
 
 		// Update
 		await caller.note_update({ id, title: "Updated" });
 		const updated = await caller.note_get({ id });
-		expect(updated?.title).toBe("Updated");
+		expect(updated.found).toBe(true);
+		if (updated.found) expect(updated.note.title).toBe("Updated");
 
 		// Delete
 		await caller.note_delete({ id });
 		const deleted = await caller.note_get({ id });
-		expect(deleted).toBeNull();
+		expect(deleted.found).toBe(false);
 	});
 
 	it("note_list returns no notes message for empty state", async () => {

--- a/package/src/mcp/router.ts
+++ b/package/src/mcp/router.ts
@@ -3,6 +3,7 @@ import { cacheHealth } from "./tools/cache-health.js";
 import { configure } from "./tools/configure.js";
 import { testCoverage } from "./tools/coverage.js";
 import { testErrors } from "./tools/errors.js";
+import { fileCoverage } from "./tools/file-coverage.js";
 import { help } from "./tools/help.js";
 import { testHistory } from "./tools/history.js";
 import { moduleList } from "./tools/module-list.js";
@@ -14,6 +15,7 @@ import { settingsList } from "./tools/settings-list.js";
 import { testStatus } from "./tools/status.js";
 import { suiteList } from "./tools/suite-list.js";
 import { testForFile } from "./tools/test-for-file.js";
+import { testGet } from "./tools/test-get.js";
 import { testList } from "./tools/test-list.js";
 import { testTrends } from "./tools/trends.js";
 
@@ -26,6 +28,8 @@ export const appRouter = router({
 	test_trends: testTrends,
 	test_errors: testErrors,
 	test_for_file: testForFile,
+	test_get: testGet,
+	file_coverage: fileCoverage,
 	run_tests: runTests,
 	cache_health: cacheHealth,
 	configure: configure,

--- a/package/src/mcp/server.ts
+++ b/package/src/mcp/server.ts
@@ -149,6 +149,48 @@ export async function startMcpServer(ctx: McpContext): Promise<void> {
 	);
 
 	server.registerTool(
+		"test_get",
+		{
+			description:
+				"Get detailed information about a single test: state, duration, errors, run history, and classification",
+			inputSchema: {
+				fullName: z.string().describe("Full test name (e.g. 'Suite > nested > test name')"),
+				project: z.optional(z.string()).describe("Project name"),
+				subProject: z.optional(z.string()).describe("Sub-project name"),
+			},
+		},
+		async (args) =>
+			textResult(
+				await caller.test_get({
+					fullName: args.fullName,
+					project: args.project,
+					subProject: args.subProject,
+				}),
+			),
+	);
+
+	server.registerTool(
+		"file_coverage",
+		{
+			description:
+				"Get coverage data for a specific source file: per-metric values, uncovered lines, and related tests",
+			inputSchema: {
+				filePath: z.string().describe("Source file path to check coverage for"),
+				project: z.optional(z.string()).describe("Project name"),
+				subProject: z.optional(z.string()).describe("Sub-project name"),
+			},
+		},
+		async (args) =>
+			textResult(
+				await caller.file_coverage({
+					filePath: args.filePath,
+					project: args.project,
+					subProject: args.subProject,
+				}),
+			),
+	);
+
+	server.registerTool(
 		"configure",
 		{
 			description: "View captured Vitest settings for a test run",
@@ -189,7 +231,7 @@ export async function startMcpServer(ctx: McpContext): Promise<void> {
 			inputSchema: {
 				project: z.optional(z.string()).describe("Project name"),
 				subProject: z.optional(z.string()).describe("Sub-project name"),
-				state: z.optional(z.string()).describe("Filter by test state (passed, failed, skipped)"),
+				state: z.optional(z.enum(["passed", "failed", "skipped", "pending"])).describe("Filter by test state"),
 				module: z.optional(z.string()).describe("Filter by module file path"),
 				limit: z.optional(z.number()).describe("Max number of results"),
 			},

--- a/package/src/mcp/tools/file-coverage.ts
+++ b/package/src/mcp/tools/file-coverage.ts
@@ -1,0 +1,98 @@
+import { Effect, Option, Schema } from "effect";
+import { DataReader } from "../../services/DataReader.js";
+import { publicProcedure } from "../context.js";
+
+export const fileCoverage = publicProcedure
+	.input(
+		Schema.standardSchemaV1(
+			Schema.Struct({
+				filePath: Schema.String,
+				project: Schema.optional(Schema.String),
+				subProject: Schema.optional(Schema.String),
+			}),
+		),
+	)
+	.query(async ({ ctx, input }) => {
+		return ctx.runtime.runPromise(
+			Effect.gen(function* () {
+				const reader = yield* DataReader;
+				const project = input.project ?? "default";
+				const subProject = input.subProject ?? null;
+
+				const coverageOpt = yield* reader.getCoverage(project, subProject);
+
+				if (Option.isNone(coverageOpt)) {
+					return "No coverage data available. Run tests with coverage enabled.";
+				}
+
+				const coverage = coverageOpt.value;
+
+				// Search lowCoverage for the file (try exact match, then suffix match)
+				const normalizedPath = input.filePath.replace(/^\.\//, "");
+				let match = coverage.lowCoverage.find((f) => f.file === normalizedPath);
+				if (!match) {
+					match = coverage.lowCoverage.find((f) => f.file.endsWith(normalizedPath) || normalizedPath.endsWith(f.file));
+				}
+
+				const lines: string[] = [`# Coverage: \`${normalizedPath}\``, ""];
+
+				if (match) {
+					const metrics = ["statements", "branches", "functions", "lines"] as const;
+					lines.push("## Metrics", "");
+					lines.push("| Metric | Value | Threshold |");
+					lines.push("| --- | --- | --- |");
+
+					for (const metric of metrics) {
+						const value = match.summary[metric];
+						const threshold = coverage.thresholds.global[metric];
+						const thresholdStr = threshold !== undefined ? `${threshold}%` : "\u2014";
+						const icon = threshold !== undefined && value < threshold ? "\u274C" : "\u2705";
+						lines.push(`| ${metric} | ${icon} ${value.toFixed(2)}% | ${thresholdStr} |`);
+					}
+
+					if (match.uncoveredLines) {
+						lines.push("");
+						lines.push(`## Uncovered Lines`);
+						lines.push("");
+						lines.push(`\`${match.uncoveredLines}\``);
+					}
+
+					lines.push("");
+					lines.push("## Next steps", "");
+					lines.push("- Use test_for_file to find tests covering this file");
+					lines.push("- Write tests targeting the uncovered lines");
+				} else {
+					// File not in lowCoverage — either fully covered or not in coverage data
+					lines.push("This file is not in the low-coverage list.");
+					lines.push("");
+					lines.push("Possible reasons:");
+					lines.push("- File meets all coverage thresholds");
+					lines.push("- File was not included in the coverage run");
+					lines.push("- File path does not match any tracked source file");
+					lines.push("");
+
+					// Show global totals for context
+					const { totals } = coverage;
+					lines.push("## Project Coverage Totals", "");
+					lines.push("| Metric | Value |");
+					lines.push("| --- | --- |");
+					lines.push(`| statements | ${totals.statements.toFixed(2)}% |`);
+					lines.push(`| branches | ${totals.branches.toFixed(2)}% |`);
+					lines.push(`| functions | ${totals.functions.toFixed(2)}% |`);
+					lines.push(`| lines | ${totals.lines.toFixed(2)}% |`);
+				}
+
+				// Related tests
+				const testFiles = yield* reader.getTestsForFile(normalizedPath);
+				if (testFiles.length > 0) {
+					lines.push("");
+					lines.push("## Tests Covering This File", "");
+					for (const tf of testFiles) {
+						lines.push(`- \`${tf}\``);
+					}
+				}
+
+				return lines.join("\n");
+			}),
+		);
+	});

--- a/package/src/mcp/tools/help.ts
+++ b/package/src/mcp/tools/help.ts
@@ -2,7 +2,7 @@ import { publicProcedure } from "../context.js";
 
 const HELP_TEXT = `# vitest-agent-reporter MCP Tools
 
-> 22 tools total.
+> 24 tools total.
 
 ## General
 
@@ -16,7 +16,9 @@ const HELP_TEXT = `# vitest-agent-reporter MCP Tools
 | ---- | ---------- | ----------- |
 | \`test_status\` | \`project?\` | Per-project test pass/fail state |
 | \`test_overview\` | \`project?\` | Test landscape with run metrics |
+| \`test_get\` | \`fullName\`, \`project?\`, \`subProject?\` | Single test drill-down: state, errors, history, classification |
 | \`test_coverage\` | \`project?\`, \`subProject?\` | Coverage gaps with uncovered lines |
+| \`file_coverage\` | \`filePath\`, \`project?\`, \`subProject?\` | Per-file coverage with uncovered lines and related tests |
 | \`test_history\` | \`project\`, \`subProject?\` | Flaky/persistent/recovered tests |
 | \`test_trends\` | \`project\`, \`subProject?\`, \`limit?\` | Coverage trajectory over time |
 | \`test_errors\` | \`project\`, \`subProject?\`, \`errorName?\` | Errors with diffs and stacks |

--- a/package/src/mcp/tools/module-list.ts
+++ b/package/src/mcp/tools/module-list.ts
@@ -21,7 +21,7 @@ export const moduleList = publicProcedure
 				const modules = yield* reader.listModules(project, subProject);
 
 				if (modules.length === 0) {
-					return "No modules found.";
+					return "No modules found. Run run_tests({}) to execute tests and populate the database.";
 				}
 
 				const lines: string[] = ["## Modules", ""];

--- a/package/src/mcp/tools/notes.ts
+++ b/package/src/mcp/tools/notes.ts
@@ -63,7 +63,7 @@ export const noteList = publicProcedure
 				const notes = yield* reader.getNotes(input.scope, input.project, input.testFullName);
 
 				if (notes.length === 0) {
-					return "No notes found.";
+					return "No notes found. Use note_create to add notes.";
 				}
 
 				const lines: string[] = ["## Notes", ""];
@@ -92,7 +92,10 @@ export const noteGet = publicProcedure
 			Effect.gen(function* () {
 				const reader = yield* DataReader;
 				const noteOpt = yield* reader.getNoteById(input.id);
-				return Option.getOrNull(noteOpt);
+				if (Option.isNone(noteOpt)) {
+					return { found: false as const, id: input.id };
+				}
+				return { found: true as const, note: noteOpt.value };
 			}),
 		);
 	});
@@ -159,7 +162,7 @@ export const noteSearch = publicProcedure
 				const notes = yield* reader.searchNotes(input.query);
 
 				if (notes.length === 0) {
-					return "No notes found.";
+					return "No notes found. Use note_create to add notes.";
 				}
 
 				const lines: string[] = [`## Notes matching "${input.query}"`, ""];

--- a/package/src/mcp/tools/run-tests.test.ts
+++ b/package/src/mcp/tools/run-tests.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeTestArgs } from "./run-tests.js";
+import { coerceErrors, formatReportMarkdown, sanitizeTestArgs } from "./run-tests.js";
 
 describe("sanitizeTestArgs", () => {
 	it("allows file paths", () => {
@@ -28,5 +28,136 @@ describe("sanitizeTestArgs", () => {
 
 	it("allows relative paths with slashes and dots", () => {
 		expect(sanitizeTestArgs(["./package/src/utils/ansi.test.ts"])).toEqual(["./package/src/utils/ansi.test.ts"]);
+	});
+});
+
+describe("coerceErrors", () => {
+	it("extracts message from Error-like objects", () => {
+		const result = coerceErrors([new Error("boom")]);
+		expect(result).toHaveLength(1);
+		expect(result[0].message).toBe("boom");
+	});
+
+	it("uses stacks array when present", () => {
+		const result = coerceErrors([{ message: "fail", stacks: ["frame1", "frame2"] }]);
+		expect(result[0].stacks).toEqual(["frame1", "frame2"]);
+	});
+
+	it("wraps stack string into stacks array", () => {
+		const result = coerceErrors([{ message: "fail", stack: "at foo:1:1" }]);
+		expect(result[0].stacks).toEqual(["at foo:1:1"]);
+	});
+
+	it("prefers stacks over stack when both are present", () => {
+		const result = coerceErrors([{ message: "fail", stacks: ["frame1"], stack: "ignored" }]);
+		expect(result[0].stacks).toEqual(["frame1"]);
+	});
+
+	it("converts non-object values to string messages", () => {
+		const result = coerceErrors(["string error", 42, null]);
+		expect(result[0].message).toBe("string error");
+		expect(result[1].message).toBe("42");
+		expect(result[2].message).toBe("null");
+	});
+
+	it("returns empty array for empty input", () => {
+		expect(coerceErrors([])).toEqual([]);
+	});
+});
+
+describe("formatReportMarkdown", () => {
+	it("formats a passing report", () => {
+		const report = {
+			timestamp: "2026-01-01T00:00:00.000Z",
+			reason: "passed" as const,
+			summary: { total: 3, passed: 3, failed: 0, skipped: 0, duration: 150 },
+			failed: [],
+			unhandledErrors: [],
+			failedFiles: [],
+		};
+
+		const md = formatReportMarkdown(report);
+		expect(md).toContain("3 passed");
+		expect(md).toContain("150ms");
+		expect(md).not.toContain("failed");
+	});
+
+	it("formats a failing report with errors", () => {
+		const report = {
+			timestamp: "2026-01-01T00:00:00.000Z",
+			reason: "failed" as const,
+			summary: { total: 2, passed: 1, failed: 1, skipped: 0, duration: 200 },
+			failed: [
+				{
+					file: "src/math.test.ts",
+					state: "failed" as const,
+					duration: 50,
+					tests: [
+						{
+							name: "adds numbers",
+							fullName: "Math > adds numbers",
+							state: "failed" as const,
+							duration: 10,
+							errors: [{ message: "expected 3 to equal 4", diff: "- 3\n+ 4" }],
+						},
+					],
+				},
+			],
+			unhandledErrors: [],
+			failedFiles: ["src/math.test.ts"],
+		};
+
+		const md = formatReportMarkdown(report);
+		expect(md).toContain("1 failed");
+		expect(md).toContain("1 passed");
+		expect(md).toContain("src/math.test.ts");
+		expect(md).toContain("Math > adds numbers");
+		expect(md).toContain("expected 3 to equal 4");
+		expect(md).toContain("diff");
+	});
+
+	it("includes project name when present", () => {
+		const report = {
+			timestamp: "2026-01-01T00:00:00.000Z",
+			project: "my-lib",
+			reason: "passed" as const,
+			summary: { total: 1, passed: 1, failed: 0, skipped: 0, duration: 10 },
+			failed: [],
+			unhandledErrors: [],
+			failedFiles: [],
+		};
+
+		const md = formatReportMarkdown(report);
+		expect(md).toContain("Project: my-lib");
+	});
+
+	it("formats unhandled errors", () => {
+		const report = {
+			timestamp: "2026-01-01T00:00:00.000Z",
+			reason: "failed" as const,
+			summary: { total: 0, passed: 0, failed: 0, skipped: 0, duration: 0 },
+			failed: [],
+			unhandledErrors: [{ message: "global crash", stack: "at top-level" }],
+			failedFiles: [],
+		};
+
+		const md = formatReportMarkdown(report);
+		expect(md).toContain("Unhandled Errors");
+		expect(md).toContain("global crash");
+		expect(md).toContain("at top-level");
+	});
+
+	it("shows skipped count when present", () => {
+		const report = {
+			timestamp: "2026-01-01T00:00:00.000Z",
+			reason: "passed" as const,
+			summary: { total: 5, passed: 3, failed: 0, skipped: 2, duration: 100 },
+			failed: [],
+			unhandledErrors: [],
+			failedFiles: [],
+		};
+
+		const md = formatReportMarkdown(report);
+		expect(md).toContain("2 skipped");
 	});
 });

--- a/package/src/mcp/tools/run-tests.ts
+++ b/package/src/mcp/tools/run-tests.ts
@@ -168,31 +168,19 @@ export const runTests = publicProcedure
 
 			const report = buildAgentReport(testModules, unhandledErrors, reason, { omitPassingTests: true });
 
-			// Read classifications from DB (written by the reporter during vitest.start)
+			// Read stored classifications from DB (written by the reporter via
+			// classifyTest() during vitest.start). This avoids reimplementing
+			// classification logic and stays consistent with AgentReporter.
 			let classifications: ReadonlyMap<string, string> | undefined;
 			try {
 				const project = input.project ?? "default";
-				const subProject: string | null = null;
 				classifications = await ctx.runtime.runPromise(
 					Effect.gen(function* () {
 						const reader = yield* DataReader;
-						const history = yield* reader.getHistory(project, subProject);
-						const map = new Map<string, string>();
-						for (const entry of history.tests) {
-							if (entry.runs.length > 0) {
-								const lastState = entry.runs[entry.runs.length - 1].state;
-								const prevStates = entry.runs.slice(0, -1).map((r: { state: string }) => r.state);
-								if (lastState === "failed") {
-									const hadPriorRuns = prevStates.length > 0;
-									const prevFailed = prevStates.some((s: string) => s === "failed");
-									const prevPassed = prevStates.some((s: string) => s === "passed");
-									if (!hadPriorRuns || !prevFailed) map.set(entry.fullName, "new-failure");
-									else if (prevPassed && prevFailed) map.set(entry.fullName, "flaky");
-									else map.set(entry.fullName, "persistent");
-								}
-							}
-						}
-						return map;
+						const tests = yield* reader.listTests(project, null, {});
+						return new Map(
+							tests.filter((t) => t.classification != null).map((t) => [t.fullName, t.classification as string]),
+						);
 					}),
 				);
 			} catch {

--- a/package/src/mcp/tools/run-tests.ts
+++ b/package/src/mcp/tools/run-tests.ts
@@ -1,5 +1,9 @@
-import { spawnSync } from "node:child_process";
-import { Schema } from "effect";
+import { Writable } from "node:stream";
+import { Effect, Schema } from "effect";
+import type { AgentReport } from "../../schemas/AgentReport.js";
+import { DataReader } from "../../services/DataReader.js";
+import type { VitestModuleError } from "../../utils/build-report.js";
+import { buildAgentReport } from "../../utils/build-report.js";
 import { publicProcedure } from "../context.js";
 
 const FORBIDDEN_CHARS = /[;|&`$(){}[\]<>!#]/;
@@ -15,6 +19,94 @@ export function sanitizeTestArgs(args: readonly string[]): string[] {
 	return result;
 }
 
+/**
+ * Coerce unknown Vitest unhandled errors into VitestModuleError shape.
+ *
+ * @internal
+ */
+export function coerceErrors(errors: readonly unknown[]): VitestModuleError[] {
+	return errors.map((e) => {
+		if (e && typeof e === "object" && "message" in e) {
+			const err = e as { message: string; stacks?: string[]; stack?: string };
+			return {
+				message: String(err.message),
+				...(err.stacks ? { stacks: err.stacks } : err.stack ? { stacks: [err.stack] } : {}),
+			};
+		}
+		return { message: String(e) };
+	});
+}
+
+/**
+ * Format an AgentReport as concise markdown suitable for MCP tool output.
+ *
+ * Classifications map test fullName to labels like "new-failure",
+ * "persistent", "flaky", "recovered", "stable". Populated from DB
+ * after the reporter writes history.
+ *
+ * @internal
+ */
+export function formatReportMarkdown(report: AgentReport, classifications?: ReadonlyMap<string, string>): string {
+	const lines: string[] = [];
+	const { summary } = report;
+	const status = summary.failed > 0 ? "\u274C" : "\u2705";
+
+	lines.push(
+		`## ${status} Vitest -- ${summary.failed > 0 ? `${summary.failed} failed, ` : ""}${summary.passed} passed${summary.skipped > 0 ? `, ${summary.skipped} skipped` : ""} (${summary.duration}ms)`,
+	);
+
+	if (report.project) {
+		lines.push(`\nProject: ${report.project}`);
+	}
+
+	for (const mod of report.failed) {
+		lines.push(`\n### \u274C \`${mod.file}\``);
+		for (const test of mod.tests) {
+			if (test.state !== "failed") continue;
+			const badge = classifications?.get(test.fullName);
+			const label = badge ? ` [${badge}]` : "";
+			lines.push(`\n- \u274C **${test.fullName}**${label}`);
+			if (test.errors) {
+				for (const err of test.errors) {
+					lines.push(`  ${err.message}`);
+					if (err.diff) {
+						lines.push(`\n  \`\`\`diff\n  ${err.diff}\n  \`\`\``);
+					}
+				}
+			}
+		}
+	}
+
+	if (report.unhandledErrors.length > 0) {
+		lines.push("\n### Unhandled Errors");
+		for (const err of report.unhandledErrors) {
+			lines.push(`\n- ${err.message}`);
+			if (err.stack) {
+				lines.push(`  \`\`\`\n  ${err.stack}\n  \`\`\``);
+			}
+		}
+	}
+
+	// Next steps
+	if (summary.failed > 0 || report.unhandledErrors.length > 0) {
+		const newFailures = classifications ? [...classifications.values()].filter((c) => c === "new-failure").length : 0;
+		const persistent = classifications ? [...classifications.values()].filter((c) => c === "persistent").length : 0;
+		const flaky = classifications ? [...classifications.values()].filter((c) => c === "flaky").length : 0;
+
+		lines.push("\n### Next steps\n");
+		if (newFailures > 0) lines.push(`- ${newFailures} new failure${newFailures > 1 ? "s" : ""} since last run`);
+		if (persistent > 0) lines.push(`- ${persistent} persistent failure${persistent > 1 ? "s" : ""} (pre-existing)`);
+		if (flaky > 0) lines.push(`- ${flaky} flaky test${flaky > 1 ? "s" : ""} -- consider retrying`);
+		lines.push("- Use test_errors for detailed error analysis");
+		lines.push("- Use test_history to check failure patterns");
+		if (report.failedFiles.length > 0) {
+			lines.push(`- Re-run failed: run_tests({ files: ${JSON.stringify(report.failedFiles)} })`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
 export const runTests = publicProcedure
 	.input(
 		Schema.standardSchemaV1(
@@ -26,45 +118,96 @@ export const runTests = publicProcedure
 		),
 	)
 	.mutation(async ({ ctx, input }) => {
-		const args = ["vitest", "run", "--coverage.enabled=false"];
-		if (input.files) {
-			args.push(...sanitizeTestArgs(input.files));
-		}
+		const files = input.files ? sanitizeTestArgs(input.files) : [];
 		if (input.project) {
-			args.push("--project", ...sanitizeTestArgs([input.project]));
+			sanitizeTestArgs([input.project]);
 		}
 
 		const timeoutMs = (input.timeout ?? 120) * 1000;
 
-		// Strip coverage env vars so the spawned vitest process doesn't
-		// interfere with the parent's v8 coverage collection (avoids
-		// ENOENT on coverage/.tmp files in CI).
-		const env = { ...process.env };
-		delete env.NODE_V8_COVERAGE;
-
-		// Use spawnSync with array args to avoid shell interpretation.
-		// This handles file paths with spaces correctly and eliminates
-		// shell injection risk entirely (no shell involved).
-		const result = spawnSync("npx", args, {
-			cwd: ctx.cwd,
-			timeout: timeoutMs,
-			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "pipe"],
-			env,
+		// The MCP server communicates over stdio, so Vitest's console
+		// output must not leak into stdout. Redirect to a null writable.
+		const nullStream = new Writable({
+			write(_chunk, _encoding, cb) {
+				cb();
+			},
 		});
 
-		const stdout = result.stdout ?? "";
-		const stderr = result.stderr ?? "";
-		const exitCode = result.status ?? 1;
+		// Dynamic import: vitest/node is only needed when this tool is
+		// invoked. Keeps the MCP server startup fast.
+		const { createVitest } = await import("vitest/node");
 
-		if (!stdout && !stderr) {
-			return "Tests completed with no output.";
+		let vitest: Awaited<ReturnType<typeof createVitest>> | undefined;
+
+		try {
+			vitest = await createVitest(
+				"test",
+				{
+					root: ctx.cwd,
+					run: true,
+					coverage: { enabled: false },
+					...(input.project ? { project: input.project } : {}),
+				},
+				{}, // viteOverrides
+				{
+					stdout: nullStream as unknown as NodeJS.WriteStream,
+					stderr: nullStream as unknown as NodeJS.WriteStream,
+				},
+			);
+
+			const result = await Promise.race([
+				vitest.start(files.length > 0 ? files : undefined),
+				new Promise<never>((_, reject) => setTimeout(() => reject(new Error("VITEST_TIMEOUT")), timeoutMs)),
+			]);
+
+			const testModules = result.testModules as unknown as Parameters<typeof buildAgentReport>[0];
+			const unhandledErrors = coerceErrors(result.unhandledErrors);
+
+			const reason =
+				unhandledErrors.length > 0 || result.testModules.some((m) => m.state() === "failed") ? "failed" : "passed";
+
+			const report = buildAgentReport(testModules, unhandledErrors, reason, { omitPassingTests: true });
+
+			// Read classifications from DB (written by the reporter during vitest.start)
+			let classifications: ReadonlyMap<string, string> | undefined;
+			try {
+				const project = input.project ?? "default";
+				const subProject: string | null = null;
+				classifications = await ctx.runtime.runPromise(
+					Effect.gen(function* () {
+						const reader = yield* DataReader;
+						const history = yield* reader.getHistory(project, subProject);
+						const map = new Map<string, string>();
+						for (const entry of history.tests) {
+							if (entry.runs.length > 0) {
+								const lastState = entry.runs[entry.runs.length - 1].state;
+								const prevStates = entry.runs.slice(0, -1).map((r: { state: string }) => r.state);
+								if (lastState === "failed") {
+									const hadPriorRuns = prevStates.length > 0;
+									const prevFailed = prevStates.some((s: string) => s === "failed");
+									const prevPassed = prevStates.some((s: string) => s === "passed");
+									if (!hadPriorRuns || !prevFailed) map.set(entry.fullName, "new-failure");
+									else if (prevPassed && prevFailed) map.set(entry.fullName, "flaky");
+									else map.set(entry.fullName, "persistent");
+								}
+							}
+						}
+						return map;
+					}),
+				);
+			} catch {
+				// Classification is best-effort; don't fail the tool if DB read fails
+			}
+
+			return formatReportMarkdown(report, classifications);
+		} catch (err) {
+			if (err instanceof Error && err.message === "VITEST_TIMEOUT") {
+				return `Test run timed out after ${input.timeout ?? 120} seconds.`;
+			}
+			const message = err instanceof Error ? err.message : String(err);
+			return `Test run failed: ${message}`;
+		} finally {
+			await vitest?.close();
+			nullStream.destroy();
 		}
-
-		let output = stdout;
-		if (exitCode !== 0 && stderr.trim().length > 0) {
-			output += `\n\n### Errors\n\n\`\`\`\n${stderr}\n\`\`\``;
-		}
-
-		return output || "Tests completed with no output.";
 	});

--- a/package/src/mcp/tools/run-tests.ts
+++ b/package/src/mcp/tools/run-tests.ts
@@ -70,7 +70,11 @@ export function formatReportMarkdown(report: AgentReport, classifications?: Read
 				for (const err of test.errors) {
 					lines.push(`  ${err.message}`);
 					if (err.diff) {
-						lines.push(`\n  \`\`\`diff\n  ${err.diff}\n  \`\`\``);
+						const diff =
+							err.diff.length > 1000
+								? `${err.diff.slice(0, 1000)}\n... (truncated, ${err.diff.length} chars total)`
+								: err.diff;
+						lines.push(`\n  \`\`\`diff\n  ${diff}\n  \`\`\``);
 					}
 				}
 			}
@@ -119,9 +123,7 @@ export const runTests = publicProcedure
 	)
 	.mutation(async ({ ctx, input }) => {
 		const files = input.files ? sanitizeTestArgs(input.files) : [];
-		if (input.project) {
-			sanitizeTestArgs([input.project]);
-		}
+		const project = input.project ? sanitizeTestArgs([input.project])[0] : undefined;
 
 		const timeoutMs = (input.timeout ?? 120) * 1000;
 
@@ -146,7 +148,7 @@ export const runTests = publicProcedure
 					root: ctx.cwd,
 					run: true,
 					coverage: { enabled: false },
-					...(input.project ? { project: input.project } : {}),
+					...(project ? { project } : {}),
 				},
 				{}, // viteOverrides
 				{
@@ -155,10 +157,15 @@ export const runTests = publicProcedure
 				},
 			);
 
+			let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 			const result = await Promise.race([
 				vitest.start(files.length > 0 ? files : undefined),
-				new Promise<never>((_, reject) => setTimeout(() => reject(new Error("VITEST_TIMEOUT")), timeoutMs)),
-			]);
+				new Promise<never>((_, reject) => {
+					timeoutHandle = setTimeout(() => reject(new Error("VITEST_TIMEOUT")), timeoutMs);
+				}),
+			]).finally(() => {
+				if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+			});
 
 			const testModules = result.testModules as unknown as Parameters<typeof buildAgentReport>[0];
 			const unhandledErrors = coerceErrors(result.unhandledErrors);
@@ -173,11 +180,11 @@ export const runTests = publicProcedure
 			// classification logic and stays consistent with AgentReporter.
 			let classifications: ReadonlyMap<string, string> | undefined;
 			try {
-				const project = input.project ?? "default";
+				const classProject = project ?? "default";
 				classifications = await ctx.runtime.runPromise(
 					Effect.gen(function* () {
 						const reader = yield* DataReader;
-						const tests = yield* reader.listTests(project, null, {});
+						const tests = yield* reader.listTests(classProject, null, {});
 						return new Map(
 							tests.filter((t) => t.classification != null).map((t) => [t.fullName, t.classification as string]),
 						);

--- a/package/src/mcp/tools/suite-list.ts
+++ b/package/src/mcp/tools/suite-list.ts
@@ -25,7 +25,7 @@ export const suiteList = publicProcedure
 				const suites = yield* reader.listSuites(project, subProject, opts);
 
 				if (suites.length === 0) {
-					return "No suites found.";
+					return "No suites found. Run run_tests({}) to execute tests and populate the database.";
 				}
 
 				const lines: string[] = ["## Suites", ""];

--- a/package/src/mcp/tools/test-for-file.ts
+++ b/package/src/mcp/tools/test-for-file.ts
@@ -17,7 +17,7 @@ export const testForFile = publicProcedure
 				const testFiles = yield* reader.getTestsForFile(input.filePath);
 
 				if (testFiles.length === 0) {
-					return `No test modules found covering \`${input.filePath}\`.`;
+					return `No test modules found covering \`${input.filePath}\`. Run run_tests({}) to populate the database, or check the file path.`;
 				}
 
 				const lines: string[] = [

--- a/package/src/mcp/tools/test-get.ts
+++ b/package/src/mcp/tools/test-get.ts
@@ -1,0 +1,106 @@
+import { Effect, Schema } from "effect";
+import { DataReader } from "../../services/DataReader.js";
+import { publicProcedure } from "../context.js";
+
+export const testGet = publicProcedure
+	.input(
+		Schema.standardSchemaV1(
+			Schema.Struct({
+				fullName: Schema.String,
+				project: Schema.optional(Schema.String),
+				subProject: Schema.optional(Schema.String),
+			}),
+		),
+	)
+	.query(async ({ ctx, input }) => {
+		return ctx.runtime.runPromise(
+			Effect.gen(function* () {
+				const reader = yield* DataReader;
+				const project = input.project ?? "default";
+				const subProject = input.subProject ?? null;
+
+				// Find the test by fullName (no limit — must search all tests)
+				const tests = yield* reader.listTests(project, subProject, {});
+				const test = tests.find((t) => t.fullName === input.fullName);
+
+				if (!test) {
+					return `Test not found: \`${input.fullName}\`\n\nUse test_list to discover available tests.`;
+				}
+
+				const lines: string[] = [`# Test: ${test.fullName}`, ""];
+
+				// Basic info
+				lines.push("## Details", "");
+				lines.push("| Field | Value |");
+				lines.push("| --- | --- |");
+				lines.push(`| State | ${test.state} |`);
+				lines.push(`| Duration | ${test.duration !== null ? `${test.duration}ms` : "\u2014"} |`);
+				lines.push(`| Module | \`${test.module}\` |`);
+				lines.push(`| Classification | ${test.classification ?? "\u2014"} |`);
+				lines.push("");
+
+				// Errors for this test
+				const errors = yield* reader.getErrors(project, subProject);
+				const testErrors = errors.filter((e) => e.testFullName === input.fullName);
+
+				if (testErrors.length > 0) {
+					lines.push("## Errors", "");
+					for (const err of testErrors) {
+						lines.push(`**${err.name ?? "(unnamed)"}**`);
+						lines.push(`> ${err.message.split("\n").join("\n> ")}`);
+						if (err.diff) {
+							lines.push("");
+							lines.push("```diff");
+							lines.push(err.diff.slice(0, 1000));
+							if (err.diff.length > 1000) {
+								lines.push(`... (truncated, ${err.diff.length} chars total)`);
+							}
+							lines.push("```");
+						}
+						if (err.stack && !err.diff) {
+							lines.push("");
+							lines.push("```");
+							lines.push(err.stack.slice(0, 1000));
+							if (err.stack.length > 1000) {
+								lines.push(`... (truncated, ${err.stack.length} chars total)`);
+							}
+							lines.push("```");
+						}
+						lines.push("");
+					}
+				}
+
+				// History for this test
+				const history = yield* reader.getHistory(project, subProject);
+				const testHistory = history.tests.find((t) => t.fullName === input.fullName);
+
+				if (testHistory && testHistory.runs.length > 0) {
+					lines.push("## Run History", "");
+					const runs = testHistory.runs;
+					const viz = runs
+						.map((r: { state: string }) => (r.state === "passed" ? "P" : r.state === "failed" ? "F" : "S"))
+						.join("");
+					const passCount = runs.filter((r: { state: string }) => r.state === "passed").length;
+					const failCount = runs.filter((r: { state: string }) => r.state === "failed").length;
+					lines.push(`Pass rate: ${passCount}/${runs.length} (${Math.round((passCount / runs.length) * 100)}%)`);
+					lines.push(`Recent runs: \`${viz}\` (P=passed F=failed S=skipped, newest last)`);
+					if (failCount > 0 && passCount > 0) {
+						lines.push("Pattern: **flaky** (mixed pass/fail)");
+					} else if (failCount > 0) {
+						lines.push(`Pattern: **persistent failure** (${failCount} consecutive)`);
+					}
+					lines.push("");
+				}
+
+				// Suggest next actions
+				if (test.state === "failed") {
+					lines.push("## Next steps", "");
+					lines.push(`- Re-run: run_tests({ files: ["${test.module}"] })`);
+					lines.push("- Use test_for_file to find related tests");
+					lines.push("- Use note_create to record debugging findings");
+				}
+
+				return lines.join("\n");
+			}),
+		);
+	});

--- a/package/src/mcp/tools/test-get.ts
+++ b/package/src/mcp/tools/test-get.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect";
+import { Effect, Option, Schema } from "effect";
 import { DataReader } from "../../services/DataReader.js";
 import { publicProcedure } from "../context.js";
 
@@ -19,13 +19,13 @@ export const testGet = publicProcedure
 				const project = input.project ?? "default";
 				const subProject = input.subProject ?? null;
 
-				// Find the test by fullName (no limit — must search all tests)
-				const tests = yield* reader.listTests(project, subProject, {});
-				const test = tests.find((t) => t.fullName === input.fullName);
+				// Direct indexed lookup by fullName
+				const testOpt = yield* reader.getTestByFullName(project, subProject, input.fullName);
 
-				if (!test) {
-					return `Test not found: \`${input.fullName}\`\n\nUse test_list to discover available tests.`;
+				if (Option.isNone(testOpt)) {
+					return `Test not found: \`${input.fullName}\`\n\nUse test_list to discover available tests (format: "Suite > test name").`;
 				}
+				const test = testOpt.value;
 
 				const lines: string[] = [`# Test: ${test.fullName}`, ""];
 

--- a/package/src/mcp/tools/test-list.ts
+++ b/package/src/mcp/tools/test-list.ts
@@ -29,7 +29,7 @@ export const testList = publicProcedure
 				const tests = yield* reader.listTests(project, subProject, opts);
 
 				if (tests.length === 0) {
-					return "No tests found.";
+					return "No tests found. Run run_tests({}) to execute tests and populate the database.";
 				}
 
 				const lines: string[] = ["## Tests", ""];

--- a/package/src/reporter.test.ts
+++ b/package/src/reporter.test.ts
@@ -30,6 +30,7 @@ function makeTestCase(
 		type: "test",
 		name,
 		fullName: overrides.fullName ?? name,
+		tags: [],
 		result: () => {
 			const res: {
 				state: string;
@@ -69,6 +70,9 @@ function makeTestModule(
 		children: {
 			*allTests() {
 				for (const t of tests) yield t;
+			},
+			*allSuites() {
+				// No suites in test helpers
 			},
 		},
 		diagnostic: () => ({ duration: overrides.duration ?? 50 }),

--- a/package/src/reporter.ts
+++ b/package/src/reporter.ts
@@ -371,7 +371,7 @@ export class AgentReporter {
 				// Compute total duration for the run
 				let totalDuration = 0;
 				for (const mod of projectModules) {
-					totalDuration += mod.diagnostic().duration;
+					totalDuration += mod.diagnostic()?.duration ?? 0;
 				}
 
 				// Write test run to DB
@@ -401,7 +401,7 @@ export class AgentReporter {
 							fileId,
 							relativeModuleId: mod.relativeModuleId,
 							state: mod.state(),
-							duration: mod.diagnostic().duration,
+							duration: mod.diagnostic()?.duration ?? 0,
 						},
 					]);
 					const moduleId = moduleIds[0];
@@ -412,6 +412,29 @@ export class AgentReporter {
 						yield* store.writeSourceMap(sourceFile, moduleId, "convention");
 					}
 
+					// Write suites for this module, tracking IDs for parent relationships
+					const suiteIdMap = new Map<string, number>();
+					for (const suite of mod.children.allSuites()) {
+						const parentSuiteId =
+							suite.parent && suite.parent.type === "suite" ? suiteIdMap.get(suite.parent.fullName) : undefined;
+						const suiteIds = yield* store.writeSuites(moduleId, [
+							{
+								name: suite.name,
+								fullName: suite.fullName,
+								state: suite.state(),
+								...(parentSuiteId !== undefined && { parentSuiteId }),
+								...(suite.options?.mode !== undefined && { mode: suite.options.mode }),
+								...(suite.options?.concurrent !== undefined && { concurrent: suite.options.concurrent }),
+								...(suite.options?.shuffle !== undefined && { shuffle: suite.options.shuffle }),
+								...(suite.options?.retry !== undefined && { retry: suite.options.retry }),
+								...(suite.options?.repeats !== undefined && { repeats: suite.options.repeats }),
+								...(suite.location?.line !== undefined && { locationLine: suite.location.line }),
+								...(suite.location?.column !== undefined && { locationColumn: suite.location.column }),
+							} as Parameters<typeof store.writeSuites>[1][number],
+						]);
+						suiteIdMap.set(suite.fullName, suiteIds[0]);
+					}
+
 					// Collect test cases for this module
 					const testCases: Array<{
 						name: string;
@@ -420,6 +443,7 @@ export class AgentReporter {
 						duration?: number;
 						flaky?: boolean;
 						slow?: boolean;
+						tags?: readonly string[];
 					}> = [];
 					for (const testCase of mod.children.allTests()) {
 						const result = testCase.result();
@@ -427,10 +451,11 @@ export class AgentReporter {
 						testCases.push({
 							name: testCase.name,
 							fullName: testCase.fullName,
-							state: result.state,
-							duration: diag.duration,
-							flaky: diag.flaky,
-							slow: diag.slow,
+							state: result?.state ?? "pending",
+							...(diag?.duration !== undefined && { duration: diag.duration }),
+							...(diag?.flaky !== undefined && { flaky: diag.flaky }),
+							...(diag?.slow !== undefined && { slow: diag.slow }),
+							...(testCase.tags.length > 0 && { tags: testCase.tags }),
 						});
 					}
 
@@ -443,6 +468,7 @@ export class AgentReporter {
 							...(tc.duration !== undefined && { duration: tc.duration }),
 							...(tc.flaky !== undefined && { flaky: tc.flaky }),
 							...(tc.slow !== undefined && { slow: tc.slow }),
+							...(tc.tags !== undefined && { tags: tc.tags }),
 						})),
 					);
 
@@ -451,7 +477,7 @@ export class AgentReporter {
 					let testIdx = 0;
 					for (const testCase of mod.children.allTests()) {
 						const result = testCase.result();
-						if (result.errors && result.errors.length > 0) {
+						if (result?.errors && result.errors.length > 0) {
 							const testCaseId = testCaseIds[testIdx];
 							yield* store.writeErrors(
 								runId,
@@ -507,7 +533,7 @@ export class AgentReporter {
 				const testOutcomes: TestOutcome[] = [];
 				for (const mod of projectModules) {
 					for (const testCase of mod.children.allTests()) {
-						const state = testCase.result().state;
+						const state = testCase.result()?.state;
 						if (state === "passed" || state === "failed") {
 							testOutcomes.push({ fullName: testCase.fullName, state });
 						}
@@ -522,9 +548,10 @@ export class AgentReporter {
 				const errorMap = new Map<string, string | null>();
 				for (const mod of projectModules) {
 					for (const tc of mod.children.allTests()) {
-						diagMap.set(tc.fullName, tc.diagnostic());
-						if (tc.result().state === "failed") {
-							const errors = tc.result().errors;
+						diagMap.set(tc.fullName, tc.diagnostic() ?? {});
+						const tcResult = tc.result();
+						if (tcResult?.state === "failed") {
+							const errors = tcResult.errors;
 							errorMap.set(tc.fullName, errors?.[0]?.message ?? null);
 						}
 					}

--- a/package/src/services/DataReader.ts
+++ b/package/src/services/DataReader.ts
@@ -160,6 +160,11 @@ export class DataReader extends Context.Tag("vitest-agent-reporter/DataReader")<
 		readonly getManifest: () => Effect.Effect<Option.Option<CacheManifest>, DataStoreError>;
 		readonly getSettings: (hash: string) => Effect.Effect<Option.Option<SettingsRow>, DataStoreError>;
 		readonly getLatestSettings: () => Effect.Effect<Option.Option<SettingsRow>, DataStoreError>;
+		readonly getTestByFullName: (
+			project: string,
+			subProject: string | null,
+			fullName: string,
+		) => Effect.Effect<Option.Option<TestListEntry>, DataStoreError>;
 		readonly listTests: (
 			project: string,
 			subProject: string | null,

--- a/package/src/services/DataStore.ts
+++ b/package/src/services/DataStore.ts
@@ -69,6 +69,7 @@ export interface TestCaseInput {
 	readonly skipNote?: string;
 	readonly locationLine?: number;
 	readonly locationColumn?: number;
+	readonly tags?: readonly string[];
 }
 
 export interface TestErrorInput {

--- a/package/src/utils/build-report.test.ts
+++ b/package/src/utils/build-report.test.ts
@@ -19,6 +19,8 @@ function makeTestCase(
 		flaky: boolean;
 		slow: boolean;
 		errors: Array<{ message: string; diff?: string; stacks?: string[] }>;
+		/** When true, result() and diagnostic() return undefined (simulates pending/skipped tests) */
+		noDiagnostic: boolean;
 	}> = {},
 ): VitestTestCase {
 	const name = overrides.name ?? "my test";
@@ -26,18 +28,23 @@ function makeTestCase(
 		type: "test",
 		name,
 		fullName: overrides.fullName ?? name,
+		tags: [],
 		result: () => {
+			if (overrides.noDiagnostic) return undefined as never;
 			const res: { state: string; errors?: ReadonlyArray<{ message: string; diff?: string; stacks?: string[] }> } = {
 				state: overrides.state ?? "passed",
 			};
 			if (overrides.errors != null) res.errors = overrides.errors;
 			return res;
 		},
-		diagnostic: () => ({
-			duration: overrides.duration ?? 10,
-			flaky: overrides.flaky ?? false,
-			slow: overrides.slow ?? false,
-		}),
+		diagnostic: () => {
+			if (overrides.noDiagnostic) return undefined as never;
+			return {
+				duration: overrides.duration ?? 10,
+				flaky: overrides.flaky ?? false,
+				slow: overrides.slow ?? false,
+			};
+		},
 	};
 }
 
@@ -50,6 +57,8 @@ function makeTestModule(
 		duration: number;
 		tests: VitestTestCase[];
 		errors: Array<{ message: string; stacks?: string[] }>;
+		/** When true, diagnostic() returns undefined */
+		noDiagnostic: boolean;
 	}> = {},
 ): VitestTestModule {
 	const relativeId = overrides.relativeModuleId ?? "src/foo.test.ts";
@@ -65,8 +74,14 @@ function makeTestModule(
 			*allTests() {
 				for (const t of tests) yield t;
 			},
+			*allSuites() {
+				// No suites in test helpers
+			},
 		},
-		diagnostic: () => ({ duration: overrides.duration ?? 50 }),
+		diagnostic: () => {
+			if (overrides.noDiagnostic) return undefined as never;
+			return { duration: overrides.duration ?? 50 };
+		},
 		errors: () => overrides.errors ?? [],
 	};
 }
@@ -336,5 +351,68 @@ describe("buildAgentReport", () => {
 		expect(moduleReport.errors).toHaveLength(1);
 		expect(moduleReport.errors?.[0].message).toBe("module syntax error");
 		expect(moduleReport.errors?.[0].stack).toBe("at parse");
+	});
+
+	it("handles tests where diagnostic() returns undefined (skipped/todo)", () => {
+		const skippedTest = makeTestCase({ name: "skipped test", state: "skipped", noDiagnostic: true });
+		const passingTest = makeTestCase({ name: "passing test", state: "passed", duration: 20 });
+
+		const modules = [
+			makeTestModule({
+				relativeModuleId: "src/skip.test.ts",
+				state: "passed",
+				tests: [skippedTest, passingTest],
+			}),
+		];
+
+		const report = buildAgentReport(modules, [], "passed", { omitPassingTests: false });
+
+		expect(report.summary.total).toBe(2);
+		expect(report.summary.passed).toBe(1);
+		expect(report.summary.skipped).toBe(1);
+	});
+
+	it("handles tests where result() returns undefined (pending/collected)", () => {
+		const pendingTest = makeTestCase({ name: "pending test", noDiagnostic: true });
+		const passingTest = makeTestCase({ name: "passing test", state: "passed", duration: 20 });
+
+		const modules = [
+			makeTestModule({
+				relativeModuleId: "src/pending.test.ts",
+				state: "passed",
+				tests: [pendingTest, passingTest],
+			}),
+		];
+
+		const report = buildAgentReport(modules, [], "passed", { omitPassingTests: false });
+
+		expect(report.summary.total).toBe(2);
+		expect(report.summary.passed).toBe(1);
+		// pending (undefined result) normalizes to "pending" which counts as skipped
+		expect(report.summary.skipped).toBe(1);
+
+		// The pending test report should have no duration
+		expect(report.failed).toHaveLength(0);
+	});
+
+	it("handles modules where diagnostic() returns undefined", () => {
+		const modules = [
+			makeTestModule({
+				relativeModuleId: "src/a.test.ts",
+				duration: 100,
+				tests: [makeTestCase()],
+			}),
+			makeTestModule({
+				relativeModuleId: "src/b.test.ts",
+				noDiagnostic: true,
+				tests: [makeTestCase()],
+			}),
+		];
+
+		const report = buildAgentReport(modules, [], "passed", { omitPassingTests: true });
+
+		// Module with undefined diagnostic contributes 0 to total duration
+		expect(report.summary.duration).toBe(100);
+		expect(report.summary.total).toBe(2);
 	});
 });

--- a/package/src/utils/build-report.ts
+++ b/package/src/utils/build-report.ts
@@ -27,6 +27,9 @@ export interface VitestTestError {
 /**
  * Duck-typed Vitest test result returned by `TestCase.result()`.
  *
+ * Vitest returns `undefined` for tests that have not finished running
+ * (pending/collected state).
+ *
  * @internal
  */
 export interface VitestTestResult {
@@ -59,8 +62,9 @@ export interface VitestTestCase {
 	type: "test";
 	name: string;
 	fullName: string;
-	result(): VitestTestResult;
-	diagnostic(): VitestTestDiagnostic;
+	tags: readonly string[];
+	result(): VitestTestResult | undefined;
+	diagnostic(): VitestTestDiagnostic | undefined;
 }
 
 /**
@@ -92,14 +96,39 @@ export interface VitestModuleError {
  *
  * @internal
  */
+/**
+ * Duck-typed Vitest TestSuite from the Reporter v2 API.
+ *
+ * @internal
+ */
+export interface VitestTestSuite {
+	type: "suite";
+	name: string;
+	fullName: string;
+	state(): string;
+	parent: VitestTestSuite | VitestTestModule;
+	options: {
+		concurrent?: boolean;
+		shuffle?: boolean;
+		retry?: number;
+		repeats?: number;
+		mode?: string;
+		tags?: string[];
+	};
+	location?: { line: number; column: number };
+}
+
 export interface VitestTestModule {
 	type: "module";
 	moduleId: string;
 	relativeModuleId: string;
 	project: { name: string };
 	state(): string;
-	children: { allTests(filter?: string): Generator<VitestTestCase> };
-	diagnostic(): VitestModuleDiagnostic;
+	children: {
+		allTests(filter?: string): Generator<VitestTestCase>;
+		allSuites(): Generator<VitestTestSuite>;
+	};
+	diagnostic(): VitestModuleDiagnostic | undefined;
 	errors(): Array<VitestModuleError>;
 }
 
@@ -174,7 +203,7 @@ export function buildAgentReport(
 	const failedFiles: string[] = [];
 
 	for (const testModule of testModules) {
-		const moduleDuration = testModule.diagnostic().duration;
+		const moduleDuration = testModule.diagnostic()?.duration ?? 0;
 		totalDuration += moduleDuration;
 
 		const moduleState = normalizeState(testModule.state());
@@ -190,7 +219,7 @@ export function buildAgentReport(
 			totalCount++;
 			const result = testCase.result();
 			const diag = testCase.diagnostic();
-			const state = normalizeState(result.state);
+			const state = normalizeState(result?.state ?? "pending");
 
 			if (state === "passed") passedCount++;
 			else if (state === "failed") {
@@ -202,14 +231,14 @@ export function buildAgentReport(
 			// Include test in report based on omitPassingTests
 			const shouldInclude = !omitPassing || state !== "passed";
 			if (shouldInclude) {
-				const errors = mapErrors(result.errors);
+				const errors = mapErrors(result?.errors);
 				const testReport: TestReport = {
 					name: testCase.name,
 					fullName: testCase.fullName,
 					state,
-					duration: diag.duration,
-					...(diag.flaky ? { flaky: true } : {}),
-					...(diag.slow ? { slow: true } : {}),
+					...(diag?.duration !== undefined ? { duration: diag.duration } : {}),
+					...(diag?.flaky ? { flaky: true } : {}),
+					...(diag?.slow ? { slow: true } : {}),
 					...(errors ? { errors } : {}),
 				};
 				testReports.push(testReport);

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -46,28 +46,36 @@ Or configure permanently in your Claude Code settings:
 ### MCP Server (auto-registered)
 
 The plugin registers the `vitest-reporter` MCP server automatically
-via `.mcp.json`. The server exposes 16 tools for querying test data
+via `.mcp.json`. The server exposes 24 tools for querying test data
 stored in the SQLite database written by the reporter after each test
-run.
+run. Use the `help` tool for the full list with parameters.
 
 | Tool | Description |
 | --- | --- |
+| `run_tests` | Run tests via Vitest programmatic API (results persist to DB) |
 | `test_status` | Per-project test pass/fail state from the last run |
 | `test_overview` | Full test landscape: files, suites, test counts |
+| `test_get` | Single test drill-down: state, errors, history, classification |
 | `test_coverage` | Coverage gaps with uncovered line ranges |
+| `file_coverage` | Per-file coverage with uncovered lines and related tests |
 | `test_history` | Flaky, persistent, and recovered test detection |
 | `test_trends` | Per-project coverage trajectory over time |
 | `test_errors` | Search errors by type or message across projects |
 | `test_for_file` | Find all tests that cover a given source file |
-| `run_tests` | Execute vitest for specific files or patterns |
 | `cache_health` | Database health diagnostic |
 | `configure` | View captured Vitest settings |
+| `project_list` | All projects with latest run summary |
+| `test_list` | Test cases with state, duration, and classification |
+| `module_list` | Test modules (files) with test counts |
+| `suite_list` | Test suites (describe blocks) |
+| `settings_list` | Vitest config snapshots |
 | `note_create` | Create a note scoped to a file, test, or project |
 | `note_list` | List notes by scope |
 | `note_get` | Read a note by ID |
 | `note_update` | Update note content, pin state, or expiration |
 | `note_delete` | Delete a note |
 | `note_search` | Full-text search across all notes |
+| `help` | List all tools with parameters |
 
 ### Hooks
 
@@ -84,6 +92,7 @@ Skills are invoked via `/skill <name>` in Claude Code.
 | --- | --- |
 | `tdd` | Red-green-refactor workflow using MCP tools |
 | `debugging` | Systematic failure diagnosis using `test_history`, `test_errors`, `test_for_file` |
+| `coverage-improvement` | Systematic coverage improvement using `file_coverage`, `test_for_file`, `test_trends` |
 | `configuration` | Plugin setup and `AgentPlugin` option reference |
 
 ### Commands

--- a/plugin/hooks/post-test-run.sh
+++ b/plugin/hooks/post-test-run.sh
@@ -11,7 +11,7 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
 # Check if the command looks like a test run
-if echo "$COMMAND" | grep -qE '(^|/|npx\s+|pnpm\s+exec\s+)(vitest|jest)(\s|$)|(\s|^)(pnpm|npm|bun|yarn)\s+(run\s+)?test(\s|$)'; then
+if echo "$COMMAND" | grep -qE '(^|/|npx[[:space:]]+|pnpm[[:space:]]+exec[[:space:]]+)(vitest|jest)([[:space:]]|$)|([[:space:]]|^)(pnpm|npm|bun|yarn)[[:space:]]+(run[[:space:]]+)?test([[:space:]]|$)'; then
   # Check exit code from tool result
   EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_result.exit_code // "0"' 2>/dev/null || echo "0")
 

--- a/plugin/hooks/post-test-run.sh
+++ b/plugin/hooks/post-test-run.sh
@@ -11,18 +11,23 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
 # Check if the command looks like a test run
-if echo "$COMMAND" | grep -qE '(vitest|jest|pnpm test|npm test|bun test|yarn test)'; then
+if echo "$COMMAND" | grep -qE '(^|/|npx\s+|pnpm\s+exec\s+)(vitest|jest)(\s|$)|(\s|^)(pnpm|npm|bun|yarn)\s+(run\s+)?test(\s|$)'; then
   # Check exit code from tool result
   EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_result.exit_code // "0"' 2>/dev/null || echo "0")
 
   if [ "$EXIT_CODE" != "0" ]; then
-    # Tests failed -- suggest debugging tools
+    # Tests failed -- suggest debugging tools and run_tests
     CONTEXT="<test_failure_guidance>
-Use MCP tools for analysis:
+Use MCP tools for analysis instead of re-running vitest via Bash:
+- run_tests to re-run tests (uses Vitest programmatic API, updates the database)
+- test_get for single-test drill-down with errors, history, and classification
 - test_errors to search errors by type
 - test_history to check if failures are flaky
 - test_for_file to find related tests
+- file_coverage to check coverage for affected files
 - note_create to record debugging findings
+
+Prefer run_tests over vitest via Bash so results persist to the database and all query tools reflect the latest run.
 </test_failure_guidance>"
 
     jq -n --arg ctx "$CONTEXT" '{
@@ -31,8 +36,19 @@ Use MCP tools for analysis:
         additionalContext: $ctx
       }
     }'
+  else
+    # Tests passed via Bash -- gentle nudge to use run_tests next time
+    CONTEXT="<test_run_tip>
+Tip: Use the run_tests MCP tool instead of running vitest via Bash. It uses Vitest's programmatic API and automatically updates the database so all query tools (test_status, test_coverage, etc.) reflect the latest results.
+</test_run_tip>"
+
+    jq -n --arg ctx "$CONTEXT" '{
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: $ctx
+      }
+    }'
   fi
-  # If tests passed, stay silent (no noise)
 fi
 
 # Exit 0 for non-test commands (no output)

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -20,57 +20,15 @@ if [ "$HAS_DATA" = "true" ]; then
   LAST_RESULT=$(echo "$STATUS" | jq -r '.manifest.projects[0].lastResult // "unknown"' 2>/dev/null || echo "unknown")
 
   CONTEXT="<EXTREMELY_IMPORTANT>
-<vitest_agent_reporter>
+<vitest_agent_reporter projects=\"${PROJECT_COUNT}\" last_result=\"${LAST_RESULT}\">
 
-<overview>
-This project uses vitest-agent-reporter, a Vitest reporter and plugin designed for LLM coding agents. It separates test output — you see structured, token-efficient summaries while the developer sees standard Vitest output. Test results, coverage, failure history, and trends persist to a SQLite database across runs so you always have context from previous test runs.
+ALWAYS use the run_tests MCP tool to execute tests. NEVER run vitest via Bash. run_tests uses Vitest's programmatic API so results persist to the database and all query tools reflect the latest run immediately.
 
-Prefer MCP tools over raw vitest run commands. The MCP tools give you structured data — coverage gaps with exact uncovered lines, flaky test detection, per-file test mapping — without parsing console output. You can still run vitest run directly when needed, but the MCP tools are faster and more precise for targeted queries.
-</overview>
+Scoping: run_tests({}) for all, run_tests({ project: \"name\" }) by project, run_tests({ files: [\"path\"] }) by file.
 
-<mcp_tools>
-  <tool name=\"help\">List all available MCP tools with parameters</tool>
-  <tool name=\"run_tests\">Execute vitest for specific files or projects</tool>
-  <tool name=\"project_list\">List all known projects</tool>
-  <tool name=\"test_list\">List test cases with state and duration</tool>
-  <tool name=\"module_list\">List test modules (files)</tool>
-  <tool name=\"suite_list\">List test suites (describe blocks)</tool>
-  <tool name=\"test_status\">Per-project test pass/fail state</tool>
-  <tool name=\"test_overview\">Test landscape: files, suites, counts</tool>
-  <tool name=\"test_for_file\">Tests covering a source file</tool>
-  <tool name=\"test_coverage\">Coverage gaps with uncovered lines</tool>
-  <tool name=\"test_history\">Flaky/persistent/recovered tests</tool>
-  <tool name=\"test_trends\">Coverage trajectory per project</tool>
-  <tool name=\"test_errors\">Search errors by type/message</tool>
-  <tool name=\"note_create\">Create a note</tool>
-  <tool name=\"note_list\">List notes by scope</tool>
-  <tool name=\"note_get\">Get a note by ID</tool>
-  <tool name=\"note_update\">Update an existing note</tool>
-  <tool name=\"note_delete\">Delete a note</tool>
-  <tool name=\"note_search\">Full-text search notes</tool>
-  <tool name=\"cache_health\">Database health and staleness check</tool>
-  <tool name=\"configure\">View captured Vitest settings</tool>
-  <tool name=\"settings_list\">List Vitest config snapshots</tool>
-</mcp_tools>
+Key tools: test_get for single-test drill-down, test_for_file before modifying code, file_coverage for per-file coverage, test_history to check if failures are flaky, test_errors for detailed error analysis, note_create to record findings.
 
-<running_tests>
-Use run_tests to execute tests at different scopes:
-- All tests: run_tests({})
-- By project: run_tests({ project: \"my-project\" })
-- Individual files: run_tests({ files: [\"src/utils.test.ts\"] })
-- By suite/pattern: run_tests({ files: [\"src/services/\"] })
-
-The tool runs vitest run under the hood and returns structured output. Default timeout is 120 seconds (override with timeout parameter).
-</running_tests>
-
-<best_practices>
-- Use test_for_file before modifying code to know which tests cover it
-- Use test_history to check if failures are flaky before debugging
-- Use note_create to record debugging findings for future sessions
-- Check test_coverage for uncovered lines after writing code
-</best_practices>
-
-<project_status projects=\"${PROJECT_COUNT}\" last_result=\"${LAST_RESULT}\" />
+Use help for the full tool list with parameters.
 
 </vitest_agent_reporter>
 </EXTREMELY_IMPORTANT>"
@@ -79,23 +37,9 @@ else
   CONTEXT="<EXTREMELY_IMPORTANT>
 <vitest_agent_reporter>
 
-<overview>
-This project uses vitest-agent-reporter, a Vitest reporter and plugin designed for LLM coding agents. It separates test output — you see structured, token-efficient summaries while the developer sees standard Vitest output. Test results, coverage, failure history, and trends persist to a SQLite database across runs so you always have context from previous test runs.
+This project uses vitest-agent-reporter. ALWAYS use the run_tests MCP tool to execute tests, NEVER vitest via Bash. Results persist to a SQLite database so all query tools reflect the latest run.
 
-Prefer MCP tools over raw vitest run commands. The MCP tools give you structured data — coverage gaps with exact uncovered lines, flaky test detection, per-file test mapping — without parsing console output. You can still run vitest run directly when needed, but the MCP tools are faster and more precise for targeted queries.
-</overview>
-
-<status>
-No test data yet. Run tests to populate: pnpm test
-
-MCP tools are available but will return empty results until tests have been run. You can use note_create immediately to capture planning notes.
-</status>
-
-<mcp_tools>
-All 22 tools are registered but most return empty results until tests have been run: help, test_status, test_overview, test_coverage, test_history, test_trends, test_errors, test_for_file, run_tests, cache_health, configure, project_list, test_list, module_list, suite_list, settings_list, note_create, note_list, note_get, note_update, note_delete, note_search.
-
-Use run_tests({}) to run all tests, or run_tests({ project: \"name\" }) for a specific project.
-</mcp_tools>
+No test data yet. Run run_tests({}) to populate the database. Use help for the full tool list.
 
 </vitest_agent_reporter>
 </EXTREMELY_IMPORTANT>"

--- a/plugin/skills/coverage-improvement/SKILL.md
+++ b/plugin/skills/coverage-improvement/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: coverage-improvement
+description: Guide systematic coverage improvement using vitest-agent-reporter MCP tools. Use when improving code coverage, targeting uncovered lines, or working toward coverage targets.
+---
+
+# Improving Code Coverage
+
+Systematic approach to identifying and covering untested code using
+MCP tools.
+
+## Step 1: Identify Coverage Gaps
+
+Use `test_coverage` to see project-wide coverage gaps:
+
+- Files below threshold with exact uncovered line ranges
+- Per-metric values (statements, branches, functions, lines)
+- Current thresholds and targets
+
+For a specific file, use `file_coverage({ filePath: "src/foo.ts" })`
+to get per-metric values and uncovered line ranges.
+
+## Step 2: Understand Existing Tests
+
+Use `test_for_file({ filePath: "src/foo.ts" })` to find which test
+files already cover the source file. Then use
+`test_get({ fullName: "Suite > test name" })` to understand
+individual test scope and history.
+
+## Step 3: Write Targeted Tests
+
+Focus on the uncovered lines from step 1:
+
+1. Read the source file at the uncovered line ranges
+2. Identify untested code paths (branches, error handlers, edge cases)
+3. Write tests targeting those specific paths
+4. Run with `run_tests({ files: ["path/to/test.ts"] })`
+
+## Step 4: Verify Improvement
+
+1. Use `file_coverage` to check the file's updated coverage
+2. Use `test_coverage` to verify project-wide improvement
+3. Use `test_trends` to confirm coverage direction is improving
+
+## Prioritization
+
+Focus on files with the largest coverage gaps first. Files near
+the threshold ("at-risk" files) are the highest priority since
+a small regression could push them below the threshold.
+
+## Recording Progress
+
+Use `note_create` to document:
+
+- Which files you improved and by how much
+- Untested paths that were intentionally deferred
+- Coverage targets agreed upon with the team

--- a/plugin/skills/debugging/SKILL.md
+++ b/plugin/skills/debugging/SKILL.md
@@ -58,6 +58,11 @@ sessions.
 
 ## Step 6: Verify the Fix
 
-1. Run the specific failing test with `run_tests`
-2. Run the full suite to check for regressions
+1. Run the specific failing test:
+   `run_tests({ files: ["path/to/failing.test.ts"] })`
+2. Run the full suite to check for regressions: `run_tests({})`
 3. Check `test_trends` to confirm coverage direction
+
+Always use the `run_tests` MCP tool instead of running vitest via
+Bash. It uses Vitest's programmatic API, so results persist to the
+database and all query tools reflect the latest run immediately.

--- a/plugin/skills/tdd/SKILL.md
+++ b/plugin/skills/tdd/SKILL.md
@@ -20,21 +20,27 @@ intelligence.
 ## Red Phase (Write Failing Test)
 
 1. Write a test that describes the desired behavior
-2. Run tests with `run_tests` to confirm the test fails
+2. Run with `run_tests({ files: ["path/to/test.ts"] })` to confirm
+   the test fails. Always use the MCP tool, not vitest via Bash
 3. Verify the failure message is clear and specific
 
 ## Green Phase (Make It Pass)
 
 1. Write the minimal code to make the test pass
-2. Run tests with `run_tests` targeting your specific test file
+2. Run with `run_tests({ files: ["path/to/test.ts"] })` targeting
+   your specific test file
 3. Confirm the test passes
 
 ## Refactor Phase
 
 1. Clean up the implementation
-2. Run the full test suite with `run_tests`
+2. Run the full test suite with `run_tests({})`
 3. Check `test_coverage` to verify coverage didn't drop
 4. Use `test_trends` to confirm coverage direction
+
+All `run_tests` calls use Vitest's programmatic API in-process,
+so results automatically persist to the database and all query
+tools reflect the latest run immediately.
 
 ## Recording Decisions
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,70 +7,71 @@ settings:
 catalogs:
   silk:
     '@effect/cli':
-      specifier: ^0.75.0
-      version: 0.75.0
+      specifier: ^0.75.1
+      version: 0.75.1
     '@effect/platform':
-      specifier: ^0.96.0
-      version: 0.96.0
+      specifier: ^0.96.1
+      version: 0.96.1
     '@effect/platform-node':
       specifier: ^0.106.0
       version: 0.106.0
     '@effect/sql':
-      specifier: ^0.51.0
-      version: 0.51.0
+      specifier: ^0.51.1
+      version: 0.51.1
     '@effect/sql-sqlite-node':
       specifier: ^0.52.0
       version: 0.52.0
     '@types/node':
-      specifier: ^25.5.0
-      version: 25.5.0
+      specifier: ^25.6.0
+      version: 25.6.0
     '@typescript/native-preview':
-      specifier: ^7.0.0-dev.20260326.1
-      version: 7.0.0-dev.20260327.2
+      specifier: ^7.0.0-dev.20260422.1
+      version: 7.0.0-dev.20260423.1
     effect:
-      specifier: ^3.21.0
-      version: 3.21.0
+      specifier: ^3.21.2
+      version: 3.21.2
     typescript:
-      specifier: ^5.9.3
-      version: 5.9.3
+      specifier: ^6.0.3
+      version: 6.0.3
 
 overrides:
   '@isaacs/brace-expansion': ^5.0.1
   lodash: ^4.17.23
   markdown-it: ^14.1.1
   minimatch: '>=10.2.3'
+  smol-toml: '>=1.6.1'
   tmp: ^0.2.4
 
-pnpmfileChecksum: sha256-27wSjsferWrjX0baanhUkyi9NQwG3sKOssFmbRpT7sQ=
+pnpmfileChecksum: sha256-c9H7NdFuy+EHPxtzs2AyECsNH3ZP4b8bcqm4aWTxXV0=
 
 importers:
 
   .:
     devDependencies:
       '@savvy-web/changesets':
-        specifier: ^0.7.3
-        version: 0.7.3(@changesets/cli@2.30.0(@types/node@25.5.0))(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))
+        specifier: ^0.8.0
+        version: 0.8.0(@changesets/cli@2.31.0(@types/node@25.6.0))(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))
       '@savvy-web/commitlint':
-        specifier: ^0.5.1
-        version: 0.5.1(@commitlint/cli@20.5.0(@types/node@25.5.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3))(@commitlint/config-conventional@20.5.0)(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/typeclass@0.40.0(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(commitizen@4.3.1(@types/node@25.5.0)(typescript@5.9.3))(husky@9.1.7)
+        specifier: ^0.5.2
+        version: 0.5.2(@commitlint/cli@20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3))(@commitlint/config-conventional@20.5.0)(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/typeclass@0.40.0(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(commitizen@4.3.1(@types/node@25.6.0)(typescript@6.0.3))(husky@9.1.7)
       '@savvy-web/lint-staged':
-        specifier: ^0.7.2
-        version: 0.7.2(88bc74b6e7c8e49a5f745efabf87a7f6)
+        specifier: ^1.0.0
+        version: 1.0.0(75f98f15d93bd459d8942de7d8b41eb0)
       '@types/node':
         specifier: catalog:silk
-        version: 25.5.0
+        version: 25.6.0
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260327.2
+        version: 7.0.0-dev.20260423.1
       '@vitest/coverage-v8':
-        specifier: ^4.1.2
-        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)))
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       typescript:
         specifier: catalog:silk
-        version: 5.9.3
+        version: 6.0.3
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
       vitest-agent-reporter:
         specifier: workspace:*
         version: link:package/dist/dev
@@ -79,10 +80,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.1.2
-        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)))
+        version: 4.1.5(vitest@4.1.5)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
       vitest-agent-reporter:
         specifier: workspace:*
         version: link:../../package/dist/dev
@@ -91,50 +92,53 @@ importers:
     dependencies:
       '@effect/cli':
         specifier: catalog:silk
-        version: 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+        version: 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/platform':
         specifier: catalog:silk
-        version: 0.96.0(effect@3.21.0)
+        version: 0.96.1(effect@3.21.2)
       '@effect/platform-node':
         specifier: catalog:silk
-        version: 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+        version: 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/sql':
         specifier: catalog:silk
-        version: 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+        version: 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/sql-sqlite-node':
         specifier: catalog:silk
-        version: 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+        version: 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
       '@trpc/server':
         specifier: ^11.16.0
-        version: 11.16.0(typescript@5.9.3)
+        version: 11.16.0(typescript@6.0.3)
       '@vitest/coverage-istanbul':
         specifier: '>=4.1.0'
-        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)))
+        version: 4.1.5(vitest@4.1.5)
       effect:
         specifier: catalog:silk
-        version: 3.21.0
+        version: 3.21.2
       std-env:
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^4.1.0
+        version: 4.1.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@savvy-web/rslib-builder':
-        specifier: ^0.19.1
-        version: 0.19.1(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@pnpm/logger@1001.0.1)(@rslib/core@0.20.1(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@typescript/native-preview@7.0.0-dev.20260327.2)(typescript@5.9.3))(@types/node@25.5.0)(@typescript/native-preview@7.0.0-dev.20260327.2)(jiti@2.6.1)(typescript@5.9.3)
+        specifier: ^0.20.2
+        version: 0.20.2(@pnpm/logger@1001.0.1)(@rslib/core@0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3))(@types/node@25.6.0)(@typescript/native-preview@7.0.0-dev.20260423.1)(jiti@2.6.1)(typescript@6.0.3)
+      '@types/node':
+        specifier: catalog:silk
+        version: 25.6.0
       '@vitest/coverage-v8':
-        specifier: ^4.1.2
-        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)))
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       vite:
-        specifier: ^8.0.3
-        version: 8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
     publishDirectory: dist/dev
 
 packages:
@@ -276,33 +280,33 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@changesets/apply-release-plan@7.1.0':
-    resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
+  '@changesets/apply-release-plan@7.1.1':
+    resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
 
-  '@changesets/assemble-release-plan@6.0.9':
-    resolution: {integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==}
+  '@changesets/assemble-release-plan@6.0.10':
+    resolution: {integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==}
 
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/cli@2.30.0':
-    resolution: {integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==}
+  '@changesets/cli@2.31.0':
+    resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
     hasBin: true
 
-  '@changesets/config@3.1.3':
-    resolution: {integrity: sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==}
+  '@changesets/config@3.1.4':
+    resolution: {integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==}
 
   '@changesets/errors@0.2.0':
     resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
 
-  '@changesets/get-dependents-graph@2.1.3':
-    resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+  '@changesets/get-dependents-graph@2.1.4':
+    resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
 
   '@changesets/get-github-info@0.8.0':
     resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
 
-  '@changesets/get-release-plan@4.0.15':
-    resolution: {integrity: sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==}
+  '@changesets/get-release-plan@4.0.16':
+    resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
 
   '@changesets/get-version-range-type@0.4.0':
     resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
@@ -403,34 +407,34 @@ packages:
     resolution: {integrity: sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==}
     engines: {node: '>=v18'}
 
-  '@conventional-changelog/git-client@2.6.0':
-    resolution: {integrity: sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg==}
+  '@conventional-changelog/git-client@2.7.0':
+    resolution: {integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==}
     engines: {node: '>=18'}
     peerDependencies:
       conventional-commits-filter: ^5.0.0
-      conventional-commits-parser: ^6.3.0
+      conventional-commits-parser: ^6.4.0
     peerDependenciesMeta:
       conventional-commits-filter:
         optional: true
       conventional-commits-parser:
         optional: true
 
-  '@effect/cli@0.75.0':
-    resolution: {integrity: sha512-SAJj1a1kb5yoSUz4yORmwjyOBv89y2wf2Q08KC/RwskUCZunj29eNZgl8Pkbv6nDFTGlre6EW/Kl2S/aOtQWwQ==}
+  '@effect/cli@0.75.1':
+    resolution: {integrity: sha512-aDZ1OZzaFAb6NyBOrP+Bl52eICds5ERI9aa67LzloJELt5SCWeNwthtaEacBvvMkwVUcykJ+YHcGCkD1t47g8g==}
     peerDependencies:
       '@effect/platform': ^0.96.0
       '@effect/printer': ^0.49.0
       '@effect/printer-ansi': ^0.49.0
-      effect: ^3.21.0
+      effect: ^3.21.1
 
-  '@effect/cluster@0.58.0':
-    resolution: {integrity: sha512-0Zog7s7XdntWcTqdqWPoj6nc7hPaWIzp0k0DsFUWyCynXNPK9dAtgFrSce04NhddNqqbhtZck/lhuqJwNBrprQ==}
+  '@effect/cluster@0.58.2':
+    resolution: {integrity: sha512-oxQ3zUhXq0mJA7Y4TliALMP39Bx0LtAIxcqOW1Bdjh6uk+nG7kul/Puw80SwlcYGv3ul50SG+gvSRUTXB8d3JQ==}
     peerDependencies:
-      '@effect/platform': ^0.96.0
-      '@effect/rpc': ^0.75.0
-      '@effect/sql': ^0.51.0
+      '@effect/platform': ^0.96.1
+      '@effect/rpc': ^0.75.1
+      '@effect/sql': ^0.51.1
       '@effect/workflow': ^0.18.0
-      effect: ^3.21.0
+      effect: ^3.21.2
 
   '@effect/experimental@0.60.0':
     resolution: {integrity: sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g==}
@@ -463,10 +467,10 @@ packages:
       '@effect/sql': ^0.51.0
       effect: ^3.21.0
 
-  '@effect/platform@0.96.0':
-    resolution: {integrity: sha512-U7PLhkVzg7zzrgFvyWATOzD6reL87KG/fcdOxgLWBQ/J5CCU6qdPAVG+0o6o+IxcsLoqGwxs+rFxaFzrdtDV1A==}
+  '@effect/platform@0.96.1':
+    resolution: {integrity: sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==}
     peerDependencies:
-      effect: ^3.21.0
+      effect: ^3.21.2
 
   '@effect/printer-ansi@0.49.0':
     resolution: {integrity: sha512-N2OyqDTqcGLKeUy2URowThoU5issZQwG/Ihv5qOYWJD0neq9qBIgC57/9BkFpTRPNSMtPHyCOk1TFj297HGLLQ==}
@@ -480,11 +484,11 @@ packages:
       '@effect/typeclass': ^0.40.0
       effect: ^3.21.0
 
-  '@effect/rpc@0.75.0':
-    resolution: {integrity: sha512-VFeJ16cZUXqiIzG9UHOVKGuiBPJ7fV+0lEbJU6xi12JnnxXe/19BQPpOwiRawCUbPOR3/xIURDUgGxU+Ft0pvQ==}
+  '@effect/rpc@0.75.1':
+    resolution: {integrity: sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg==}
     peerDependencies:
-      '@effect/platform': ^0.96.0
-      effect: ^3.21.0
+      '@effect/platform': ^0.96.1
+      effect: ^3.21.2
 
   '@effect/sql-sqlite-node@0.52.0':
     resolution: {integrity: sha512-yijDbly4MwxAPebvd2ZBI62qDpGdXKL96drMzflXDnjEh2JiVr/xVyy1VB0JsVxqw8IJ9TUIgOvAJWQ88oVMXA==}
@@ -494,12 +498,12 @@ packages:
       '@effect/sql': ^0.51.0
       effect: ^3.21.0
 
-  '@effect/sql@0.51.0':
-    resolution: {integrity: sha512-e7hWe46QD15eMCr4kNBMVdItIVK/WLHJG+d8DLL1FjVf5Ra82k2mwUYIXplJewVbHjt3my6GSKPPd1ZrQjVd5A==}
+  '@effect/sql@0.51.1':
+    resolution: {integrity: sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA==}
     peerDependencies:
       '@effect/experimental': ^0.60.0
-      '@effect/platform': ^0.96.0
-      effect: ^3.21.0
+      '@effect/platform': ^0.96.1
+      effect: ^3.21.2
 
   '@effect/typeclass@0.40.0':
     resolution: {integrity: sha512-L/2o2ImeqbemFlqH0b3y2PqQTFc+E0/DUnffCU8bkJUGh0yUZmh2RXuXhR8QOpfNCe718JQjI+mLnpVF2MMmaQ==}
@@ -514,14 +518,14 @@ packages:
       '@effect/rpc': ^0.75.0
       effect: ^3.21.0
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -533,62 +537,46 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.23.3':
-    resolution: {integrity: sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==}
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-array@0.23.4':
-    resolution: {integrity: sha512-lf19F24LSMfF8weXvW5QEtnLqW70u7kgit5e9PSx0MsHAFclGd1T9ynvWEMDT1w5J4Qt54tomGeAhdoAku1Xow==}
+  '@eslint/config-helpers@0.5.5':
+    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.5.3':
-    resolution: {integrity: sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==}
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.5.4':
-    resolution: {integrity: sha512-jJhqiY3wPMlWWO3370M86CPJ7pt8GmEwSLglMfQhjXal07RCvhmU0as4IuUEW5SJeunfItiEetHmSxCCe9lDBg==}
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/core@1.1.1':
-    resolution: {integrity: sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/core@1.2.0':
-    resolution: {integrity: sha512-8FTGbNzTvmSlc4cZBaShkC6YvFMG0riksYWRFKXztqVdXaQbcZLXlFbSpC05s70sGEsXAw0qwhx69JiW7hQS7A==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/object-schema@3.0.3':
-    resolution: {integrity: sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/object-schema@3.0.4':
-    resolution: {integrity: sha512-55lO/7+Yp0ISKRP0PsPtNTeNGapXaO085aELZmWCVc5SH3jfrqpuU6YgOdIxMS99ZHkQN1cXKE+cdIqwww9ptw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/plugin-kit@0.6.1':
-    resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/plugin-kit@0.7.0':
-    resolution: {integrity: sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==}
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@gwhitney/detect-indent@7.0.1':
     resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
     engines: {node: '>=12.20'}
 
-  '@hono/node-server@1.19.12':
-    resolution: {integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
 
-  '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
 
-  '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/module-importer@1.0.1':
@@ -608,8 +596,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
     engines: {node: '>=8'}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -634,11 +622,11 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@microsoft/api-extractor-model@7.33.4':
-    resolution: {integrity: sha512-u1LTaNTikZAQ9uK6KG1Ms7nvNedsnODnspq/gH2dcyETWvH4hVNGNDvRAEutH66kAmxA4/necElqGNs1FggC8w==}
+  '@microsoft/api-extractor-model@7.33.8':
+    resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
 
-  '@microsoft/api-extractor@7.57.7':
-    resolution: {integrity: sha512-kmnmVs32MFWbV5X6BInC1/TfCs7y1ugwxv1xHsAIj/DyUfoe7vtO0alRUgbQa57+yRGHBBjlNcEk33SCAt5/dA==}
+  '@microsoft/api-extractor@7.58.7':
+    resolution: {integrity: sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.18.1':
@@ -687,8 +675,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.2':
+    resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -702,8 +699,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oxc-project/types@0.122.0':
-    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -793,13 +790,17 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
-  '@pnpm/catalogs.config@1000.0.6':
-    resolution: {integrity: sha512-B/ZQj/pzHFgzkTKbP/8klI03bfimk0QdcG/fq7gQPqo2ExmbGeXEre4skZGyguhjp03xLr5/a4GNYSrLUsUUUQ==}
-    engines: {node: '>=18.12'}
+  '@pnpm/catalogs.config@1100.0.0':
+    resolution: {integrity: sha512-m6w7+/q9BAyEvlJEuuu4DX6cnFQnCbcsED6AB4AJlz+Nw0UQ/Tas1QOmH1EQ1skM+s+Un1nEQO7D61HG8w3LYw==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/catalogs.protocol-parser@1001.0.0':
     resolution: {integrity: sha512-9rHKCMRvhfv7TSAVSCVLI+8OZhi1OcT8lanAGqOPbGgQTkFrPH3PfEWJNxz43xqrXRa4HCFRAMu+g19su5eRLA==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/catalogs.protocol-parser@1100.0.0':
+    resolution: {integrity: sha512-PZ5dC9QBdsZVxIOdk3sgZkLurCzv7Jx5PGmk8xsBFLYljC8qIgSblayxz+1BReIICmDgGhKQffth55u8tH6qUA==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/catalogs.resolver@1000.0.5':
     resolution: {integrity: sha512-h6UiDAu/Ztj0LCd9sqmJwSWvJYTMUuxo/+/Iz2WZuWboyUI+2BylWJvokkMG4hNlvroLzBQ5+cz9/e+TDSLpoA==}
@@ -809,57 +810,73 @@ packages:
     resolution: {integrity: sha512-2hf0s4pVrVEH8RvdJJ7YRKjQdiG8m0iAT26TTqXnCbK30kKwJW69VLmP5tED5zstmDRXcOeH5eRcrpkdwczQ9g==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/constants@1100.0.0':
+    resolution: {integrity: sha512-CSJ5fKSUgqXrON5J2zQd1LwttU4gdqffJ3zYyHGAEhZ8u22fhQEVfCnc4+3aczDHbBNU0pNRX2ajiioPj46YtA==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/core-loggers@1001.0.9':
     resolution: {integrity: sha512-pW58m3ssrwVjwhlmTXDW1dh1sv2y6R2Gl5YvQInjM2d01/5mre/sYAY4MK3XfgEShZJQxv6wVXDUvyHHJ0oizg==}
     engines: {node: '>=18.12'}
     peerDependencies:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
-  '@pnpm/crypto.hash@1000.2.2':
-    resolution: {integrity: sha512-W8pLZvXWLlGG5p0Z2nCvtBhlM6uuTcbAbsS15wlGS31jBBJKJW2udLoFeM7qfWPo7E2PqRPGxca7APpVYAjJhw==}
-    engines: {node: '>=18.12'}
+  '@pnpm/crypto.hash@1100.0.0':
+    resolution: {integrity: sha512-pHWtsGNtDzro7y3F/rqmpUIPcvrnZOgQJxsbBziz18aewQkIVN98KWaZQPDQLCPGu9MtRS5DOJeSdoCTfhYOCg==}
+    engines: {node: '>=22.13'}
 
-  '@pnpm/crypto.polyfill@1000.1.0':
-    resolution: {integrity: sha512-tNe7a6U4rCpxLMBaR0SIYTdjxGdL0Vwb3G1zY8++sPtHSvy7qd54u8CIB0Z+Y6t5tc9pNYMYCMwhE/wdSY7ltg==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/dependency-path@1001.1.10':
-    resolution: {integrity: sha512-PNImtV2SmNTDpLi4HdN86tJPmsOeIxm4VhmxgBVsMrJPEBfkNEWFcflR3wU6XVn/26g9qWdvlNHaawtCjeB93Q==}
-    engines: {node: '>=18.12'}
+  '@pnpm/deps.path@1100.0.1':
+    resolution: {integrity: sha512-2aom+aWVzRurBZwKt+rmnMzb64eDautwYxNNbLD3fVUGPnSpPti/eMGc2ZzKd90EWKmhIylR0wGy964/X0UTWg==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/error@1000.1.0':
     resolution: {integrity: sha512-Dqc2IJJPjUatwc9Letw+vG29rnaMrDGi5g6WCx1HiZYm0obXbTmLygeRafMbgf+sLKXrWE1shOeiayQuczBdoA==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/error@1100.0.0':
+    resolution: {integrity: sha512-Pe+UcOhBwBBM38GPavnPJllik4/DZ8Fawt9+D2JLoWSo6FNZBJWQbaDMuwba3W0Ej0v43etKmyCT+MOvwt95Gg==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/exportable-manifest@1000.4.2':
     resolution: {integrity: sha512-rtUWmIKzloHwxgP16PYxTdr3+1lyuBH1JG5Gkgyca32dfmqy3Y55oEfkLywU2NYf/Zvk0C5gHaAMTFZOxuW8kg==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/git-utils@1000.0.0':
-    resolution: {integrity: sha512-W6isNTNgB26n6dZUgwCw6wly+uHQ2Zh5QiRKY1HHMbLAlsnZOxsSNGnuS9euKWHxDftvPfU7uR8XB5x95T5zPQ==}
-    engines: {node: '>=18.12'}
+  '@pnpm/fetching.fetcher-base@1100.1.0':
+    resolution: {integrity: sha512-db/WIJ9Fj8+mQyOKqYuI06mCl7lRSYRlKKG7uB4JFlVg7qitJSHk3ahy2pT8YfEyZ1Vv1K1Ow1ckMOn2/Ug9KA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/fetching.pick-fetcher@1100.0.3':
+    resolution: {integrity: sha512-iQcCQqzCMT8yI7BlCHtFToYPgK71kTJI7oULQFY4+PwD5nGoFuknuyiAJQuTQRjsgK+ZuOCQ8C2USrluYv9HDw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/fs.graceful-fs@1100.0.0':
+    resolution: {integrity: sha512-/9EZ4NGDTBCXg5zufAsS94iJ15M0uskADSqHGexG5UzYGExs85h9kMK9IsE8REZnblxT5fglLlKEFCCzCIvxZQ==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/graceful-fs@1000.1.0':
     resolution: {integrity: sha512-EsMX4slK0qJN2AR0/AYohY5m0HQNYGMNe+jhN74O994zp22/WbX+PbkIKyw3UQn39yQm2+z6SgwklDxbeapsmQ==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/lockfile.fs@1001.1.32':
-    resolution: {integrity: sha512-I+aHBjbgDy2Ftxla8FVZkx/ARuKOyGag1zaCuVuZDzH4Xb2ETUuTeGAf1GTr1XqM7UnCNse1GKgr5KZJ0cz43w==}
-    engines: {node: '>=18.12'}
+  '@pnpm/hooks.types@1100.0.3':
+    resolution: {integrity: sha512-Tl6XL1iMyMylMLL0ONwr3770/SobNaHrEFyODiKWq1n2jyp8H6lnW/zZ/Hh6ay6xPiT5fkKeGn2efaPlgwVgtA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/lockfile.fs@1100.0.3':
+    resolution: {integrity: sha512-EIR2veZjux/r7uMs3RN9NMOS7oiwFHOfhU7PUhwk6i+onmmerAWQbXcqFMce2T4lSO6hRnEj8YgH42RGzNgSRQ==}
+    engines: {node: '>=22.13'}
     peerDependencies:
-      '@pnpm/logger': ^1001.0.1
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
-  '@pnpm/lockfile.merger@1001.0.20':
-    resolution: {integrity: sha512-93MKB5fObr49PMRoDZVcUewe2uuR6TRj8In0y1CeXeDzXY1SPVKZsODCVvAA2z2UxZ1YXKcw9Oaak31E9ln5CQ==}
-    engines: {node: '>=18.12'}
+  '@pnpm/lockfile.merger@1100.0.2':
+    resolution: {integrity: sha512-Mta1339xb5epXtKKCEeUUeybt/y2iYCQ0APWvvpoPjm6FUHr7xd9L+0hD5sDXsMmyMNASU4gAgassL18qvvh9g==}
+    engines: {node: '>=22.13'}
 
-  '@pnpm/lockfile.types@1002.1.0':
-    resolution: {integrity: sha512-Oa9Fhwo4Ipodj3hyUPC5wUt5ucVkuttyct2DbFUkB79Fq5HL9MHHQ+JFYh03eajmLqWrN1t8+6DbmcKqRtNjNg==}
-    engines: {node: '>=18.12'}
+  '@pnpm/lockfile.types@1100.0.2':
+    resolution: {integrity: sha512-C9g/4ffOtnw+Jc6ohgRvOaPq6ru3P9ppSE+Bmx9nMNfCAo/wMm4sctpyDRgjgZpFHw1a1u7bqJoGQOo8Yh9LLA==}
+    engines: {node: '>=22.13'}
 
-  '@pnpm/lockfile.utils@1004.0.3':
-    resolution: {integrity: sha512-02hFBFk/BGmZYhqd7paBjJm5mHy7GwI6DOJL25dakctRIPCr2kUZkPs/DH3WLKAjNLykEh7Dp/dPs5rnUsUE5g==}
-    engines: {node: '>=18.12'}
+  '@pnpm/lockfile.utils@1100.0.3':
+    resolution: {integrity: sha512-YXYkPFKUfWEeIWBW0UZLjBuWV4C4KbGXkoMJAIXqFSRhAWjGHGtotdqAStN/c35PK/efHWftJRAljQ2oXKhWrw==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/logger@1001.0.1':
     resolution: {integrity: sha512-gdwlAMXC4Wc0s7Dmg/4wNybMEd/4lSd9LsXQxeg/piWY0PPXjgz1IXJWnVScx6dZRaaodWP3c1ornrw8mZdFZw==}
@@ -871,17 +888,17 @@ packages:
     peerDependencies:
       '@pnpm/logger': ^1001.0.1
 
-  '@pnpm/object.key-sorting@1000.0.1':
-    resolution: {integrity: sha512-YTJCXyUGOrJuj4QqhSKqZa1vlVAm82h1/uw00ZmD/kL2OViggtyUwWyIe62kpwWVPwEYixfGjfvaFKVJy2mjzA==}
-    engines: {node: '>=18.12'}
+  '@pnpm/network.git-utils@1100.0.0':
+    resolution: {integrity: sha512-3V6D/25uXgT3EJwS+uhqaprlWvMSgzriwog6//Dt/lzL31Ym2mXdty9bCgatSmMZMNohnyEqBS2Vv1Z+VFkoFQ==}
+    engines: {node: '>=22.13'}
 
-  '@pnpm/patching.types@1000.1.0':
-    resolution: {integrity: sha512-Zib2ysLctRnWM4KXXlljR44qSKwyEqYmLk+8VPBDBEK3l5Gp5mT3N4ix9E4qjYynvFqahumsxzOfxOYQhUGMGw==}
-    engines: {node: '>=18.12'}
+  '@pnpm/object.key-sorting@1100.0.0':
+    resolution: {integrity: sha512-2p9Ew48onwdeuPctbHWSwet1j3JcA/ZHlCikfYyxwjBdvR1Rva/2YNgLKvMhzCOMTxQ+CyimisWkvCqaRrTicg==}
+    engines: {node: '>=22.13'}
 
-  '@pnpm/pick-fetcher@1001.0.0':
-    resolution: {integrity: sha512-Zl8npMjFSS1gSGM27KkbmfmeOuwU2MCxRFIofAUo/PkqOE2IzzXr0yzB1XYJM8Ml1nUXt9BHfwAlUQKC5MdBLA==}
-    engines: {node: '>=18.12'}
+  '@pnpm/patching.types@1100.0.0':
+    resolution: {integrity: sha512-trrr0UIaIEIDagZhuxjO83z+/aCvyKib+g5zXQQ7d2H3bj8GN2sHPPi/5/i8C1eMiBGNZut/8cl8ipNRbFwIow==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/ramda@0.28.1':
     resolution: {integrity: sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==}
@@ -892,17 +909,21 @@ packages:
     peerDependencies:
       '@pnpm/logger': ^1001.0.1
 
-  '@pnpm/resolver-base@1005.4.1':
-    resolution: {integrity: sha512-47zGgACkbZWLOmM61kaE0nkqxiYx63C6DJ4wzDsdj0iXDZJ9SJEl+T035pkhquHe8XEh3YxvwMg2BRyZSgmZ9Q==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/resolving.jsr-specifier-parser@1000.0.4':
     resolution: {integrity: sha512-oxf+Y5lumvfNx9Igss/dvDb0t4iWtE0wjrmdDPFkVrXTlQbdWLujnyYSp3Obim/65K+r5RspoizJgjWJRe69nw==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/resolving.resolver-base@1100.1.0':
+    resolution: {integrity: sha512-iQUj/d28QNAbfWhOlXqU0Tnh77YMSxC4066C13x0iLn/fkX2fVimg0aOk8pemeGaa5CtFjcQaFhjbQG3FLiDVA==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/semver.peer-range@1000.0.0':
     resolution: {integrity: sha512-r6VzkrdH7ZKjPmAogTNvxuV/UyS/xwHNme+ZuEFiG0UthZgqudDftYtKmG20fcfrjG1lgJbbWICA8KvZy7mmbw==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/store.cafs-types@1100.0.0':
+    resolution: {integrity: sha512-l92gIOgY6G2XErPNXAkXQ9fwfUnBrrlUCLxP9osESQbw5+WnfXvSl6ykxYnTmSxd4+/zcj/vnRfjrc8WI29qcA==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/text.comments-parser@1000.0.0':
     resolution: {integrity: sha512-ivv/esrETOq9uMiKOC0ddVZ1BktEGsfsMQ9RWmrDpwPiqFSqWsIspnquxTBmm5GflC5N06fbqjGOpulZVYo3vQ==}
@@ -911,6 +932,10 @@ packages:
   '@pnpm/types@1001.3.0':
     resolution: {integrity: sha512-NLTXheat/u7OEGg5M5vF6Z85zx8uKUZE0+whtX/sbFV2XL48RdnOWGPTKYuVVkv8M+launaLUTgGEXNs/ess2w==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/types@1101.0.0':
+    resolution: {integrity: sha512-mDjsSJCsyuWQ6fbh3wa4FL+lx2FtE4GMEP79v6Uqf301Iz40LnD2Jjn2jVnkrPgReftmKV6DxTB/qeWTbtV+oA==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/util.lex-comparator@3.0.2':
     resolution: {integrity: sha512-blFO4Ws97tWv/SNE6N39ZdGmZBrocXnBOfVp0ln4kELmns4pGPZizqyRtR8EjfOLMLstbmNCTReBoDvLz1isVg==}
@@ -924,106 +949,106 @@ packages:
     resolution: {integrity: sha512-zG68fk03ryot7TWUl9S/ShQ91uHWzIL9sVr2aQCuNHJo8G9kjsG6S0p58Zj/voahdDQeakZYYBSJ0mjNZeiJnw==}
     engines: {node: '>=18.12'}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
-    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
-    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
-    engines: {node: '>=14.0.0'}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.12':
-    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
-  '@rsbuild/core@2.0.0-beta.10':
-    resolution: {integrity: sha512-6xalOGzWjamJQvC+qnAipo6azfW3cn9JSRSkTMBz/hiXFzcfy54GX31gCDhRY0TooEisyJ2wbGWjGcT8zPwwxg==}
+  '@rsbuild/core@2.0.0':
+    resolution: {integrity: sha512-RbVMK3/4l4g+yt2B/cQv+ardlfGroF1Lgcin3pYUbtsLXKPwDjJII8g0XoCvIgapu0kaA+32YmzKlnfnLGx2NA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1032,8 +1057,18 @@ packages:
       core-js:
         optional: true
 
-  '@rslib/core@0.20.1':
-    resolution: {integrity: sha512-5Mw9HvMCBNkyvzyxeMpxuOBYhtoZ+lwlm/d966JtH9eGesV8QGRNNZiC1axlZVO490kOTfMpbfbSt74XRCn/2A==}
+  '@rsbuild/core@2.0.0-rc.0':
+    resolution: {integrity: sha512-XutQgxd71RyH9jT0x+/F0DiGqk2Q5oofZuzNZFEkSayjO1UG+uVLhK90zB4hW43qRHqGEqcWlVaNPSQ8rHLk6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
+  '@rslib/core@0.20.3':
+    resolution: {integrity: sha512-WImc5z84oKbK0wZI5M4rk6BTK9BeYLk3lfietrR4k9e9Wk81BWR0RtPnRpDsj2+HCy8KZHCG8ZywU2QTqq36OA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1045,64 +1080,120 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.0-beta.8':
-    resolution: {integrity: sha512-h3x2GreEh8J36A3cWFeHZGTuz4vjUArk9dBDq8fZSyaUQQQox/lp8bUOGa/2YuYUOXk0gei2GN+/BVi2R5p39A==}
+  '@rspack/binding-darwin-arm64@2.0.0':
+    resolution: {integrity: sha512-ICBHDKYyndFqljLhjxvKfWWZu39RJSH2jkSmbceXl0kmptLSE0cLWpvk+eGSzLqtxKN0jVchwCw+5P5mWCzwAw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.0-beta.8':
-    resolution: {integrity: sha512-+XTA37+FZjXgwxkNX94T/EqspFO8Q3Km4CklQ3nOQzieMi31w+TLBB0uTsnT1ugp0UTN5PHLd4DFK1SQB7Ckbg==}
+  '@rspack/binding-darwin-arm64@2.0.0-rc.0':
+    resolution: {integrity: sha512-F1phoByw5bMZ44TVJevn7Yw1mn1dWQ6Z3dxMQrkXoFsxwUPSNOHBX1TSkQ3rmhw2CZpFinbLL6aYjDWM6aHO5A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.0.0':
+    resolution: {integrity: sha512-YQ96LMmzIzhZt9cZWUDWXSxS9UWWHWoLxJyZ5f42DSaVPVelBg5ThbVORDwOP5QDA2xFXj60rVnmmcZLzg/aDA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.8':
-    resolution: {integrity: sha512-vD2+ztbMmeBR65jBlwUZCNIjUzO0exp/LaPSMIhLlqPlk670gMCQ7fmKo3tSgQ9tobfizEA/Atdy3/lW1Rl64A==}
+  '@rspack/binding-darwin-x64@2.0.0-rc.0':
+    resolution: {integrity: sha512-oVzDuXwtn1uM9ovV12gTwkTHCwN1q0U0oxfclJjEjb1EhE/a/UGGABUsLl84wSbIW1fvcd9UwAr7vBqPWsjB4Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@2.0.0':
+    resolution: {integrity: sha512-Ufn33gzkIV7JY69k6vJQEdOzRvBqThIgH46pwXksHSMwRZp8IbJhXfyYIAVsRWCk8fXpr9t1nAvCDvJXT2EeyA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.0.0-beta.8':
-    resolution: {integrity: sha512-jJ1XB7Yz9YdPRA6MJ35S9/mb+3jeI4p9v78E3dexzCPA3G4X7WXbyOcRbUlYcyOlE5MtX5O19rDexqWlkD9tVw==}
+  '@rspack/binding-linux-arm64-gnu@2.0.0-rc.0':
+    resolution: {integrity: sha512-f0EQ0uBWXmknhZ7HR8ud+AhEtLSKbMK9IFHNkhMH3rN4J6wMI+uCPAs+ZlIrNk076bv8YB/z2Amx1ByDLjOBRA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-musl@2.0.0':
+    resolution: {integrity: sha512-CZbvFKlNY9UC0C+Czz6i8JFCzGpuL9oX8gEqcJA1+84Y6eEEBH50UiTzeCewxKW3dOofkZdvT5vgNMXz6aMUmg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.0.0-beta.8':
-    resolution: {integrity: sha512-qy+fK/tiYw3KvGjTGGMu/mWOdvBYrMO8xva/ouiaRTrx64PPZ6vyqFXOUfHj9rhY5L6aU2NTObpV6HZHcBtmhQ==}
+  '@rspack/binding-linux-arm64-musl@2.0.0-rc.0':
+    resolution: {integrity: sha512-+OiO3x6biWU+z/H/rBzgCJuhvZj7YkGz4w7zQk2ZEHnL8nB5pzPqFiEZesbRp+WIseAONzitn7R0qk102hBi5g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-x64-gnu@2.0.0':
+    resolution: {integrity: sha512-dPjFGpoCvZfFpJBsWAUR+PR7mWYxpou6L026qIOpAVkz7WiTzErwKD3P1jVrpP4dM9yLb3fVE+PHHjTglhTJ4g==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.0.0-beta.8':
-    resolution: {integrity: sha512-eJF1IsayHhsURu5Dp6fzdr5jYGeJmoREOZAc9UV3aEqY6zNAcWgZT1RwKCCujJylmHgCTCOuxqdK/VdFJqWDyw==}
+  '@rspack/binding-linux-x64-gnu@2.0.0-rc.0':
+    resolution: {integrity: sha512-n1XXXjTcPyCUoV+t3BPfBoF16CgsBxXI7WQuajIgQ33ifm7AEkRi8OVC2ci6908/MnYJSBFHlZvuDE42EwEstQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-musl@2.0.0':
+    resolution: {integrity: sha512-4fgDTMWt0mJDiugdia2mdOjTbnm7yM1Drzl1JpPqlUlOr113byOhc+qgN57LURSGypz2yz/h/Zad7/UnVAxYJw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.0.0-beta.8':
-    resolution: {integrity: sha512-HssdOQE8i+nUWoK+NDeD5OSyNxf80k3elKCl/due3WunoNn0h6tUTSZ8QB+bhcT4tjH9vTbibWZIT91avtvUNw==}
+  '@rspack/binding-linux-x64-musl@2.0.0-rc.0':
+    resolution: {integrity: sha512-EQK7SGu7FWFf1HPPvcahsk2pNL326GQY+jIg3FxGdiAWl1DtSCPrTo/eBKT3nSnXItWta1N80pN5wWVlfs/Liw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-wasm32-wasi@2.0.0':
+    resolution: {integrity: sha512-ANk73ZKtPrZf9gdtyRK2nQUfhi1uXoC5P2KF89pyVAE8+zcoLBnYtZGYpWa/cmNi5BcO5g4Z+v2l1UA3bUPLQQ==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.8':
-    resolution: {integrity: sha512-RuHbXuIMJr0ANMFoGXIb3sUZE5VwIsJw70u3TKPwfoaOFiJjgW7Pi2JTLPoTYfOlE+CNcu2ldX8VJRBbktR4NA==}
+  '@rspack/binding-wasm32-wasi@2.0.0-rc.0':
+    resolution: {integrity: sha512-zu+iW0kEYJd2AEEqYMSU64f98RMOXVwevnQuPtMg3WhVL79FOfkfXOlf16ZYzB8di8hpMRss7m4traGEUEyjZA==}
+    cpu: [wasm32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.0':
+    resolution: {integrity: sha512-IHZFRtJ85ONbM+BCtF4TeYXS2Fu9X0IJS2phX1rPibYq9iEtHGfBt4cNlnsJPhbPAXVvi4Oli/yiLRJ1zxtCIg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.8':
-    resolution: {integrity: sha512-ajzIOk30zjTKPiay+d6oV7lqzzqdgIXQhDD5YtcOqPn7NTh7949EB1NZX5l3Ueh1m8k4DSe7n07qFLjHDhZ8jw==}
+  '@rspack/binding-win32-arm64-msvc@2.0.0-rc.0':
+    resolution: {integrity: sha512-QDOVpN0SdjrW4OicHmkuj8T7PWSqEbUs20FX2pTRBw4ReU7BABAp7wwGdtQzZIaPKDv3CTNz/1DygmInbiNgJg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@2.0.0':
+    resolution: {integrity: sha512-n4tbIqacq/FhNJflMlgZV50AeQFTLh5hnDS3v4W+rJWa3IW1VfgB0+XppdeW+Dqhw7QcMIsCmro01kwNdlXZDQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.0-beta.8':
-    resolution: {integrity: sha512-MqPuHCbxyLSEjavbhYapHs7cvs2zSA9GKd8nJtDuSMmDTVHFzwHfUXTffUMFB4JTCAvdpMn8XtOG/UOW5QVRCA==}
+  '@rspack/binding-win32-ia32-msvc@2.0.0-rc.0':
+    resolution: {integrity: sha512-89CNtgzs67FRHB+lBQoNZmjVqrrd3i+cNCqn0MzCH6Xe12XrO/2eC41gbl69mfYWIYWHpKuySkSTgOOGp0PqNQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.0.0':
+    resolution: {integrity: sha512-cJOgikIW2t3S+42TQZsv+DJriJt2m6lnUk+pUFu/fO93rrMvNrx8gfMxR8W5zDTreBX0cfMx2pw6EVmyi/YzsQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.0.0-beta.8':
-    resolution: {integrity: sha512-6tG/yYhUIF1zcEF7qw9GPA1Bwj5gq+Hqy4OzVzIBUWOn/2bKsFTWuorEJh8Yx1LwOnjNO7O+NbsATvk5zEOGKQ==}
+  '@rspack/binding-win32-x64-msvc@2.0.0-rc.0':
+    resolution: {integrity: sha512-OaxuI+WHzSNoCtv0FfIw41yjCFvwt/aCoEodBSObzm8PH5YbmiYL/FfTeAOVAJbDoEmkA8qYH+gws7vOzgQzSw==}
+    cpu: [x64]
+    os: [win32]
 
-  '@rspack/core@2.0.0-beta.8':
-    resolution: {integrity: sha512-GHiMNhcxfzJV3DqxIYYjiBGzhFkwwt+jSJl8+aVFRbQM0AYRdZJSfQDH4G5rHD1gO2yc3ktOOMHYnZWNtXCwdA==}
+  '@rspack/binding@2.0.0':
+    resolution: {integrity: sha512-WA2f9eQpejkvf5Vrnf6wNCn1m8RT1p08NjgOZpKhsCzr0uBjWeRvGduawlrFFHZh/jPnWZTVaVdQ08FEAWbwGw==}
+
+  '@rspack/binding@2.0.0-rc.0':
+    resolution: {integrity: sha512-zWjMryvt8J8H/Z/sa0MHWfblUTHNCwXhw2x13Yz9Nw2P8JjZ/k/h3ni0xBBl/QubIVoA1IfN2OaiNCtFlVmDrQ==}
+
+  '@rspack/core@2.0.0':
+    resolution: {integrity: sha512-WD1mJM9LbZ7Z399Rbv9dE3BNEV0+3sE5OzDdzV8hOxUb3mX++ynK5n9kil8w60B6nGdcKeV9ly5aN4PgqiwWUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -1113,8 +1204,20 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rushstack/node-core-library@5.20.3':
-    resolution: {integrity: sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==}
+  '@rspack/core@2.0.0-rc.0':
+    resolution: {integrity: sha512-hFc2284m/075etKLLNsECAwOcyNQ8NHUaBhwJCQJQ3J9iqjDoZisefGC8I457u2iieoc1KNSANB9hxZ0ZOHuJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rushstack/node-core-library@5.23.1':
+    resolution: {integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -1129,70 +1232,72 @@ packages:
       '@types/node':
         optional: true
 
-  '@rushstack/rig-package@0.7.2':
-    resolution: {integrity: sha512-9XbFWuqMYcHUso4mnETfhGVUSaADBRj6HUAAEYk50nMPn8WRICmBuCphycQGNB3duIR6EEZX3Xj3SYc2XiP+9A==}
+  '@rushstack/rig-package@0.7.3':
+    resolution: {integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==}
 
-  '@rushstack/terminal@0.22.3':
-    resolution: {integrity: sha512-gHC9pIMrUPzAbBiI4VZMU7Q+rsCzb8hJl36lFIulIzoceKotyKL3Rd76AZ2CryCTKEg+0bnTj406HE5YY5OQvw==}
+  '@rushstack/terminal@0.24.0':
+    resolution: {integrity: sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/ts-command-line@5.3.3':
-    resolution: {integrity: sha512-c+ltdcvC7ym+10lhwR/vWiOhsrm/bP3By2VsFcs5qTKv+6tTmxgbVrtJ5NdNjANiV5TcmOZgUN+5KYQ4llsvEw==}
+  '@rushstack/ts-command-line@5.3.9':
+    resolution: {integrity: sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==}
 
-  '@savvy-web/changesets@0.7.3':
-    resolution: {integrity: sha512-vAU1YuDkONAwBjFVrbLk8geNTcsowdEzZRYNXP2vtOfeW3ENkock3cYhkYdLX5AzPNhQz+wdfDHScnoIeHa3JA==}
+  '@savvy-web/changesets@0.8.0':
+    resolution: {integrity: sha512-U/Kt19wmT8Dkzk4w41TjCDUGqtHCnzdgVPRCpEEqNctphaV3onkD6mFy47CljL2qwRMlFwvswwMBA9qXZtSTTQ==}
     engines: {node: '>=24.0.0'}
     hasBin: true
     peerDependencies:
       '@changesets/cli': ^2.30.0
 
-  '@savvy-web/commitlint@0.5.1':
-    resolution: {integrity: sha512-vlB9+WNeYQec82JOPNznJ1F4EFdteV0ZzZxKeSh+8aw3EyNSRPUXPVJvBZZstHM+kq1Hcq02lJduqfw8a4BMLg==}
+  '@savvy-web/commitlint@0.5.2':
+    resolution: {integrity: sha512-nHxT72BhCleJ0SD54uow5NQ7xjrq22k0xtGhYxJZizFPXHs7ZA+78/TIPcZg26xGEIJmU2uTuRlaOpgMlQxLYA==}
     hasBin: true
     peerDependencies:
       '@commitlint/cli': ^20.5.0
       '@commitlint/config-conventional': ^20.5.0
-      commitizen: ^4.3.1
+      commitizen: ^4.3.0
       husky: ^9.1.0
 
-  '@savvy-web/lint-staged@0.7.2':
-    resolution: {integrity: sha512-hwdKc2adJUsYvii+qxXgtmYj1F8xHoxdscVdB8HyLj+8x/2rY6QzIHE8NDrkAzHMrKNSPY+OTFoA4a5OtCfetg==}
+  '@savvy-web/lint-staged@1.0.0':
+    resolution: {integrity: sha512-r+IoAhZeiGw+cKX+0Ly3Y+EX+MKEpJe2Z9Kjkob9z95YADWZT5tTHiTYt0+n5TWLv4qd2nY6/uTeZtZ4u/I1/Q==}
     engines: {node: '>=24.0.0'}
     hasBin: true
     peerDependencies:
-      '@biomejs/biome': 2.4.9
-      '@types/node': ^25.5.0
+      '@biomejs/biome': 2.4.12
+      '@types/node': ^25.6.0
       '@typescript/native-preview': ^7.0.0-dev.20260124.1
       husky: ^9.1.0
       lint-staged: ^16.4.0
       markdownlint-cli2: ^0.22.0
       markdownlint-cli2-formatter-codequality: ^0.0.7
-      turbo: ^2.8.0
-      typescript: ^5.9.3
+      turbo: ^2.9.0
+      typescript: ^6.0.0
     peerDependenciesMeta:
       '@biomejs/biome':
         optional: true
 
-  '@savvy-web/rslib-builder@0.19.1':
-    resolution: {integrity: sha512-vG0dKK5zPOzeypLfNssqAM/4/fS7MMSKcoeSdGvlp+r6VLMR374uJmA/f1IApQCtnuuFz0J3CTWyc8Wlm/P/EQ==}
+  '@savvy-web/rslib-builder@0.20.2':
+    resolution: {integrity: sha512-f8dxm+aWPVXV95qxhULh2KGMsR3f3zIDC4kM7W/SDCXCvBWPdkzwbAcqbQ7xDXk0MixIhdiAaiFZM7G24vFwuA==}
     peerDependencies:
-      '@microsoft/api-extractor': ^7.57.7
-      '@rsbuild/plugin-react': ^1.4.0
-      '@rslib/core': ^0.20.0
-      '@types/node': ^25.5.0
-      '@types/react': ^19.0.0
+      '@rsbuild/plugin-react': ^2.0.0
+      '@rslib/core': ^0.21.0
+      '@types/node': ^25.6.0
+      '@types/react': ^19.2.0
+      '@types/react-dom': ^19.2.0
       '@typescript/native-preview': ^7.0.0-dev.20260124.1
-      react: ^19.0.0
-      react-dom: ^19.0.0
-      typescript: ^5.9.3
+      react: ^19.2.0
+      react-dom: ^19.2.0
+      typescript: ^6.0.0
     peerDependenciesMeta:
       '@rsbuild/plugin-react':
         optional: true
       '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
       react:
         optional: true
@@ -1203,6 +1308,15 @@ packages:
     resolution: {integrity: sha512-3Lq20TpyAgwHULCJxdveLZCvt48Al6TJwavBJKjJgFkQ2m29JTxNJtMZWD4lYaC2qvu+oONYxV5ylipAqfMk0g==}
     peerDependencies:
       effect: '>=3.21.0'
+
+  '@savvy-web/silk-effects@0.3.0':
+    resolution: {integrity: sha512-2F7+MlexUaEN+NbLBGNTGCscJ2nww90y+rq4MwSXN4rGGE/j58oA5Tcbnm1A3koaUBpQ50jVG9aITXxqmoC2nQ==}
+    peerDependencies:
+      '@effect/platform': '>=0.96.0'
+      effect: '>=3.21.0'
+
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
@@ -1228,33 +1342,33 @@ packages:
     peerDependencies:
       typescript: '>=5.7.2'
 
-  '@turbo/darwin-64@2.8.20':
-    resolution: {integrity: sha512-FQ9EX1xMU5nbwjxXxM3yU88AQQ6Sqc6S44exPRroMcx9XZHqqppl5ymJF0Ig/z3nvQNwDmz1Gsnvxubo+nXWjQ==}
+  '@turbo/darwin-64@2.9.6':
+    resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.8.20':
-    resolution: {integrity: sha512-Gpyh9ATFGThD6/s9L95YWY54cizg/VRWl2B67h0yofG8BpHf67DFAh9nuJVKG7bY0+SBJDAo5cMur+wOl9YOYw==}
+  '@turbo/darwin-arm64@2.9.6':
+    resolution: {integrity: sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.8.20':
-    resolution: {integrity: sha512-p2QxWUYyYUgUFG0b0kR+pPi8t7c9uaVlRtjTTI1AbCvVqkpjUfCcReBn6DgG/Hu8xrWdKLuyQFaLYFzQskZbcA==}
+  '@turbo/linux-64@2.9.6':
+    resolution: {integrity: sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.8.20':
-    resolution: {integrity: sha512-Gn5yjlZGLRZWarLWqdQzv0wMqyBNIdq1QLi48F1oY5Lo9kiohuf7BPQWtWxeNVS2NgJ1+nb/DzK1JduYC4AWOA==}
+  '@turbo/linux-arm64@2.9.6':
+    resolution: {integrity: sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.8.20':
-    resolution: {integrity: sha512-vyaDpYk/8T6Qz5V/X+ihKvKFEZFUoC0oxYpC1sZanK6gaESJlmV3cMRT3Qhcg4D2VxvtC2Jjs9IRkrZGL+exLw==}
+  '@turbo/windows-64@2.9.6':
+    resolution: {integrity: sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.8.20':
-    resolution: {integrity: sha512-voicVULvUV5yaGXo0Iue13BcHGYW3u0VgqSbfQwBaHbpj1zLjYV4KIe+7fYIo6DO8FVUJzxFps3ODCQG/Wy2Qw==}
+  '@turbo/windows-arm64@2.9.6':
+    resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
     cpu: [arm64]
     os: [win32]
 
@@ -1294,12 +1408,15 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@25.5.0':
-    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
+
+  '@types/ssri@7.1.5':
+    resolution: {integrity: sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1307,15 +1424,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript-eslint/parser@8.57.2':
-    resolution: {integrity: sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/parser@8.58.0':
-    resolution: {integrity: sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==}
+  '@typescript-eslint/parser@8.59.0':
+    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1327,14 +1437,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/project-service@8.57.2':
-    resolution: {integrity: sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.58.0':
-    resolution: {integrity: sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==}
+  '@typescript-eslint/project-service@8.59.0':
+    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1343,12 +1447,8 @@ packages:
     resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.57.2':
-    resolution: {integrity: sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/scope-manager@8.58.0':
-    resolution: {integrity: sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==}
+  '@typescript-eslint/scope-manager@8.59.0':
+    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.56.1':
@@ -1357,14 +1457,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/tsconfig-utils@8.57.2':
-    resolution: {integrity: sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/tsconfig-utils@8.58.0':
-    resolution: {integrity: sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==}
+  '@typescript-eslint/tsconfig-utils@8.59.0':
+    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1373,12 +1467,8 @@ packages:
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.57.2':
-    resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/types@8.58.0':
-    resolution: {integrity: sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==}
+  '@typescript-eslint/types@8.59.0':
+    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.56.1':
@@ -1387,14 +1477,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/typescript-estree@8.57.2':
-    resolution: {integrity: sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/typescript-estree@8.58.0':
-    resolution: {integrity: sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==}
+  '@typescript-eslint/typescript-estree@8.59.0':
+    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1410,72 +1494,76 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.57.2':
-    resolution: {integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==}
+  '@typescript-eslint/visitor-keys@8.59.0':
+    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.58.0':
-    resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-lEcUWwu2DLY0NjoB3x7Fivz63zd57D1fD6PD8ByQqa0/xO8+EC5GHr5YniJlHSpF05cn2sgl7SPS92qVs0Xhlw==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1':
+    resolution: {integrity: sha512-wbLr6o5fROaCYt6cOpFhbe92FJAOdhAHwm/s8I/IyN5HbL1ULgel/wHaZiR+ws+27rgruNUiCENzTUg9vSz2bA==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-IvUv0dCaVNKbA9Oq/GEEhtBPF9PP3E5MfW4pla4NpDsZh+6/nL5p0WXvlocV0fe1rT9fqmCQfk3oH+XrN1I8Qw==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1':
+    resolution: {integrity: sha512-13MpNT+4MgkgrfiW2u03rnER5aB3yz9fA0bWEYh6IH3rIqA2AR3Dntp3QXW4sQrZf0SriXqHe2R7X3HCT5xmqA==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-k98Q20XAC8bM9L915GFIfjo/ii/sYIaEzIDH3l6MwhiJMDPucARQpfbReUdXl8N3TsdCNwk8xay0pNIK0DOkvg==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1':
+    resolution: {integrity: sha512-ICIkJDTqmn0R4Vs811+Ht2RYTk1OCrAhHCu0JthmhR216T1Tqgi5DWRoCprp3RL1qU6fLnxxrIpEbNlNN7XFYA==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-7ATSft1YojnRp/VG70i97CxFe+umhTHYA/jJwQBPrjdopAFa5IvFDr4kNajjy1uypbz/x6pfvCnTdOd1/lM3FQ==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1':
+    resolution: {integrity: sha512-CxUA15qbPQRvz2nanBpiv1h4tgXTCJJwqOtgKMSdIuPkow8dyYW3ba5oLoH/jZhS4792XislX659hlFrfiU6CQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-XTe5M1sTwjlxHS1NaNci4vf2nR7bAEwPB70SbhbSTS9ka+75mTP7cv8jHbGhKXEPxDLURBPSyvionog4+5NXmA==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1':
+    resolution: {integrity: sha512-cWLFS4R8dOU1YuUJ/2VLeGMVIjgI3GGb/f9rRY5MbWHq5l3NNZh8y1QwAOrTh3+g3q6+znArfxVnD2hZHUz8Mw==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-1F86Pmf1QcHv0IENBJJ7nWWVSWjR1nn4jokuSbWiPkKGD57rkJWiHY7xtpt4ql8ZG4bIWxdHonLaepBfjIkaug==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1':
+    resolution: {integrity: sha512-OWaGUI4+dHqYZv+k6sITx9Y27FNy3XzNFk4OrOiYtBkIO/xrb9TPMP4A5XI4n5zwRLIv3xne9g039xgRbaeyoQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-zMI8AIWRr98hOgTC5DCe3GD/MGHfusX/E/Dz64Xcf+re4EUVS/pXP5fAUb3dQr8ndi9mHbM0DEmNb4ctSxsxew==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1':
+    resolution: {integrity: sha512-5MQjO/qdLwXpjW7Dy/1lNv7Vtpvo6bhCkbjan4PoRN5/eeyqEqDWxdf8AGE4btLmHqyIjEHRuYf7kp2tlAr6lQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-npU/LrswTK7gawemSkI2BufIgNgoOHA1OwwIC5EUh++oWLDuWZSvSAcH6mfn28NOt5A196zrHQd3SK7f5XCVAw==}
+  '@typescript/native-preview@7.0.0-dev.20260423.1':
+    resolution: {integrity: sha512-9WD7TJJlGvt9PQqJI/+44dVP4oqGQFIkYrpXt7nlQ0WgNIErN52x/XhxmJ4nWft06qejgPiUbPo4aYRNOmIHXg==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
-  '@vitest/coverage-istanbul@4.1.2':
-    resolution: {integrity: sha512-WSz7+4a7PcMtMNvIP7AXUMffsq4JrWeJaguC8lg6fSQyGxSfaT4Rf81idqwxTT6qX5kjjZw2t9rAnCRRQobSqw==}
+  '@vitest/coverage-istanbul@4.1.5':
+    resolution: {integrity: sha512-X4kQMDEWh9mA0IiLuigtdYv4kXe+W8KLTbucoz15lbyZRPAxT5l+hu0JizI7Am050+G9vQnB7QJNgYi2LnwV4w==}
     peerDependencies:
-      vitest: 4.1.2
+      vitest: 4.1.5
 
-  '@vitest/coverage-v8@4.1.2':
-    resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
     peerDependencies:
-      '@vitest/browser': 4.1.2
-      vitest: 4.1.2
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.2':
-    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
-  '@vitest/mocker@4.1.2':
-    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1485,20 +1573,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.2':
-    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
 
-  '@vitest/runner@4.1.2':
-    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
 
-  '@vitest/snapshot@4.1.2':
-    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
 
-  '@vitest/spy@4.1.2':
-    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
 
-  '@vitest/utils@4.1.2':
-    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -1507,9 +1595,9 @@ packages:
     resolution: {integrity: sha512-SO+h5Jg079r2JvGle0jbdtk1EY7ppu6TGzmfWTp3Gy61IEb1OVKBocJ6ydTn4++nYFNfRKYenI2MniZQwsM9KQ==}
     hasBin: true
 
-  '@zkochan/rimraf@3.0.2':
-    resolution: {integrity: sha512-GBf4ua7ogWTr7fATnzk/JLowZDBnBJMm8RkMaC/KcvxZ9gxbMWix0/jImd815LmqKyIHZ7h7lADRddGMdGBuCA==}
-    engines: {node: '>=18.12'}
+  '@zkochan/rimraf@4.0.0':
+    resolution: {integrity: sha512-0EdBn93hMsbx4svJsKQCch+sNMuXvzWbVYqTCGdctQmxtuYK57uCURZPNiNdwS2Y31d96DMWI3BpJ9DLN2Jxfw==}
+    engines: {node: '>=22.13'}
 
   '@zkochan/which@2.0.3':
     resolution: {integrity: sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==}
@@ -1629,8 +1717,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.11:
-    resolution: {integrity: sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==}
+  baseline-browser-mapping@2.10.21:
+    resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1638,8 +1726,8 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@12.8.0:
-    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   bindings@1.5.0:
@@ -1663,8 +1751,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1683,8 +1771,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -1695,8 +1783,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001781:
-    resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
+  caniuse-lite@1.0.30001790:
+    resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1794,15 +1882,15 @@ packages:
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
-  comver-to-semver@1.0.0:
-    resolution: {integrity: sha512-gcGtbRxjwROQOdXLUWH1fQAXqThUVRZ219aAwgtX3KfYw429/Zv6EIJRf5TBSzWdAGwePmqH7w70WTaX4MDqag==}
-    engines: {node: '>=12.17'}
+  comver-to-semver@2.0.0:
+    resolution: {integrity: sha512-4pxiLt2bXHe5BDrolTJs9wfwwT0pPQPQxeUj+X6SKTCkpi8VwvOvgMzohTVVDLXHmAjrZuKEq+tyb0C5zzTSxw==}
+    engines: {node: '>=22.13'}
 
   consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
 
-  content-disposition@1.0.1:
-    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
 
   content-type@1.0.5:
@@ -1840,8 +1928,8 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
-  cosmiconfig-typescript-loader@6.2.0:
-    resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
+  cosmiconfig-typescript-loader@6.3.0:
+    resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
     engines: {node: '>=v18'}
     peerDependencies:
       '@types/node': '*'
@@ -1959,11 +2047,11 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@3.21.0:
-    resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
 
-  electron-to-chromium@1.5.328:
-    resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
+  electron-to-chromium@1.5.344:
+    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -2049,18 +2137,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.1.0:
-    resolution: {integrity: sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    hasBin: true
-    peerDependencies:
-      jiti: '*'
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-
-  eslint@10.2.0:
-    resolution: {integrity: sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==}
+  eslint@10.2.1:
+    resolution: {integrity: sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -2104,17 +2182,17 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  execa@5.1.1:
-    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
-    engines: {node: '>=10'}
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -2128,8 +2206,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.3.2:
-    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+  express-rate-limit@8.4.0:
+    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -2186,6 +2264,10 @@ packages:
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2299,9 +2381,9 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   git-hooks-list@4.2.1:
     resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
@@ -2352,8 +2434,8 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  globby@16.1.1:
-    resolution: {integrity: sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==}
+  globby@16.2.0:
+    resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
     engines: {node: '>=20'}
 
   gopd@1.2.0:
@@ -2386,16 +2468,16 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.10:
-    resolution: {integrity: sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -2409,9 +2491,9 @@ packages:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
-  human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -2576,10 +2658,6 @@ packages:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
 
-  is-plain-obj@2.1.0:
-    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
-    engines: {node: '>=8'}
-
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
@@ -2602,9 +2680,9 @@ packages:
   is-ssh@1.4.1:
     resolution: {integrity: sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==}
 
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -2621,6 +2699,10 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-utf8@0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
@@ -2718,15 +2800,15 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
-  jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
-  katex@0.16.44:
-    resolution: {integrity: sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==}
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
     hasBin: true
 
   keyv@4.5.4:
@@ -2875,16 +2957,12 @@ packages:
     resolution: {integrity: sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==}
     engines: {node: '>=0.10.0'}
 
-  lru-cache@11.2.7:
-    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2913,8 +2991,8 @@ packages:
     peerDependencies:
       markdownlint-cli2: '>=0.0.4'
 
-  markdownlint-cli2@0.22.0:
-    resolution: {integrity: sha512-mOC9BY/XGtdX3M9n3AgERd79F0+S7w18yBBTNIQ453sI87etZfp1z4eajqSMV70CYjbxKe5ktKvT2HCpvcWx9w==}
+  markdownlint-cli2@0.22.1:
+    resolution: {integrity: sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2976,9 +3054,6 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
-
-  merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3106,10 +3181,6 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -3138,8 +3209,8 @@ packages:
     resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
     hasBin: true
 
-  msgpackr@1.11.9:
-    resolution: {integrity: sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==}
+  msgpackr@1.11.10:
+    resolution: {integrity: sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==}
 
   multipasta@0.2.7:
     resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
@@ -3186,16 +3257,16 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
-  node-releases@2.0.36:
-    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3292,6 +3363,10 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   parse-passwd@1.0.0:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
@@ -3318,6 +3393,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-name@1.0.0:
     resolution: {integrity: sha512-/dcAb5vMXH0f51yvMuSUqFpxUcA8JelbRmE5mW/p4CUJxrNgK24IkstnV7ENtg2IDGBOu6izKTG6eilbnbNKWQ==}
@@ -3362,8 +3441,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -3381,10 +3460,14 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
 
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
@@ -3407,8 +3490,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -3474,8 +3557,8 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
@@ -3494,8 +3577,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown@1.0.0-rc.12:
-    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3503,8 +3586,8 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  rsbuild-plugin-dts@0.20.1:
-    resolution: {integrity: sha512-V3cQ/hh8XpkZIYFmokGlk0OLsSSuttpeGgiSjNVRFsXsKxQUG1B8GhLDJ4wVKSZGAiRjZdQu+e96Y5QF6Ra/og==}
+  rsbuild-plugin-dts@0.20.3:
+    resolution: {integrity: sha512-WJlhX8UIlyLBC/wyFK7YK3FzQkQKGEpRbPC8m6wyKu+Db8H5sJkCIvVoBZW+7201V8dJnM2+pmn/NhHDpWqO2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -3532,9 +3615,9 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  safe-execa@0.1.2:
-    resolution: {integrity: sha512-vdTshSQ2JsRCgT8eKZWNJIL26C6bVqy1SOmuCMlKHegVeo8KYRobRrefOdUq9OozSPUUiSxrylteeRmLOMFfWg==}
-    engines: {node: '>=12'}
+  safe-execa@0.3.0:
+    resolution: {integrity: sha512-LMzgcWXnnL60sDuAzlmGehx7OHa4ajy0R/3djFOfnZwj4aksZUcdHfZgIIWLNcqverOAQJ2qOe7BDFm7Qpxd6Q==}
+    engines: {node: '>=22.13'}
 
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
@@ -3553,11 +3636,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.5.4:
-    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.7.4:
@@ -3592,8 +3670,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -3640,13 +3718,13 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
-  sort-keys@4.2.0:
-    resolution: {integrity: sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==}
-    engines: {node: '>=8'}
+  sort-keys@6.0.0:
+    resolution: {integrity: sha512-ueSlHJMwpIw42CJ4B11Uxzh/S0p0AlOyiNktlv2KOu5e1JpUE6DlC4AAUjXqesHdBRv/g0wC9Q4vwq0NP2pA9w==}
+    engines: {node: '>=20'}
 
   sort-object-keys@2.1.0:
     resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
@@ -3674,9 +3752,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  ssri@10.0.5:
-    resolution: {integrity: sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+  ssri@13.0.1:
+    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3685,8 +3763,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@4.0.0:
-    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3731,12 +3809,16 @@ packages:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
     engines: {node: '>=8'}
 
+  strip-bom@5.0.0:
+    resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
+    engines: {node: '>=12'}
+
   strip-comments-strings@1.2.0:
     resolution: {integrity: sha512-zwF4bmnyEjZwRhaak9jUWNxc0DoeKBJ7lwSN/LEc8dQXZcUFG6auaaTQJokQWXopLdM3iTx01nQT8E4aL29DAQ==}
 
-  strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -3779,12 +3861,12 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -3824,8 +3906,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.8.20:
-    resolution: {integrity: sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==}
+  turbo@2.9.6:
+    resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
 
   type-check@0.4.0:
@@ -3840,25 +3922,29 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript@5.8.2:
-    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.24.6:
-    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   unicorn-magic@0.4.0:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
@@ -3920,14 +4006,14 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@8.0.3:
-    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -3963,18 +4049,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.2:
-    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.2
-      '@vitest/browser-preview': 4.1.2
-      '@vitest/browser-webdriverio': 4.1.2
-      '@vitest/ui': 4.1.2
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3990,6 +4078,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -4037,11 +4129,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workspace-tools@0.41.0:
-    resolution: {integrity: sha512-iBB6LNqtJpfjTWnyjlgOwdJmf1wBTUsIr1V5phOBCJMywubpYAijDUqhgz7RfrTYdscA4vEFyhjiy4OSAGULcA==}
+  workspace-tools@0.41.4:
+    resolution: {integrity: sha512-FuSHMNmM1AXJaaWIUMFsWH/+dR0KEzkHhTv96KZ5iKxCvi4TXnATRr/U23d8d8DMUx7oL/oVfr9SvEaDvDYN2A==}
 
   workspaces-effect@0.3.0:
     resolution: {integrity: sha512-ntu9AdP2Q2DTLQdb8rLddzkTBidkbnH0glTS4VVLj/DDTI21ru+sVZq1SIdaNgKqG0DHACoIqRcYGYxvYn3x5g==}
+    peerDependencies:
+      '@effect/platform': '>=0.96.0'
+      effect: '>=3.21.0'
+
+  workspaces-effect@0.4.1:
+    resolution: {integrity: sha512-+YBCKKK8PMG4/sPWyslUpX6cH7YTLpEcSsRNEG2kSxLhPXoMEV7XpK6VIWtYs3jdG+wN59M1d+YQnhVaaFB8eQ==}
     peerDependencies:
       '@effect/platform': '>=0.96.0'
       effect: '>=3.21.0'
@@ -4060,6 +4158,10 @@ packages:
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   write-yaml-file@5.0.0:
     resolution: {integrity: sha512-FdNA4RyH1L43TlvGG8qOMIfcEczwA5ij+zLXUy3Z83CjxhLvcV7/Q/8pk22wnCgYw7PJhtK+7lhO+qqyT4NdvQ==}
@@ -4083,9 +4185,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml-effect@0.2.3:
     resolution: {integrity: sha512-378iw8DWn+6cLzHfOZFLEPu/UXcymHtixKe+CM9OFk9G/uFeQfRU/WNnKRVjIkTCj9M8EwJdiOgH3rOrUwyFyQ==}
@@ -4120,6 +4219,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -4213,7 +4316,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -4277,9 +4380,9 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@changesets/apply-release-plan@7.1.0':
+  '@changesets/apply-release-plan@7.1.1':
     dependencies:
-      '@changesets/config': 3.1.3
+      '@changesets/config': 3.1.4
       '@changesets/get-version-range-type': 0.4.0
       '@changesets/git': 3.0.4
       '@changesets/should-skip-package': 0.1.2
@@ -4293,10 +4396,10 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.4
 
-  '@changesets/assemble-release-plan@6.0.9':
+  '@changesets/assemble-release-plan@6.0.10':
     dependencies:
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/get-dependents-graph': 2.1.4
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
@@ -4306,15 +4409,15 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.30.0(@types/node@25.5.0)':
+  '@changesets/cli@2.31.0(@types/node@25.6.0)':
     dependencies:
-      '@changesets/apply-release-plan': 7.1.0
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/apply-release-plan': 7.1.1
+      '@changesets/assemble-release-plan': 6.0.10
       '@changesets/changelog-git': 0.2.1
-      '@changesets/config': 3.1.3
+      '@changesets/config': 3.1.4
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/get-release-plan': 4.0.15
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/get-release-plan': 4.0.16
       '@changesets/git': 3.0.4
       '@changesets/logger': 0.1.1
       '@changesets/pre': 2.0.2
@@ -4322,7 +4425,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@25.5.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.6.0)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -4337,10 +4440,10 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@changesets/config@3.1.3':
+  '@changesets/config@3.1.4':
     dependencies:
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/get-dependents-graph': 2.1.4
       '@changesets/logger': 0.1.1
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
@@ -4352,7 +4455,7 @@ snapshots:
     dependencies:
       extendable-error: 0.1.7
 
-  '@changesets/get-dependents-graph@2.1.3':
+  '@changesets/get-dependents-graph@2.1.4':
     dependencies:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
@@ -4366,10 +4469,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/get-release-plan@4.0.15':
+  '@changesets/get-release-plan@4.0.16':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9
-      '@changesets/config': 3.1.3
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/config': 3.1.4
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.7
       '@changesets/types': 6.1.0
@@ -4427,14 +4530,14 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@commitlint/cli@20.5.0(@types/node@25.5.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+  '@commitlint/cli@20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/format': 20.5.0
       '@commitlint/lint': 20.5.0
-      '@commitlint/load': 20.5.0(@types/node@25.5.0)(typescript@5.9.3)
+      '@commitlint/load': 20.5.0(@types/node@25.6.0)(typescript@6.0.3)
       '@commitlint/read': 20.5.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 20.5.0
-      tinyexec: 1.0.4
+      tinyexec: 1.1.1
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
@@ -4480,14 +4583,14 @@ snapshots:
       '@commitlint/rules': 20.5.0
       '@commitlint/types': 20.5.0
 
-  '@commitlint/load@20.5.0(@types/node@25.5.0)(typescript@5.9.3)':
+  '@commitlint/load@20.5.0(@types/node@25.6.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 20.5.0
       '@commitlint/execute-rule': 20.0.0
       '@commitlint/resolve-extends': 20.5.0
       '@commitlint/types': 20.5.0
-      cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.5.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3)
       is-plain-obj: 4.1.0
       lodash.mergewith: 4.6.2
       picocolors: 1.1.1
@@ -4509,7 +4612,7 @@ snapshots:
       '@commitlint/types': 20.5.0
       git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
       minimist: 1.2.8
-      tinyexec: 1.0.4
+      tinyexec: 1.1.1
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
@@ -4541,7 +4644,7 @@ snapshots:
       conventional-commits-parser: 6.4.0
       picocolors: 1.1.1
 
-  '@conventional-changelog/git-client@2.6.0(conventional-commits-parser@6.4.0)':
+  '@conventional-changelog/git-client@2.7.0(conventional-commits-parser@6.4.0)':
     dependencies:
       '@simple-libs/child-process-utils': 1.0.2
       '@simple-libs/stream-utils': 1.2.0
@@ -4549,209 +4652,186 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
-  '@effect/cli@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
+  '@effect/cli@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)
-      effect: 3.21.0
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
       ini: 4.1.3
       toml: 3.0.0
       yaml: 2.8.3
 
-  '@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
+  '@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/workflow': 0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      effect: 3.21.0
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/workflow': 0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
       kubernetes-types: 1.30.0
 
-  '@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)':
+  '@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      effect: 3.21.0
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      effect: 3.21.2
       uuid: 11.1.0
 
-  '@effect/platform-node-shared@0.59.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
+  '@effect/platform-node-shared@0.59.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/cluster': 0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@parcel/watcher': 2.5.6
-      effect: 3.21.0
+      effect: 3.21.2
       multipasta: 0.2.7
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
+  '@effect/platform-node@0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/cluster': 0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/platform-node-shared': 0.59.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      effect: 3.21.0
+      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-node-shared': 0.59.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
       mime: 3.0.0
-      undici: 7.24.6
+      undici: 7.25.0
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform@0.96.0(effect@3.21.0)':
+  '@effect/platform@0.96.1(effect@3.21.2)':
     dependencies:
-      effect: 3.21.0
+      effect: 3.21.2
       find-my-way-ts: 0.1.6
-      msgpackr: 1.11.9
+      msgpackr: 1.11.10
       multipasta: 0.2.7
 
-  '@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)':
+  '@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/typeclass': 0.40.0(effect@3.21.0)
-      effect: 3.21.0
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/typeclass': 0.40.0(effect@3.21.2)
+      effect: 3.21.2
 
-  '@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)':
+  '@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/typeclass': 0.40.0(effect@3.21.0)
-      effect: 3.21.0
+      '@effect/typeclass': 0.40.0(effect@3.21.2)
+      effect: 3.21.2
 
-  '@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)':
+  '@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      effect: 3.21.0
-      msgpackr: 1.11.9
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      effect: 3.21.2
+      msgpackr: 1.11.10
 
-  '@effect/sql-sqlite-node@0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
+  '@effect/sql-sqlite-node@0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      better-sqlite3: 12.8.0
-      effect: 3.21.0
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      better-sqlite3: 12.9.0
+      effect: 3.21.2
 
-  '@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)':
+  '@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      effect: 3.21.0
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      effect: 3.21.2
       uuid: 11.1.0
 
-  '@effect/typeclass@0.40.0(effect@3.21.0)':
+  '@effect/typeclass@0.40.0(effect@3.21.2)':
     dependencies:
-      effect: 3.21.0
+      effect: 3.21.2
 
-  '@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
+  '@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      effect: 3.21.0
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
 
-  '@emnapi/core@1.9.1':
+  '@emnapi/core@1.10.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.1.0(jiti@2.6.1))':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
-      eslint: 10.1.0(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
+      tslib: 2.8.1
+    optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.0(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.6.1))':
     dependencies:
-      eslint: 10.2.0(jiti@2.6.1)
+      eslint: 10.2.1(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.3':
+  '@eslint/config-array@0.23.5':
     dependencies:
-      '@eslint/object-schema': 3.0.3
-      debug: 4.4.3
-      minimatch: 10.2.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/config-array@0.23.4':
-    dependencies:
-      '@eslint/object-schema': 3.0.4
+      '@eslint/object-schema': 3.0.5
       debug: 4.4.3
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.5.3':
+  '@eslint/config-helpers@0.5.5':
     dependencies:
-      '@eslint/core': 1.1.1
+      '@eslint/core': 1.2.1
 
-  '@eslint/config-helpers@0.5.4':
-    dependencies:
-      '@eslint/core': 1.2.0
-
-  '@eslint/core@1.1.1':
+  '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/core@1.2.0':
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.1':
     dependencies:
-      '@types/json-schema': 7.0.15
-
-  '@eslint/object-schema@3.0.3': {}
-
-  '@eslint/object-schema@3.0.4': {}
-
-  '@eslint/plugin-kit@0.6.1':
-    dependencies:
-      '@eslint/core': 1.1.1
-      levn: 0.4.1
-
-  '@eslint/plugin-kit@0.7.0':
-    dependencies:
-      '@eslint/core': 1.2.0
+      '@eslint/core': 1.2.1
       levn: 0.4.1
 
   '@gwhitney/detect-indent@7.0.1': {}
 
-  '@hono/node-server@1.19.12(hono@4.12.10)':
+  '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
-      hono: 4.12.10
+      hono: 4.12.14
 
-  '@humanfs/core@0.19.1': {}
-
-  '@humanfs/node@0.16.7':
+  '@humanfs/core@0.19.2':
     dependencies:
-      '@humanfs/core': 0.19.1
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
       '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.5.0)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.6.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
 
-  '@istanbuljs/schema@0.1.3': {}
+  '@istanbuljs/schema@0.1.6': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4788,30 +4868,29 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@microsoft/api-extractor-model@7.33.4(@types/node@25.5.0)':
+  '@microsoft/api-extractor-model@7.33.8(@types/node@25.6.0)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.5.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.6.0)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.57.7(@types/node@25.5.0)':
+  '@microsoft/api-extractor@7.58.7(@types/node@25.6.0)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.4(@types/node@25.5.0)
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@25.6.0)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.5.0)
-      '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.3(@types/node@25.5.0)
-      '@rushstack/ts-command-line': 5.3.3(@types/node@25.5.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.6.0)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.24.0(@types/node@25.6.0)
+      '@rushstack/ts-command-line': 5.3.9(@types/node@25.6.0)
       diff: 8.0.4
-      lodash: 4.18.1
       minimatch: 10.2.5
-      resolve: 1.22.11
-      semver: 7.5.4
+      resolve: 1.22.12
+      semver: 7.7.4
       source-map: 0.6.1
-      typescript: 5.8.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -4820,23 +4899,23 @@ snapshots:
       '@microsoft/tsdoc': 0.16.0
       ajv: 8.18.0
       jju: 1.4.0
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   '@microsoft/tsdoc@0.16.0': {}
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.12(hono@4.12.10)
+      '@hono/node-server': 1.19.14(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.10
+      express-rate-limit: 8.4.0(express@5.2.1)
+      hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4864,10 +4943,17 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.1':
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -4883,7 +4969,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@oxc-project/types@0.122.0': {}
+  '@oxc-project/types@0.127.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -4945,11 +5031,13 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
-  '@pnpm/catalogs.config@1000.0.6':
+  '@pnpm/catalogs.config@1100.0.0':
     dependencies:
-      '@pnpm/error': 1000.1.0
+      '@pnpm/error': 1100.0.0
 
   '@pnpm/catalogs.protocol-parser@1001.0.0': {}
+
+  '@pnpm/catalogs.protocol-parser@1100.0.0': {}
 
   '@pnpm/catalogs.resolver@1000.0.5':
     dependencies:
@@ -4958,28 +5046,31 @@ snapshots:
 
   '@pnpm/constants@1001.3.1': {}
 
+  '@pnpm/constants@1100.0.0': {}
+
   '@pnpm/core-loggers@1001.0.9(@pnpm/logger@1001.0.1)':
     dependencies:
       '@pnpm/logger': 1001.0.1
       '@pnpm/types': 1001.3.0
 
-  '@pnpm/crypto.hash@1000.2.2':
+  '@pnpm/crypto.hash@1100.0.0':
     dependencies:
-      '@pnpm/crypto.polyfill': 1000.1.0
-      '@pnpm/graceful-fs': 1000.1.0
-      ssri: 10.0.5
+      '@pnpm/fs.graceful-fs': 1100.0.0
+      ssri: 13.0.1
 
-  '@pnpm/crypto.polyfill@1000.1.0': {}
-
-  '@pnpm/dependency-path@1001.1.10':
+  '@pnpm/deps.path@1100.0.1':
     dependencies:
-      '@pnpm/crypto.hash': 1000.2.2
-      '@pnpm/types': 1001.3.0
+      '@pnpm/crypto.hash': 1100.0.0
+      '@pnpm/types': 1101.0.0
       semver: 7.7.4
 
   '@pnpm/error@1000.1.0':
     dependencies:
       '@pnpm/constants': 1001.3.1
+
+  '@pnpm/error@1100.0.0':
+    dependencies:
+      '@pnpm/constants': 1100.0.0
 
   '@pnpm/exportable-manifest@1000.4.2(@pnpm/logger@1001.0.1)':
     dependencies:
@@ -4993,56 +5084,80 @@ snapshots:
     transitivePeerDependencies:
       - '@pnpm/logger'
 
-  '@pnpm/git-utils@1000.0.0':
+  '@pnpm/fetching.fetcher-base@1100.1.0':
     dependencies:
-      execa: safe-execa@0.1.2
+      '@pnpm/resolving.resolver-base': 1100.1.0
+      '@pnpm/types': 1101.0.0
+      '@types/ssri': 7.1.5
+
+  '@pnpm/fetching.pick-fetcher@1100.0.3':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.fetcher-base': 1100.1.0
+      '@pnpm/hooks.types': 1100.0.3
+      '@pnpm/resolving.resolver-base': 1100.1.0
+      '@pnpm/store.cafs-types': 1100.0.0
+
+  '@pnpm/fs.graceful-fs@1100.0.0':
+    dependencies:
+      graceful-fs: 4.2.11
 
   '@pnpm/graceful-fs@1000.1.0':
     dependencies:
       graceful-fs: 4.2.11
 
-  '@pnpm/lockfile.fs@1001.1.32(@pnpm/logger@1001.0.1)':
+  '@pnpm/hooks.types@1100.0.3':
     dependencies:
-      '@pnpm/constants': 1001.3.1
-      '@pnpm/dependency-path': 1001.1.10
-      '@pnpm/error': 1000.1.0
-      '@pnpm/git-utils': 1000.0.0
-      '@pnpm/lockfile.merger': 1001.0.20
-      '@pnpm/lockfile.types': 1002.1.0
-      '@pnpm/lockfile.utils': 1004.0.3
+      '@pnpm/fetching.fetcher-base': 1100.1.0
+      '@pnpm/lockfile.types': 1100.0.2
+      '@pnpm/resolving.resolver-base': 1100.1.0
+      '@pnpm/store.cafs-types': 1100.0.0
+      '@pnpm/types': 1101.0.0
+
+  '@pnpm/lockfile.fs@1100.0.3(@pnpm/logger@1001.0.1)':
+    dependencies:
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/deps.path': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/lockfile.merger': 1100.0.2
+      '@pnpm/lockfile.types': 1100.0.2
+      '@pnpm/lockfile.utils': 1100.0.3
       '@pnpm/logger': 1001.0.1
-      '@pnpm/object.key-sorting': 1000.0.1
-      '@pnpm/types': 1001.3.0
-      '@zkochan/rimraf': 3.0.2
-      comver-to-semver: 1.0.0
+      '@pnpm/network.git-utils': 1100.0.0
+      '@pnpm/object.key-sorting': 1100.0.0
+      '@pnpm/types': 1101.0.0
+      '@zkochan/rimraf': 4.0.0
+      comver-to-semver: 2.0.0
       js-yaml: '@zkochan/js-yaml@0.0.11'
       normalize-path: 3.0.0
       ramda: '@pnpm/ramda@0.28.1'
       semver: 7.7.4
-      strip-bom: 4.0.0
-      write-file-atomic: 5.0.1
+      strip-bom: 5.0.0
+      write-file-atomic: 7.0.1
 
-  '@pnpm/lockfile.merger@1001.0.20':
+  '@pnpm/lockfile.merger@1100.0.2':
     dependencies:
-      '@pnpm/lockfile.types': 1002.1.0
-      '@pnpm/types': 1001.3.0
-      comver-to-semver: 1.0.0
+      '@pnpm/lockfile.types': 1100.0.2
+      '@pnpm/types': 1101.0.0
+      comver-to-semver: 2.0.0
       ramda: '@pnpm/ramda@0.28.1'
       semver: 7.7.4
 
-  '@pnpm/lockfile.types@1002.1.0':
+  '@pnpm/lockfile.types@1100.0.2':
     dependencies:
-      '@pnpm/patching.types': 1000.1.0
-      '@pnpm/resolver-base': 1005.4.1
-      '@pnpm/types': 1001.3.0
+      '@pnpm/patching.types': 1100.0.0
+      '@pnpm/resolving.resolver-base': 1100.1.0
+      '@pnpm/types': 1101.0.0
 
-  '@pnpm/lockfile.utils@1004.0.3':
+  '@pnpm/lockfile.utils@1100.0.3':
     dependencies:
-      '@pnpm/dependency-path': 1001.1.10
-      '@pnpm/lockfile.types': 1002.1.0
-      '@pnpm/pick-fetcher': 1001.0.0
-      '@pnpm/resolver-base': 1005.4.1
-      '@pnpm/types': 1001.3.0
+      '@pnpm/deps.path': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.pick-fetcher': 1100.0.3
+      '@pnpm/hooks.types': 1100.0.3
+      '@pnpm/lockfile.types': 1100.0.2
+      '@pnpm/resolving.resolver-base': 1100.1.0
+      '@pnpm/types': 1101.0.0
       get-npm-tarball-url: 2.1.0
       ramda: '@pnpm/ramda@0.28.1'
 
@@ -5060,14 +5175,16 @@ snapshots:
       '@pnpm/types': 1001.3.0
       semver: 7.7.4
 
-  '@pnpm/object.key-sorting@1000.0.1':
+  '@pnpm/network.git-utils@1100.0.0':
+    dependencies:
+      execa: safe-execa@0.3.0
+
+  '@pnpm/object.key-sorting@1100.0.0':
     dependencies:
       '@pnpm/util.lex-comparator': 3.0.2
-      sort-keys: 4.2.0
+      sort-keys: 6.0.0
 
-  '@pnpm/patching.types@1000.1.0': {}
-
-  '@pnpm/pick-fetcher@1001.0.0': {}
+  '@pnpm/patching.types@1100.0.0': {}
 
   '@pnpm/ramda@0.28.1': {}
 
@@ -5088,23 +5205,27 @@ snapshots:
       read-yaml-file: 2.1.0
       strip-bom: 4.0.0
 
-  '@pnpm/resolver-base@1005.4.1':
-    dependencies:
-      '@pnpm/types': 1001.3.0
-
   '@pnpm/resolving.jsr-specifier-parser@1000.0.4':
     dependencies:
       '@pnpm/error': 1000.1.0
 
+  '@pnpm/resolving.resolver-base@1100.1.0':
+    dependencies:
+      '@pnpm/types': 1101.0.0
+
   '@pnpm/semver.peer-range@1000.0.0':
     dependencies:
       semver: 7.7.4
+
+  '@pnpm/store.cafs-types@1100.0.0': {}
 
   '@pnpm/text.comments-parser@1000.0.0':
     dependencies:
       strip-comments-strings: 1.2.0
 
   '@pnpm/types@1001.3.0': {}
+
+  '@pnpm/types@1101.0.0': {}
 
   '@pnpm/util.lex-comparator@3.0.2': {}
 
@@ -5123,126 +5244,201 @@ snapshots:
       write-file-atomic: 5.0.1
       write-yaml-file: 5.0.0
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.12': {}
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
-  '@rsbuild/core@2.0.0-beta.10':
+  '@rsbuild/core@2.0.0':
     dependencies:
-      '@rspack/core': 2.0.0-beta.8(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.0(@swc/helpers@0.5.21)
       '@swc/helpers': 0.5.21
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.20.1(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@typescript/native-preview@7.0.0-dev.20260327.2)(typescript@5.9.3)':
+  '@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.10
-      rsbuild-plugin-dts: 0.20.1(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@rsbuild/core@2.0.0-beta.10)(@typescript/native-preview@7.0.0-dev.20260327.2)(typescript@5.9.3)
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.57.7(@types/node@25.5.0)
-      typescript: 5.9.3
+      '@rspack/core': 2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/helpers@0.5.21)
+      '@swc/helpers': 0.5.21
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
+
+  '@rslib/core@0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3)':
+    dependencies:
+      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rsbuild-plugin-dts: 0.20.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
       - core-js
 
-  '@rspack/binding-darwin-arm64@2.0.0-beta.8':
+  '@rspack/binding-darwin-arm64@2.0.0':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.0-beta.8':
+  '@rspack/binding-darwin-arm64@2.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.8':
+  '@rspack/binding-darwin-x64@2.0.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.0-beta.8':
+  '@rspack/binding-darwin-x64@2.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.0-beta.8':
+  '@rspack/binding-linux-arm64-gnu@2.0.0':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.0-beta.8':
+  '@rspack/binding-linux-arm64-gnu@2.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.0.0-beta.8':
+  '@rspack/binding-linux-arm64-musl@2.0.0':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.0-rc.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.0.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.0.0-rc.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.0-rc.0':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.0.0':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.8':
+  '@rspack/binding-wasm32-wasi@2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.8':
+  '@rspack/binding-win32-arm64-msvc@2.0.0':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.0-beta.8':
+  '@rspack/binding-win32-arm64-msvc@2.0.0-rc.0':
     optional: true
 
-  '@rspack/binding@2.0.0-beta.8':
+  '@rspack/binding-win32-ia32-msvc@2.0.0':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@2.0.0-rc.0':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.0':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.0-rc.0':
+    optional: true
+
+  '@rspack/binding@2.0.0':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.0-beta.8
-      '@rspack/binding-darwin-x64': 2.0.0-beta.8
-      '@rspack/binding-linux-arm64-gnu': 2.0.0-beta.8
-      '@rspack/binding-linux-arm64-musl': 2.0.0-beta.8
-      '@rspack/binding-linux-x64-gnu': 2.0.0-beta.8
-      '@rspack/binding-linux-x64-musl': 2.0.0-beta.8
-      '@rspack/binding-wasm32-wasi': 2.0.0-beta.8
-      '@rspack/binding-win32-arm64-msvc': 2.0.0-beta.8
-      '@rspack/binding-win32-ia32-msvc': 2.0.0-beta.8
-      '@rspack/binding-win32-x64-msvc': 2.0.0-beta.8
+      '@rspack/binding-darwin-arm64': 2.0.0
+      '@rspack/binding-darwin-x64': 2.0.0
+      '@rspack/binding-linux-arm64-gnu': 2.0.0
+      '@rspack/binding-linux-arm64-musl': 2.0.0
+      '@rspack/binding-linux-x64-gnu': 2.0.0
+      '@rspack/binding-linux-x64-musl': 2.0.0
+      '@rspack/binding-wasm32-wasi': 2.0.0
+      '@rspack/binding-win32-arm64-msvc': 2.0.0
+      '@rspack/binding-win32-ia32-msvc': 2.0.0
+      '@rspack/binding-win32-x64-msvc': 2.0.0
 
-  '@rspack/core@2.0.0-beta.8(@swc/helpers@0.5.21)':
+  '@rspack/binding@2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.0-rc.0
+      '@rspack/binding-darwin-x64': 2.0.0-rc.0
+      '@rspack/binding-linux-arm64-gnu': 2.0.0-rc.0
+      '@rspack/binding-linux-arm64-musl': 2.0.0-rc.0
+      '@rspack/binding-linux-x64-gnu': 2.0.0-rc.0
+      '@rspack/binding-linux-x64-musl': 2.0.0-rc.0
+      '@rspack/binding-wasm32-wasi': 2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rspack/binding-win32-arm64-msvc': 2.0.0-rc.0
+      '@rspack/binding-win32-ia32-msvc': 2.0.0-rc.0
+      '@rspack/binding-win32-x64-msvc': 2.0.0-rc.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@rspack/core@2.0.0(@swc/helpers@0.5.21)':
     dependencies:
-      '@rspack/binding': 2.0.0-beta.8
+      '@rspack/binding': 2.0.0
     optionalDependencies:
       '@swc/helpers': 0.5.21
 
-  '@rushstack/node-core-library@5.20.3(@types/node@25.5.0)':
+  '@rspack/core@2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/helpers@0.5.21)':
+    dependencies:
+      '@rspack/binding': 2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optionalDependencies:
+      '@swc/helpers': 0.5.21
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@rushstack/node-core-library@5.23.1(@types/node@25.6.0)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -5250,57 +5446,57 @@ snapshots:
       fs-extra: 11.3.4
       import-lazy: 4.0.0
       jju: 1.4.0
-      resolve: 1.22.11
-      semver: 7.5.4
+      resolve: 1.22.12
+      semver: 7.7.4
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@25.5.0)':
+  '@rushstack/problem-matcher@0.2.1(@types/node@25.6.0)':
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
 
-  '@rushstack/rig-package@0.7.2':
+  '@rushstack/rig-package@0.7.3':
     dependencies:
-      resolve: 1.22.11
-      strip-json-comments: 3.1.1
+      jju: 1.4.0
+      resolve: 1.22.12
 
-  '@rushstack/terminal@0.22.3(@types/node@25.5.0)':
+  '@rushstack/terminal@0.24.0(@types/node@25.6.0)':
     dependencies:
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.5.0)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@25.5.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.6.0)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@25.6.0)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
 
-  '@rushstack/ts-command-line@5.3.3(@types/node@25.5.0)':
+  '@rushstack/ts-command-line@5.3.9(@types/node@25.6.0)':
     dependencies:
-      '@rushstack/terminal': 0.22.3(@types/node@25.5.0)
+      '@rushstack/terminal': 0.24.0(@types/node@25.6.0)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
 
-  '@savvy-web/changesets@0.7.3(@changesets/cli@2.30.0(@types/node@25.5.0))(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))':
+  '@savvy-web/changesets@0.8.0(@changesets/cli@2.31.0(@types/node@25.6.0))(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))':
     dependencies:
-      '@changesets/cli': 2.30.0(@types/node@25.5.0)
+      '@changesets/cli': 2.31.0(@types/node@25.6.0)
       '@changesets/get-github-info': 0.8.0
-      '@effect/cli': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@savvy-web/silk-effects': 0.2.2(effect@3.21.0)
-      effect: 3.21.0
-      jsonc-effect: 0.2.1(effect@3.21.0)
+      '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@savvy-web/silk-effects': 0.2.2(effect@3.21.2)
+      effect: 3.21.2
+      jsonc-effect: 0.2.1(effect@3.21.2)
       mdast-util-heading-range: 4.0.0
       mdast-util-to-string: 4.0.0
       remark-gfm: 4.0.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       unified: 11.0.5
       unified-lint-rule: 3.0.1
       unist-util-visit: 5.1.0
-      workspaces-effect: 0.3.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      workspaces-effect: 0.3.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
     transitivePeerDependencies:
       - '@effect/cluster'
       - '@effect/printer'
@@ -5312,23 +5508,23 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/commitlint@0.5.1(@commitlint/cli@20.5.0(@types/node@25.5.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3))(@commitlint/config-conventional@20.5.0)(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/typeclass@0.40.0(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(commitizen@4.3.1(@types/node@25.5.0)(typescript@5.9.3))(husky@9.1.7)':
+  '@savvy-web/commitlint@0.5.2(@commitlint/cli@20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3))(@commitlint/config-conventional@20.5.0)(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/typeclass@0.40.0(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(commitizen@4.3.1(@types/node@25.6.0)(typescript@6.0.3))(husky@9.1.7)':
     dependencies:
-      '@commitlint/cli': 20.5.0(@types/node@25.5.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+      '@commitlint/cli': 20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
       '@commitlint/config-conventional': 20.5.0
-      '@effect/cli': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/cluster': 0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@savvy-web/silk-effects': 0.2.2(effect@3.21.0)
-      commitizen: 4.3.1(@types/node@25.5.0)(typescript@5.9.3)
-      effect: 3.21.0
+      '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@savvy-web/silk-effects': 0.2.2(effect@3.21.2)
+      commitizen: 4.3.1(@types/node@25.6.0)(typescript@6.0.3)
+      effect: 3.21.2
       husky: 9.1.7
-      workspaces-effect: 0.3.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      workspaces-effect: 0.3.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       zod: 4.3.6
     transitivePeerDependencies:
       - '@effect/experimental'
@@ -5337,28 +5533,25 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@savvy-web/lint-staged@0.7.2(88bc74b6e7c8e49a5f745efabf87a7f6)':
+  '@savvy-web/lint-staged@1.0.0(75f98f15d93bd459d8942de7d8b41eb0)':
     dependencies:
-      '@effect/cli': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@savvy-web/silk-effects': 0.2.2(effect@3.21.0)
-      '@types/node': 25.5.0
-      '@typescript-eslint/parser': 8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript/native-preview': 7.0.0-dev.20260327.2
-      effect: 3.21.0
-      eslint: 10.2.0(jiti@2.6.1)
-      eslint-plugin-tsdoc: 0.5.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
+      '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@savvy-web/silk-effects': 0.3.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@types/node': 25.6.0
+      '@typescript/native-preview': 7.0.0-dev.20260423.1
+      effect: 3.21.2
       husky: 9.1.7
-      jsonc-effect: 0.2.1(effect@3.21.0)
+      jsonc-effect: 0.2.1(effect@3.21.2)
       lint-staged: 16.4.0
-      markdownlint-cli2: 0.22.0
-      markdownlint-cli2-formatter-codequality: 0.0.7(markdownlint-cli2@0.22.0)
-      prettier: 3.8.1
+      markdownlint-cli2: 0.22.1
+      markdownlint-cli2-formatter-codequality: 0.0.7(markdownlint-cli2@0.22.1)
+      prettier: 3.8.3
       sort-package-json: 3.6.1
-      turbo: 2.8.20
-      typescript: 5.9.3
-      workspaces-effect: 0.3.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      turbo: 2.9.6
+      typescript: 6.0.3
+      workspaces-effect: 0.4.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       yaml: 2.8.3
       yaml-lint: 1.7.0
     transitivePeerDependencies:
@@ -5368,46 +5561,58 @@ snapshots:
       - '@effect/rpc'
       - '@effect/sql'
       - bufferutil
-      - jiti
-      - supports-color
       - utf-8-validate
 
-  '@savvy-web/rslib-builder@0.19.1(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@pnpm/logger@1001.0.1)(@rslib/core@0.20.1(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@typescript/native-preview@7.0.0-dev.20260327.2)(typescript@5.9.3))(@types/node@25.5.0)(@typescript/native-preview@7.0.0-dev.20260327.2)(jiti@2.6.1)(typescript@5.9.3)':
+  '@savvy-web/rslib-builder@0.20.2(@pnpm/logger@1001.0.1)(@rslib/core@0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3))(@types/node@25.6.0)(@typescript/native-preview@7.0.0-dev.20260423.1)(jiti@2.6.1)(typescript@6.0.3)':
     dependencies:
-      '@microsoft/api-extractor': 7.57.7(@types/node@25.5.0)
+      '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@pnpm/catalogs.config': 1000.0.6
-      '@pnpm/catalogs.protocol-parser': 1001.0.0
+      '@pnpm/catalogs.config': 1100.0.0
+      '@pnpm/catalogs.protocol-parser': 1100.0.0
       '@pnpm/exportable-manifest': 1000.4.2(@pnpm/logger@1001.0.1)
-      '@pnpm/lockfile.fs': 1001.1.32(@pnpm/logger@1001.0.1)
+      '@pnpm/lockfile.fs': 1100.0.3(@pnpm/logger@1001.0.1)
       '@pnpm/workspace.read-manifest': 1000.3.1
-      '@rslib/core': 0.20.1(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@typescript/native-preview@7.0.0-dev.20260327.2)(typescript@5.9.3)
-      '@types/node': 25.5.0
-      '@typescript-eslint/parser': 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript/native-preview': 7.0.0-dev.20260327.2
+      '@rsbuild/core': 2.0.0
+      '@rslib/core': 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3)
+      '@types/node': 25.6.0
+      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript/native-preview': 7.0.0-dev.20260423.1
       deep-equal: 2.2.3
-      eslint: 10.1.0(jiti@2.6.1)
-      eslint-plugin-tsdoc: 0.5.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 10.2.1(jiti@2.6.1)
+      eslint-plugin-tsdoc: 0.5.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       glob: 13.0.6
       picocolors: 1.1.1
       sort-package-json: 3.6.1
       tmp: 0.2.5
-      typescript: 5.9.3
-      workspace-tools: 0.41.0
+      typescript: 6.0.3
+      workspace-tools: 0.41.4
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@pnpm/logger'
+      - core-js
       - jiti
       - supports-color
 
-  '@savvy-web/silk-effects@0.2.2(effect@3.21.0)':
+  '@savvy-web/silk-effects@0.2.2(effect@3.21.2)':
     dependencies:
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      effect: 3.21.0
-      jsonc-effect: 0.2.1(effect@3.21.0)
-      semver-effect: 0.2.1(effect@3.21.0)
-      workspaces-effect: 0.3.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      yaml-effect: 0.2.3(effect@3.21.0)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      effect: 3.21.2
+      jsonc-effect: 0.2.1(effect@3.21.2)
+      semver-effect: 0.2.1(effect@3.21.2)
+      workspaces-effect: 0.3.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      yaml-effect: 0.2.3(effect@3.21.2)
+
+  '@savvy-web/silk-effects@0.3.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      effect: 3.21.2
+      jsonc-effect: 0.2.1(effect@3.21.2)
+      semver-effect: 0.2.1(effect@3.21.2)
+      workspaces-effect: 0.4.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      yaml-effect: 0.2.3(effect@3.21.2)
+
+  '@sec-ant/readable-stream@0.4.1': {}
 
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
@@ -5423,26 +5628,26 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@trpc/server@11.16.0(typescript@5.9.3)':
+  '@trpc/server@11.16.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@turbo/darwin-64@2.8.20':
+  '@turbo/darwin-64@2.9.6':
     optional: true
 
-  '@turbo/darwin-arm64@2.8.20':
+  '@turbo/darwin-arm64@2.9.6':
     optional: true
 
-  '@turbo/linux-64@2.8.20':
+  '@turbo/linux-64@2.9.6':
     optional: true
 
-  '@turbo/linux-arm64@2.8.20':
+  '@turbo/linux-arm64@2.9.6':
     optional: true
 
-  '@turbo/windows-64@2.8.20':
+  '@turbo/windows-64@2.9.6':
     optional: true
 
-  '@turbo/windows-arm64@2.8.20':
+  '@turbo/windows-arm64@2.9.6':
     optional: true
 
   '@tybys/wasm-util@0.10.1':
@@ -5479,66 +5684,49 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.5.0':
+  '@types/node@25.6.0':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 7.19.2
 
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
 
+  '@types/ssri@7.1.5':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/parser@8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.57.2
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.57.2
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
-      eslint: 10.1.0(jiti@2.6.1)
-      typescript: 5.9.3
+      eslint: 10.2.1(jiti@2.6.1)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.56.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.58.0
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.58.0
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.0
       debug: 4.4.3
-      eslint: 10.2.0(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.59.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.0
       debug: 4.4.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.57.2(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.2
-      debug: 4.4.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.58.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.58.0
-      debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5547,98 +5735,61 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
 
-  '@typescript-eslint/scope-manager@8.57.2':
+  '@typescript-eslint/scope-manager@8.59.0':
     dependencies:
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/visitor-keys': 8.57.2
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
 
-  '@typescript-eslint/scope-manager@8.58.0':
+  '@typescript-eslint/tsconfig-utils@8.56.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/visitor-keys': 8.58.0
+      typescript: 6.0.3
 
-  '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
-
-  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
-  '@typescript-eslint/tsconfig-utils@8.58.0(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@typescript-eslint/types@8.56.1': {}
 
-  '@typescript-eslint/types@8.57.2': {}
+  '@typescript-eslint/types@8.59.0': {}
 
-  '@typescript-eslint/types@8.58.0': {}
-
-  '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.56.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.56.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.57.2(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/visitor-keys': 8.57.2
-      debug: 4.4.3
-      minimatch: 10.2.4
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.58.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/visitor-keys': 8.58.0
+      '@typescript-eslint/project-service': 8.59.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      eslint: 10.1.0(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.56.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.0(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      eslint: 10.2.0(jiti@2.6.1)
-      typescript: 5.9.3
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@6.0.3)
+      eslint: 10.2.1(jiti@2.6.1)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5647,51 +5798,46 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript-eslint/visitor-keys@8.57.2':
+  '@typescript-eslint/visitor-keys@8.59.0':
     dependencies:
-      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
-  '@typescript-eslint/visitor-keys@8.58.0':
-    dependencies:
-      '@typescript-eslint/types': 8.58.0
-      eslint-visitor-keys: 5.0.1
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260327.2':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260327.2':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260327.2':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260327.2':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260327.2':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260327.2':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260327.2':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260327.2':
+  '@typescript/native-preview@7.0.0-dev.20260423.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260327.2
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260423.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260423.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260423.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260423.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260423.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260423.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260423.1
 
-  '@vitest/coverage-istanbul@4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)))':
+  '@vitest/coverage-istanbul@4.1.5(vitest@4.1.5)':
     dependencies:
       '@babel/core': 7.29.0
-      '@istanbuljs/schema': 0.1.3
+      '@istanbuljs/schema': 0.1.6
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       istanbul-lib-coverage: 3.2.2
@@ -5700,62 +5846,62 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)))':
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.5
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
       obug: 2.1.1
-      std-env: 4.0.0
+      std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
 
-  '@vitest/expect@4.1.2':
+  '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.1.2
+      '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.2':
+  '@vitest/pretty-format@4.1.5':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.2':
+  '@vitest/runner@4.1.5':
     dependencies:
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.5
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.2':
+  '@vitest/snapshot@4.1.5':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.2': {}
+  '@vitest/spy@4.1.5': {}
 
-  '@vitest/utils@4.1.2':
+  '@vitest/utils@4.1.5':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
+      '@vitest/pretty-format': 4.1.5
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -5765,7 +5911,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  '@zkochan/rimraf@3.0.2': {}
+  '@zkochan/rimraf@4.0.0': {}
 
   '@zkochan/which@2.0.3':
     dependencies:
@@ -5865,13 +6011,13 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.11: {}
+  baseline-browser-mapping@2.10.21: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@12.8.0:
+  better-sqlite3@12.9.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
@@ -5894,7 +6040,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.1
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -5913,13 +6059,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.1:
+  browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.11
-      caniuse-lite: 1.0.30001781
-      electron-to-chromium: 1.5.328
-      node-releases: 2.0.36
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      baseline-browser-mapping: 2.10.21
+      caniuse-lite: 1.0.30001790
+      electron-to-chromium: 1.5.344
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer@5.7.1:
     dependencies:
@@ -5935,7 +6081,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  call-bind@1.0.8:
+  call-bind@1.0.9:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
@@ -5949,7 +6095,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001781: {}
+  caniuse-lite@1.0.30001790: {}
 
   ccount@2.0.1: {}
 
@@ -6027,10 +6173,10 @@ snapshots:
 
   commander@8.3.0: {}
 
-  commitizen@4.3.1(@types/node@25.5.0)(typescript@5.9.3):
+  commitizen@4.3.1(@types/node@25.6.0)(typescript@6.0.3):
     dependencies:
       cachedir: 2.3.0
-      cz-conventional-changelog: 3.3.0(@types/node@25.5.0)(typescript@5.9.3)
+      cz-conventional-changelog: 3.3.0(@types/node@25.6.0)(typescript@6.0.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -6052,11 +6198,11 @@ snapshots:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
-  comver-to-semver@1.0.0: {}
+  comver-to-semver@2.0.0: {}
 
   consola@2.15.3: {}
 
-  content-disposition@1.0.1: {}
+  content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
 
@@ -6086,21 +6232,21 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@25.5.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
-      '@types/node': 25.5.0
-      cosmiconfig: 9.0.1(typescript@5.9.3)
+      '@types/node': 25.6.0
+      cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.6.1
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  cosmiconfig@9.0.1(typescript@5.9.3):
+  cosmiconfig@9.0.1(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6108,16 +6254,16 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cz-conventional-changelog@3.3.0(@types/node@25.5.0)(typescript@5.9.3):
+  cz-conventional-changelog@3.3.0(@types/node@25.6.0)(typescript@6.0.3):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.1(@types/node@25.5.0)(typescript@5.9.3)
+      commitizen: 4.3.1(@types/node@25.6.0)(typescript@6.0.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 20.5.0(@types/node@25.5.0)(typescript@5.9.3)
+      '@commitlint/load': 20.5.0(@types/node@25.6.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -6141,7 +6287,7 @@ snapshots:
   deep-equal@2.2.3:
     dependencies:
       array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       es-get-iterator: 1.1.3
       get-intrinsic: 1.3.0
       is-arguments: 1.2.0
@@ -6215,12 +6361,12 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@3.21.0:
+  effect@3.21.2:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  electron-to-chromium@1.5.328: {}
+  electron-to-chromium@1.5.344: {}
 
   emoji-regex@10.6.0: {}
 
@@ -6253,7 +6399,7 @@ snapshots:
 
   es-get-iterator@1.1.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       is-arguments: 1.2.0
@@ -6279,21 +6425,11 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-tsdoc@0.5.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3):
+  eslint-plugin-tsdoc@0.5.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - typescript
-
-  eslint-plugin-tsdoc@0.5.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3):
-    dependencies:
-      '@microsoft/tsdoc': 0.16.0
-      '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -6310,52 +6446,15 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.1.0(jiti@2.6.1):
+  eslint@10.2.1(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.3
-      '@eslint/config-helpers': 0.5.3
-      '@eslint/core': 1.1.1
-      '@eslint/plugin-kit': 0.6.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.14.0
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.4
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.6.1
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@10.2.0(jiti@2.6.1):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.0(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.4
-      '@eslint/config-helpers': 0.5.4
-      '@eslint/core': 1.2.0
-      '@eslint/plugin-kit': 0.7.0
-      '@humanfs/node': 0.16.7
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.5.5
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
+      '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
@@ -6412,23 +6511,26 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  eventsource-parser@3.0.6: {}
+  eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
 
-  execa@5.1.1:
+  execa@9.6.1:
     dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
       cross-spawn: 7.0.6
-      get-stream: 6.0.1
-      human-signals: 2.1.0
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
 
   expand-template@2.0.3: {}
 
@@ -6438,7 +6540,7 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.3.2(express@5.2.1):
+  express-rate-limit@8.4.0(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0
@@ -6447,7 +6549,7 @@ snapshots:
     dependencies:
       accepts: 2.0.0
       body-parser: 2.2.2
-      content-disposition: 1.0.1
+      content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
@@ -6465,7 +6567,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -6519,6 +6621,10 @@ snapshots:
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -6587,7 +6693,7 @@ snapshots:
   fs-extra@11.3.4:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.2.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fs-extra@7.0.1:
@@ -6606,7 +6712,7 @@ snapshots:
     dependencies:
       at-least-node: 1.0.0
       graceful-fs: 4.2.11
-      jsonfile: 6.2.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
@@ -6634,7 +6740,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-npm-tarball-url@2.1.0: {}
@@ -6644,13 +6750,16 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@6.0.1: {}
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   git-hooks-list@4.2.1: {}
 
   git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
     dependencies:
-      '@conventional-changelog/git-client': 2.6.0(conventional-commits-parser@6.4.0)
+      '@conventional-changelog/git-client': 2.7.0(conventional-commits-parser@6.4.0)
       meow: 13.2.0
     transitivePeerDependencies:
       - conventional-commits-filter
@@ -6677,7 +6786,7 @@ snapshots:
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -6717,7 +6826,7 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globby@16.1.1:
+  globby@16.2.0:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
       fast-glob: 3.3.3
@@ -6746,7 +6855,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -6754,7 +6863,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.10: {}
+  hono@4.12.14: {}
 
   html-escaper@2.0.2: {}
 
@@ -6768,7 +6877,7 @@ snapshots:
 
   human-id@4.1.3: {}
 
-  human-signals@2.1.0: {}
+  human-signals@8.0.1: {}
 
   husky@9.1.7: {}
 
@@ -6835,7 +6944,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       side-channel: 1.1.0
 
   ip-address@10.1.0: {}
@@ -6856,7 +6965,7 @@ snapshots:
 
   is-array-buffer@3.0.5:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
@@ -6875,7 +6984,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   is-date-object@1.1.0:
     dependencies:
@@ -6913,8 +7022,6 @@ snapshots:
 
   is-path-inside@4.0.0: {}
 
-  is-plain-obj@2.1.0: {}
-
   is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
@@ -6924,7 +7031,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   is-set@2.0.3: {}
 
@@ -6936,7 +7043,7 @@ snapshots:
     dependencies:
       protocols: 2.0.2
 
-  is-stream@2.0.1: {}
+  is-stream@4.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -6954,6 +7061,8 @@ snapshots:
       safe-regex-test: 1.1.0
 
   is-unicode-supported@0.1.0: {}
+
+  is-unicode-supported@2.1.0: {}
 
   is-utf8@0.2.1: {}
 
@@ -7018,9 +7127,9 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonc-effect@0.2.1(effect@3.21.0):
+  jsonc-effect@0.2.1(effect@3.21.2):
     dependencies:
-      effect: 3.21.0
+      effect: 3.21.2
 
   jsonc-parser@3.3.1: {}
 
@@ -7028,7 +7137,7 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonfile@6.2.0:
+  jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
@@ -7036,7 +7145,7 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
-  katex@0.16.44:
+  katex@0.16.45:
     dependencies:
       commander: 8.3.0
 
@@ -7112,7 +7221,7 @@ snapshots:
       listr2: 9.0.5
       picomatch: 4.0.4
       string-argv: 0.3.2
-      tinyexec: 1.0.4
+      tinyexec: 1.1.1
       yaml: 2.8.3
 
   listr2@9.0.5:
@@ -7165,15 +7274,11 @@ snapshots:
 
   longest@2.0.1: {}
 
-  lru-cache@11.2.7: {}
+  lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
 
   magic-string@0.30.21:
     dependencies:
@@ -7200,25 +7305,25 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
-  markdownlint-cli2-formatter-codequality@0.0.7(markdownlint-cli2@0.22.0):
+  markdownlint-cli2-formatter-codequality@0.0.7(markdownlint-cli2@0.22.1):
     dependencies:
-      markdownlint-cli2: 0.22.0
+      markdownlint-cli2: 0.22.1
 
-  markdownlint-cli2-formatter-default@0.0.6(markdownlint-cli2@0.22.0):
+  markdownlint-cli2-formatter-default@0.0.6(markdownlint-cli2@0.22.1):
     dependencies:
-      markdownlint-cli2: 0.22.0
+      markdownlint-cli2: 0.22.1
 
-  markdownlint-cli2@0.22.0:
+  markdownlint-cli2@0.22.1:
     dependencies:
-      globby: 16.1.1
+      globby: 16.2.0
       js-yaml: 4.1.1
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.1.1
       markdownlint: 0.40.0
-      markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.0)
+      markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.1)
       micromatch: 4.0.8
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7355,8 +7460,6 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
-  merge-stream@2.0.0: {}
-
   merge2@1.4.1: {}
 
   merge@2.1.1: {}
@@ -7452,7 +7555,7 @@ snapshots:
     dependencies:
       '@types/katex': 0.16.8
       devlop: 1.1.0
-      katex: 0.16.44
+      katex: 0.16.45
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
@@ -7591,10 +7694,6 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.5
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -7623,7 +7722,7 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
     optional: true
 
-  msgpackr@1.11.9:
+  msgpackr@1.11.10:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
@@ -7661,13 +7760,14 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
-  node-releases@2.0.36: {}
+  node-releases@2.0.38: {}
 
   normalize-path@3.0.0: {}
 
-  npm-run-path@4.0.1:
+  npm-run-path@6.0.0:
     dependencies:
-      path-key: 3.1.1
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
 
   object-assign@4.1.1: {}
 
@@ -7675,14 +7775,14 @@ snapshots:
 
   object-is@1.1.6:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
   object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
@@ -7781,6 +7881,8 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse-ms@4.0.0: {}
+
   parse-passwd@1.0.0: {}
 
   parse-path@7.1.0:
@@ -7800,13 +7902,15 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-name@1.0.0: {}
 
   path-parse@1.0.7: {}
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.7
+      lru-cache: 11.3.5
       minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
@@ -7827,7 +7931,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.8:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -7852,7 +7956,11 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
 
   protocols@2.0.2: {}
 
@@ -7872,7 +7980,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.15.0:
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -7916,7 +8024,7 @@ snapshots:
 
   regexp.prototype.flags@1.5.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-errors: 1.3.0
       get-proto: 1.0.1
@@ -7962,8 +8070,9 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve@1.22.11:
+  resolve@1.22.12:
     dependencies:
+      es-errors: 1.3.0
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
@@ -7982,26 +8091,26 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown@1.0.0-rc.12:
+  rolldown@1.0.0-rc.17:
     dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   router@2.2.0:
     dependencies:
@@ -8013,14 +8122,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.20.1(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@rsbuild/core@2.0.0-beta.10)(@typescript/native-preview@7.0.0-dev.20260327.2)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.20.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.0-beta.10
+      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optionalDependencies:
-      '@microsoft/api-extractor': 7.57.7(@types/node@25.5.0)
-      '@typescript/native-preview': 7.0.0-dev.20260327.2
-      typescript: 5.9.3
+      '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
+      '@typescript/native-preview': 7.0.0-dev.20260423.1
+      typescript: 6.0.3
 
   run-async@2.4.1: {}
 
@@ -8034,10 +8143,10 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  safe-execa@0.1.2:
+  safe-execa@0.3.0:
     dependencies:
       '@zkochan/which': 2.0.3
-      execa: 5.1.1
+      execa: 9.6.1
       path-name: 1.0.0
 
   safe-regex-test@1.1.0:
@@ -8050,15 +8159,11 @@ snapshots:
 
   secure-keys@1.0.0: {}
 
-  semver-effect@0.2.1(effect@3.21.0):
+  semver-effect@0.2.1(effect@3.21.2):
     dependencies:
-      effect: 3.21.0
+      effect: 3.21.2
 
   semver@6.3.1: {}
-
-  semver@7.5.4:
-    dependencies:
-      lru-cache: 6.0.0
 
   semver@7.7.4: {}
 
@@ -8111,7 +8216,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -8135,7 +8240,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -8167,11 +8272,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
-  sort-keys@4.2.0:
+  sort-keys@6.0.0:
     dependencies:
-      is-plain-obj: 2.1.0
+      is-plain-obj: 4.1.0
 
   sort-object-keys@2.1.0: {}
 
@@ -8183,7 +8288,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.4
       sort-object-keys: 2.1.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
 
   source-map-js@1.2.1: {}
 
@@ -8198,7 +8303,7 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  ssri@10.0.5:
+  ssri@13.0.1:
     dependencies:
       minipass: 7.1.3
 
@@ -8206,7 +8311,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@4.0.0: {}
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -8253,9 +8358,11 @@ snapshots:
 
   strip-bom@4.0.0: {}
 
+  strip-bom@5.0.0: {}
+
   strip-comments-strings@1.2.0: {}
 
-  strip-final-newline@2.0.0: {}
+  strip-final-newline@4.0.0: {}
 
   strip-json-comments@2.0.1: {}
 
@@ -8296,9 +8403,9 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.4: {}
+  tinyexec@1.1.1: {}
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -8319,9 +8426,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tslib@2.8.1: {}
 
@@ -8329,14 +8436,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.8.20:
+  turbo@2.9.6:
     optionalDependencies:
-      '@turbo/darwin-64': 2.8.20
-      '@turbo/darwin-arm64': 2.8.20
-      '@turbo/linux-64': 2.8.20
-      '@turbo/linux-arm64': 2.8.20
-      '@turbo/windows-64': 2.8.20
-      '@turbo/windows-arm64': 2.8.20
+      '@turbo/darwin-64': 2.9.6
+      '@turbo/darwin-arm64': 2.9.6
+      '@turbo/linux-64': 2.9.6
+      '@turbo/linux-arm64': 2.9.6
+      '@turbo/windows-64': 2.9.6
+      '@turbo/windows-arm64': 2.9.6
 
   type-check@0.4.0:
     dependencies:
@@ -8350,15 +8457,17 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript@5.8.2: {}
-
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
-  undici-types@7.18.2: {}
+  undici-types@7.19.2: {}
 
-  undici@7.24.6: {}
+  undici@7.25.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   unicorn-magic@0.4.0: {}
 
@@ -8404,9 +8513,9 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -8430,43 +8539,45 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3):
+  vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.12
-      tinyglobby: 0.2.15
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.3
 
-  vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/runner': 4.1.2
-      '@vitest/snapshot': 4.1.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 4.0.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
+      '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5)
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
     transitivePeerDependencies:
       - msw
 
@@ -8499,7 +8610,7 @@ snapshots:
   which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       for-each: 0.3.5
       get-proto: 1.0.1
@@ -8521,24 +8632,32 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workspace-tools@0.41.0:
+  workspace-tools@0.41.4:
     dependencies:
       '@yarnpkg/lockfile': 1.1.0
       fast-glob: 3.3.3
       git-url-parse: 16.1.0
-      globby: 11.1.0
       jju: 1.4.0
       js-yaml: 4.1.1
       micromatch: 4.0.8
 
-  workspaces-effect@0.3.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0):
+  workspaces-effect@0.3.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2):
     dependencies:
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      effect: 3.21.0
-      jsonc-effect: 0.2.1(effect@3.21.0)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      effect: 3.21.2
+      jsonc-effect: 0.2.1(effect@3.21.2)
       minimatch: 10.2.5
-      semver-effect: 0.2.1(effect@3.21.0)
-      yaml-effect: 0.2.3(effect@3.21.0)
+      semver-effect: 0.2.1(effect@3.21.2)
+      yaml-effect: 0.2.3(effect@3.21.2)
+
+  workspaces-effect@0.4.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2):
+    dependencies:
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      effect: 3.21.2
+      jsonc-effect: 0.2.1(effect@3.21.2)
+      minimatch: 10.2.5
+      semver-effect: 0.2.1(effect@3.21.2)
+      yaml-effect: 0.2.3(effect@3.21.2)
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -8559,6 +8678,10 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
+
   write-yaml-file@5.0.0:
     dependencies:
       js-yaml: 4.1.1
@@ -8570,11 +8693,9 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yallist@4.0.0: {}
-
-  yaml-effect@0.2.3(effect@3.21.0):
+  yaml-effect@0.2.3(effect@3.21.2):
     dependencies:
-      effect: 3.21.0
+      effect: 3.21.2
 
   yaml-lint@1.7.0:
     dependencies:
@@ -8610,6 +8731,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors@2.1.2: {}
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,5 @@ packages:
   - package
 autoInstallPeers: true
 configDependencies:
-  "@savvy-web/pnpm-plugin-silk": 0.10.1+sha512-qLbAWHXszOBaSUPiTpV2qsfVA1phj/ferkbsZvd3aA3QhcfuTwATayqFfABfNmK5saTC6KhfAUxEsrAPRW7tDw==
+  "@savvy-web/pnpm-plugin-silk": 0.12.1+sha512-+eHl6vUz4G6BDjw7MDR2iDN4+DcximPGfyflbHR16UsayXKIo0JXwQvTSOcfsMw1p0SLEN9prsSq7df/ztO3Xw==
 loglevel: info


### PR DESCRIPTION
## Summary

- Replace `spawnSync` in `run_tests` MCP tool with Vitest's programmatic API (`createVitest` + `start`) so test results flow through the reporter pipeline to SQLite and all query tools reflect the latest run immediately
- Add `test_get` MCP tool for single-test drill-down: state, errors with diffs, run history with P/F/S visualization, classification, and next-step suggestions
- Add `file_coverage` MCP tool for per-file coverage: metric values vs thresholds, uncovered lines, and related tests
- Enhance `run_tests` output with classification badges (`[new-failure]`, `[persistent]`, `[flaky]`) and actionable Next Steps section
- Expand reporter data capture: suites via `allSuites()` with `parentSuiteId` hierarchy, test tags to `tags`/`test_case_tags` tables, error stacks parsed into structured `stack_frames` rows
- Guard against undefined `diagnostic()` and `result()` on skipped/pending/todo tests
- Fix `note_get` to return `{ found, note }` instead of raw `null`
- Add `state` enum validation to `test_list`, fix status icons to Unicode, update help text to 24 tools
- Trim session-start hook from 63 to 15 lines, standardize empty-result messages, add coverage-improvement plugin skill
- Sync design docs, update CLAUDE.md, add minor changeset

Closes #23

## Test plan

- [ ] All 569 tests pass (`pnpm run test`)
- [ ] Types check clean (`pnpm run typecheck`)
- [ ] Verify `run_tests` MCP tool executes tests and returns structured markdown
- [ ] Verify `test_get` returns test details with history visualization
- [ ] Verify `file_coverage` returns per-file metrics with uncovered lines
- [ ] Verify session-start hook outputs valid JSON with concise context

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>