### PR TITLE
fix(plugin): fix session ID contamination and task panel orphan bugs

### DIFF
--- a/.changeset/plugin-transport-fixes.md
+++ b/.changeset/plugin-transport-fixes.md
@@ -1,0 +1,17 @@
+---
+"vitest-agent-mcp": patch
+---
+
+## Bug Fixes
+
+### Claude Code plugin: session ID and task panel fixes
+
+Fixes a session ID contamination bug where `get_current_session_id()` could return a stale synthetic subagent key after a `context:fork` dispatch, causing all PostToolUse artifact writes to fail with "no open TDD session" errors. Replaced with `session_list({ agentKind: "main", limit: 1 })` which reads the correct value from the database.
+
+Fixes an orphaned-task bug in the task panel where abandoned sessions (which fire `behaviors_ready` but never `behavior_started`) would leave pending `□` tasks with no associated work. `TaskCreate` is now deferred from `behaviors_ready` to `behavior_started`.
+
+## Maintenance
+
+* `hook-debug.sh` added to `hooks/lib/` — structured `hook_error` (always-on) and `hook_debug` (env-gated via `VITEST_AGENT_HOOK_DEBUG=1`) logging for all hook scripts
+* `hooks/fixtures/` added — synthetic JSON payloads for manual hook invocation during development
+* `match-tdd-agent.sh` narrowed — legacy agent_type forms (`plugin:vitest-agent:tdd-task`, bare `tdd-task`) removed after being confirmed never observed in practice

--- a/.claude/design/vitest-agent/components/plugin-claude.md
+++ b/.claude/design/vitest-agent/components/plugin-claude.md
@@ -149,12 +149,25 @@ categories:
 
 The match-tdd-agent helper at `hooks/lib/match-tdd-agent.sh` is the load-bearing
 piece for orchestrator scoping. Claude Code emits the subagent identity in the
-hook envelope's `agent_type` field, but the exact value depends on how the
-plugin is namespaced — Claude Code currently sends `"vitest-agent:tdd-task"`,
-the legacy `"plugin:vitest-agent:tdd-task"` and bare `"tdd-task"` forms are
-retained defensively. All orchestrator-scoped hooks gate through the shared
-`is_tdd_agent` function so the matching logic lives in one place. If Claude
-Code's identity format changes, this is the only file that needs updating.
+hook envelope's `agent_type` field — Claude Code currently sends the value
+`"vitest-agent:tdd-task"`, and that is the only form matched. Legacy forms
+(`"plugin:vitest-agent:tdd-task"`, bare `"tdd-task"`) were removed after they
+were confirmed never observed in practice. All orchestrator-scoped hooks gate
+through the shared `is_tdd_agent` function so the matching logic lives in one
+place. If Claude Code's identity format changes, this is the only file that
+needs updating.
+
+Hook scripts source a shared logging helper at `hooks/lib/hook-debug.sh` that
+provides two logging functions. `hook_error` always appends to
+`/tmp/vitest-agent-hook-errors.log` (overrideable via
+`VITEST_AGENT_HOOK_ERROR_LOG`); CLI failures in recording and artifact hooks
+write here instead of being silently swallowed. `hook_debug` appends to
+`/tmp/vitest-agent-hook-debug.log` (overrideable via
+`VITEST_AGENT_HOOK_DEBUG_LOG`) but only when `VITEST_AGENT_HOOK_DEBUG=1` is
+set. Recording and artifact hooks use a structured capture-and-log pattern: CLI
+output is captured, exit status is tested, and failures call `hook_error` before
+the hook exits — the previous pattern of appending `|| true` to silence errors
+is gone.
 
 The allowlist file at `hooks/lib/safe-mcp-vitest-agent-ops.txt` is plain text:
 one operation suffix per line, blank lines and `#` comments stripped before
@@ -246,6 +259,14 @@ context (session-start triage, MCP tool reference) compensates for this by
 giving every dispatch the same baseline awareness of the project's test
 state.
 
+**Pre-dispatch sequence.** Before spawning the orchestrator, the main agent
+calls `session_list({ agentKind: "main", limit: 1 })` to capture the
+`cc_session_id` from the DB row — not `get_current_session_id()`, which can
+hold a stale in-memory reference if a prior subagent called
+`set_current_session_id` with its own key. The agent then calls `TaskCreate` to
+create the parent `TDD Session: <objective>` task and initializes the
+`goalById` and `behaviorById` state maps before spawning.
+
 **Channel-event flow.** When the orchestrator hits a lifecycle transition
 (goal/behavior created, started, phase changed, completed, abandoned, blocked,
 session complete), it calls `tdd_progress_push` with a typed payload. The MCP
@@ -261,6 +282,14 @@ cannot push the wrong tree coordinates — even if the orchestrator's mental
 model of the goal/behavior hierarchy drifts, the MCP server resolves
 coordinates from the database. Resolution is best-effort; malformed JSON or
 DB read failures fall through with the original payload.
+
+**`behaviors_ready` deferral.** When the main agent receives a `behaviors_ready`
+channel event, it records each behavior's ordinals in `behaviorById` but does
+**not** call `TaskCreate` yet. Task creation is deferred to `behavior_started`
+so that abandoned sessions — which fire `behaviors_ready` but never
+`behavior_started` — do not leave orphaned pending tasks in the task panel.
+This is why the `tdd` skill's event-handler table specifies "No tasks yet" for
+both `behaviors_ready` and `behavior_added`.
 
 The `tools[]` enumeration on the orchestrator is documentation, not
 enforcement. The runtime gate that prevents `tdd_goal_delete` and

--- a/.claude/design/vitest-agent/data-flows.md
+++ b/.claude/design/vitest-agent/data-flows.md
@@ -195,17 +195,16 @@ Owned by the file-based Claude Code plugin at `plugin/`. See
 [./components/plugin-claude.md](./components/plugin-claude.md) and
 [./decisions.md](./decisions.md) D30.
 
-- `plugin/bin/mcp-server.mjs` (zero-deps) reads
-  `process.env.CLAUDE_PROJECT_DIR ?? process.cwd()`.
+- `plugin/bin/start-mcp.sh` (zero-deps POSIX shell) reads
+  `CLAUDE_PROJECT_DIR` (or falls back to `pwd`).
 - Detect PM: `packageManager` field in root `package.json`, else lockfile
   (`pnpm-lock.yaml`, `bun.lock`, `bun.lockb`, `yarn.lock`,
   `package-lock.json`), else default `npm`.
-- Spawn `<pm-exec> vitest-agent-mcp` (`pnpm exec`, `npx --no-install`,
-  `yarn run`, or `bun x`) with `stdio: "inherit"`, `cwd: projectDir`, and
-  `env.VITEST_AGENT_PROJECT_DIR = projectDir` so the spawned bin sees the
-  right project root (Flow 4).
-- Forward exit code; re-raise termination signals; print PM-specific install
-  instructions on non-zero exit.
+- `exec`-replaces itself with `<pm-exec> vitest-agent-mcp` (`pnpm exec`,
+  `npx --no-install`, `yarn run`, or `bun x`) with `VITEST_AGENT_REPORTER_PROJECT_DIR`
+  set so the spawned bin sees the right project root (Flow 4).
+- After exec, Claude Code's direct child is the PM process; no wrapper hangs around.
+  Print PM-specific install instructions and exit non-zero if the bin is missing.
 
 The loader is a thin spawner because Claude Code's MCP integration runs the
 configured command as a child process and the plugin can't assume the user

--- a/.claude/design/vitest-agent/decisions.md
+++ b/.claude/design/vitest-agent/decisions.md
@@ -349,25 +349,24 @@ stderr and returns. After the migration completes, normal reads/writes
 work under WAL + `busy_timeout`. The fix lives at the call site — the
 migrator's transaction boundaries are not ours to rewrite.
 
-### Decision 30: Plugin MCP Loader as PM-Detect + Spawn
+### Decision 30: Plugin MCP Loader as PM-Detect + Exec
 
-`plugin/bin/mcp-server.mjs` is a zero-deps PM-detect + spawn script:
+`plugin/bin/start-mcp.sh` is a zero-deps POSIX shell PM-detect + exec loader:
 
-1. Resolve `projectDir` from `process.env.CLAUDE_PROJECT_DIR ||
-   process.cwd()`.
+1. Resolve `projectDir` from `CLAUDE_PROJECT_DIR` (or `pwd`).
 2. Detect the user's package manager via `packageManager` field in
    `<projectDir>/package.json`, then by lockfile presence
    (`pnpm-lock.yaml` → pnpm, `bun.lock`/`bun.lockb` → bun, `yarn.lock`
    → yarn, `package-lock.json` → npm). Default `npm`.
-3. Spawn `<pm-exec> vitest-agent-mcp` with `stdio: "inherit"`,
-   `cwd: projectDir`, and `env: { ...process.env,
-   VITEST_AGENT_PROJECT_DIR: projectDir }`. PM commands are `pnpm exec`,
-   `npx --no-install`, `yarn run`, `bun x`.
-4. On `child.error`, print PM-specific install instructions and exit 1.
-5. On `child.exit`, forward the code or re-raise the signal.
+3. `exec`-replace the shell with `<pm-exec> vitest-agent-mcp`, exporting
+   `VITEST_AGENT_REPORTER_PROJECT_DIR=projectDir`. PM commands are
+   `pnpm exec`, `npx --no-install`, `yarn run`, `bun x`.
+4. Print PM-specific install instructions and exit 1 if the bin is missing.
 
-The script imports only `node:child_process`, `node:fs`, and
-`node:path` — it must run before the user has installed anything.
+The `exec` is load-bearing — after startup, Claude Code's direct child is
+the PM process; there is no shell wrapper. A Node.js fallback loader
+(`start-mcp.mjs`) exists for debugging but is not the active loader unless
+`plugin.json` is changed to reference it.
 
 **Why this shape:** the MCP server is its own package
 (`vitest-agent-mcp`) with its own bin. The user's PM already knows how
@@ -378,7 +377,7 @@ PM-level error with PM-native install instructions, not "couldn't find
 silently downloading from the registry and exceeding Claude Code's MCP
 startup window.
 
-**`VITEST_AGENT_PROJECT_DIR` env passthrough:** the spawned MCP
+**`VITEST_AGENT_REPORTER_PROJECT_DIR` env passthrough:** the spawned MCP
 subprocess uses this env var as the highest-precedence source for
 `projectDir`. Claude Code sets `CLAUDE_PROJECT_DIR` for hook scripts
 but does not reliably propagate it to MCP server subprocesses; this

--- a/.claude/design/vitest-agent/file-structure.md
+++ b/.claude/design/vitest-agent/file-structure.md
@@ -41,9 +41,10 @@ examples/
 
 plugin/        file-based Claude Code plugin (NOT a pnpm workspace)
   .claude-plugin/plugin.json    inline mcpServers config
-  bin/mcp-server.mjs            zero-deps PM-detect + spawn loader
-  hooks/                        shell scripts + hooks.json
-  agents/tdd-orchestrator.md    subagent definition
+  bin/start-mcp.sh              zero-deps POSIX shell PM-detect + exec loader
+  bin/start-mcp.mjs             Node.js fallback loader (not active by default)
+  hooks/                        shell scripts + hooks.json + fixtures/ + lib/
+  agents/tdd-task.md            tdd-task subagent definition
   skills/                       plugin-shipped skills
   commands/                     slash commands
 
@@ -184,8 +185,8 @@ empty string, so `(project, NULL)` and `(project, '')` are different rows.
 The CLI overview and history commands need to output correct run commands.
 Canonical detection logic lives in `packages/sdk/src/utils/detect-pm.ts`
 behind a `FileSystemAdapter` interface for testability. The plugin's
-`bin/mcp-server.mjs` ships a zero-deps inline copy with the same detection
-order:
+`bin/start-mcp.sh` (and `hooks/lib/detect-pm.sh`) ship zero-deps copies
+with the same detection order:
 
 1. Check `packageManager` field in root `package.json`
 2. Fall back to lockfile detection (`pnpm-lock.yaml`, `bun.lock`,

--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -57,7 +57,11 @@ No user discussion. Pick, write, dispatch, verify.
 
 No handoff file. Dispatches the tdd-task agent with a fixed prompt that walks the TDD session machinery end-to-end. The source file `playground/src/lifecycle.ts` has a deliberate off-by-one bug (`return a + b + 1`); the orchestrator writes a test that exposes it, fixes the source, and closes the session. After each run the main agent reverts `lifecycle.ts` to restore the defect.
 
-### Dispatch prompt (send verbatim — do not add framing or meta-commentary)
+### Dispatch
+
+Complete the standard pre-dispatch setup above (session_list main → TaskCreate → initialize maps), then dispatch with `run_in_background: true`. Prepend `ccSessionId` and `parentTaskId` to the prompt, then append the verbatim block below without modification.
+
+### Verbatim prompt (append after ccSessionId/parentTaskId lines — do not add other framing)
 
 ````text
 Run a TDD lifecycle simulation to exercise the session machinery from start to finish. This is not a real coding task — use dummy goal and behavior labels throughout. You will write a temporary test file and fix a deliberately broken source file.
@@ -101,7 +105,7 @@ Report: for each phase-transition call (steps 6 and 11), state whether it was gr
 
 ### Lifecycle-specific verification (use instead of the standard seven-step audit)
 
-Run these five checks after the orchestrator returns.
+Run these five checks after the background completion notification arrives.
 
 1. **`tdd_session_get(<id>)`** — `ended` must be non-null (session closed). Phase ledger must have at least one entry. Goal and behavior must both show `completed`.
 2. **`acceptance_metrics({})`** — `phase_evidence_integrity` must be 100%. Any value below 100% means a phase transition was accepted without valid evidence binding.
@@ -127,13 +131,21 @@ If any check fails, append findings to `docs/superpowers/dogfood/lifecycle-check
 
 ## Dispatching
 
-Use the Task tool with `subagent_type: "plugin:vitest-agent:tdd-task"`. The dispatch prompt contains **only** the contents of the handoff's `# Task for the TDD orchestrator` section — never the frontmatter, never the `# What the orchestrator MUST NOT know` section, never the verification checklist, never the cheatsheet.
+Before spawning, complete the standard pre-dispatch setup (mirrors the `tdd` skill):
 
-Capture the dispatched session id immediately by querying for the most recently created subagent session:
+1. Call `session_list({ agentKind: "main", limit: 1 })` — capture the `cc_session_id` field from the first row as `ccSessionId`. Do **not** use `get_current_session_id()` — that in-memory ref can be stale after a prior subagent overwrote it.
+2. Call `TaskCreate({ subject: "TDD Session: <objective>", description: "Behavior tasks will appear as the orchestrator decomposes the goal." })` — capture the returned task ID as `parentTaskId`.
+3. Initialize: `goalById = new Map()`, `behaviorById = new Map()`.
+
+Dispatch with **`run_in_background: true`** and `subagent_type: "vitest-agent:tdd-task"`. Pass `ccSessionId` and `parentTaskId` in the launch prompt alongside the task. The dispatch prompt body contains **only** the contents of the handoff's `# Task for the TDD orchestrator` section — never the frontmatter, never the `# What the orchestrator MUST NOT know` section, never the verification checklist, never the cheatsheet.
+
+Immediately after dispatching (the background call returns before the agent completes), capture the session id:
 
 ```text
 mcp__plugin_vitest-agent_mcp__session_list({ agentKind: "subagent", limit: 1 })
 ```
+
+While the agent runs, channel events arrive as `<channel source="plugin:vitest-agent:mcp">` system reminders. Process each one immediately per the event-handler table in `plugin/skills/tdd/SKILL.md` — this produces live task-panel updates during the run, not a batch flush at the end.
 
 The returned `id` is the numeric DB id you pass to `tdd_session_get(<id>)` (or `tdd_session_resume(<id>)` for a status summary) below. The `cc_session_id` on the same row is what you pass to session-aware tools like `turn_search`.
 

--- a/plugin/CLAUDE.md
+++ b/plugin/CLAUDE.md
@@ -27,8 +27,9 @@ plugin/
 │   └── tdd.md           # /tdd slash command
 ├── hooks/
 │   ├── hooks.json       # Hook registrations (matchers, event bindings)
-│   ├── lib/             # Shared helpers: detect-pm.sh, hook-output.sh, match-tdd-agent.sh,
-│   │                    #   safe-mcp-vitest-agent-ops.txt (PreToolUse allowlist)
+│   ├── fixtures/        # Synthetic JSON payloads for manual hook invocation (README inside)
+│   ├── lib/             # Shared helpers: detect-pm.sh, hook-debug.sh, hook-output.sh,
+│   │                    #   match-tdd-agent.sh, safe-mcp-vitest-agent-ops.txt (PreToolUse allowlist)
 │   └── *.sh             # Hook scripts (see Hooks below)
 └── skills/              # Sub-skill primitives (one directory per skill, each with SKILL.md)
     ├── commit-cycle/
@@ -79,7 +80,9 @@ Hook scripts in `hooks/` are POSIX shell. All source shared helpers from `hooks/
 
 The allowlist for `pre-tool-use-mcp.sh` lives at `hooks/lib/safe-mcp-vitest-agent-ops.txt`. Add new non-destructive MCP tools here when they are deployed. Omit delete tools — those require explicit user confirmation from the main agent.
 
-`match-tdd-agent.sh` (`hooks/lib/`) provides `is_tdd_agent()` which matches `"vitest-agent:tdd-task"` (the form CC sends in hook payloads). The `plugin:vitest-agent:tdd-task` and `tdd-task` forms are retained defensively but have not been observed in practice.
+`match-tdd-agent.sh` (`hooks/lib/`) provides `is_tdd_agent()` which matches `"vitest-agent:tdd-task"` — the only form CC sends in hook payloads. The legacy `plugin:vitest-agent:tdd-task` and bare `tdd-task` forms were removed after being confirmed never observed in practice.
+
+`hook-debug.sh` (`hooks/lib/`) provides two logging functions sourced by every hook: `hook_error` always writes to `/tmp/vitest-agent-hook-errors.log` (overrideable via `VITEST_AGENT_HOOK_ERROR_LOG`); `hook_debug` writes to `/tmp/vitest-agent-hook-debug.log` only when `VITEST_AGENT_HOOK_DEBUG=1` is set. Recording and artifact hooks use a capture-and-log pattern for CLI failures — `|| true` is no longer used to suppress errors silently.
 
 ## Agents
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,9 +1,6 @@
-# vitest-agent Claude Code Plugin
+# vitest-agent Claude Code plugin
 
-A Claude Code plugin that integrates `vitest-agent` into your
-coding sessions. Provides MCP tools for test data queries, session
-context injection via hooks, and teaching skills for TDD, debugging,
-and configuration.
+A Claude Code plugin that integrates `vitest-agent` into your coding sessions. Provides MCP tools for test data queries, session context injection via hooks, a TDD orchestrator subagent, and sub-skill primitives for every step of the red-green-refactor cycle.
 
 ## Installation
 
@@ -14,7 +11,7 @@ and configuration.
 /plugin marketplace add spencerbeggs/bot
 
 # Install the plugin for this project
-/plugin install vitest-agent@spencerbeggs-bot --scope project
+/plugin install vitest-agent@spencerbeggs --scope project
 ```
 
 This adds the plugin to your `.claude/settings.json`:
@@ -22,7 +19,7 @@ This adds the plugin to your `.claude/settings.json`:
 ```json
 {
   "enabledPlugins": {
-    "vitest-agent@spencerbeggs-bot": true
+    "vitest-agent@spencerbeggs": true
   }
 }
 ```
@@ -41,27 +38,15 @@ Or configure permanently in your Claude Code settings:
 }
 ```
 
-## What the Plugin Provides
+## What the plugin provides
 
-### MCP Server (auto-registered)
+### MCP server (auto-registered)
 
-The plugin registers the `vitest-reporter` MCP server automatically
-via the `mcpServers` field in `.claude-plugin/plugin.json`. A small
-zero-dependency loader (`bin/mcp-server.mjs`) shipped with the plugin
-detects your package manager (npm, pnpm, yarn, or bun) from
-`packageManager` in `package.json` or your lockfile, then spawns the
-`vitest-agent-mcp` bin through that package manager so it
-resolves from your project's `node_modules`.
+The plugin registers the `vitest-agent` MCP server automatically via the `mcpServers` field in `.claude-plugin/plugin.json`. A zero-dependency POSIX shell loader (`bin/start-mcp.sh`) shipped with the plugin detects your package manager (npm, pnpm, yarn or bun) from `packageManager` in `package.json` or your lockfile, then `exec`-replaces itself with the `vitest-agent-mcp` bin so it resolves from your project's `node_modules` with no wrapper process left behind.
 
-This means `vitest-agent-reporter` must be installed as a dependency
-of your project for the plugin's MCP server to start. The package's
-required peer dependencies (`vitest-agent-mcp` and
-`vitest-agent-cli`) are auto-installed by modern pnpm and
-npm. If the MCP bin is missing, the loader prints PM-specific
-install instructions and exits non-zero. See
-[Prerequisites](#prerequisites) below.
+This means `vitest-agent-plugin` must be installed as a dependency of your project for the plugin's MCP server to start. The package's required peer dependencies (`vitest-agent-mcp` and `vitest-agent-cli`) are auto-installed by modern pnpm and npm. If the MCP bin is missing, the loader prints PM-specific install instructions and exits non-zero. See [Prerequisites](#prerequisites) below.
 
-The server exposes 52 tools, four resources (vendored Vitest docs at `vitest://docs/...` and curated testing patterns at `vitest-agent://patterns/...`) and six framing-only prompts for common workflows. Use the `help` tool for the full tool list with parameters, or see [docs/mcp.md](https://github.com/spencerbeggs/vitest-agent-reporter/blob/main/docs/mcp.md) for the complete reference.
+The server exposes 50+ tools, four resources (vendored Vitest docs at `vitest://docs/...` and curated testing patterns at `vitest-agent://patterns/...`) and six framing-only prompts for common workflows. Use the `help` tool for the full tool list with parameters.
 
 | Category | Tools |
 | --- | --- |
@@ -69,66 +54,84 @@ The server exposes 52 tools, four resources (vendored Vitest docs at `vitest://d
 | Discovery | `project_list`, `test_list`, `module_list`, `suite_list`, `settings_list` |
 | Execution | `run_tests` |
 | Notes | `note_create`, `note_list`, `note_get`, `note_update`, `note_delete`, `note_search` |
-| Sessions / Turns | `session_list`, `session_get`, `turn_search`, `failure_signature_get`, `acceptance_metrics` |
-| Triage / Wrap-up | `triage_brief`, `wrapup_prompt` |
+| Sessions / turns | `session_list`, `session_get`, `turn_search`, `failure_signature_get`, `acceptance_metrics` |
+| Triage / wrap-up | `triage_brief`, `wrapup_prompt` |
 | Hypotheses | `hypothesis_record`, `hypothesis_validate`, `hypothesis_list` |
-| TDD lifecycle | `tdd_session_start`, `tdd_session_end`, `tdd_session_resume`, `tdd_session_get`, `tdd_phase_transition_request` |
+| TDD lifecycle | `tdd_session_start`, `tdd_session_end`, `tdd_session_resume`, `tdd_session_get`, `tdd_phase_transition_request`, `tdd_progress_push` |
 | TDD goal CRUD | `tdd_goal_create`, `tdd_goal_get`, `tdd_goal_update`, `tdd_goal_delete`, `tdd_goal_list` |
 | TDD behavior CRUD | `tdd_behavior_create`, `tdd_behavior_get`, `tdd_behavior_update`, `tdd_behavior_delete`, `tdd_behavior_list` |
 | Workspace history | `commit_changes` |
-| Meta | `help` |
+| Session ID | `get_current_session_id`, `set_current_session_id` |
+| Meta | `help`, `ping` |
 
 ### Hooks
 
-| Hook | Trigger | Behavior |
-| --- | --- | --- |
-| `SessionStart` | Claude session begins | Injects project test status and MCP tool reference into context |
-| `PreToolUse` (`mcp__vitest-agent-reporter__*` / `mcp__plugin_vitest-agent-reporter_vitest-reporter__*`) | Before any vitest-agent-reporter MCP tool call | Auto-allows the call without a permission prompt when the tool is on the bundled allowlist (non-destructive tools; the two delete tools require explicit user confirmation) |
-| `PostToolUse` (Bash) | After any Bash tool call | Detects test runs; suggests MCP tools when tests fail |
+Hook scripts run at Claude Code lifecycle events to record session data, inject context and gate tool calls.
 
-The `PreToolUse` allowlist lives at
-`hooks/lib/safe-mcp-vitest-agent-reporter-ops.txt`. Every tool the MCP server exposes today is on the list. Future tools added to the server
-fall back to the standard permission prompt until they are added to the
-file.
+| Script | Trigger | Behavior |
+| --- | --- | --- |
+| `session-start.sh` | `SessionStart` | Writes the session row; injects project test status and MCP tool reference into context |
+| `pre-tool-use-mcp.sh` | `PreToolUse` (MCP tools) | Auto-allows non-destructive MCP tools without per-call prompts |
+| `pre-tool-use-tdd-restricted.sh` | `PreToolUse` (tdd-task subagent) | Blocks `tdd_goal_delete` and `tdd_behavior_delete` inside the orchestrator |
+| `pre-tool-use-bash-tdd.sh` | `PreToolUse` (Bash, tdd-task subagent) | Blocks `--update`, `--bail`, `--testNamePattern`; injects reminder to use `run_tests` MCP |
+| `post-tool-use-tdd-artifact.sh` | `PostToolUse` (Write/Edit/run_tests, tdd-task) | Records `test_written`, `test_failed_run`, `test_passed_run`, `code_written` artifacts |
+| `post-tool-use-test-quality.sh` | `PostToolUse` (Write/Edit, tdd-task) | Detects test-weakening edits; records `test_weakened` artifact |
+| `subagent-start-tdd.sh` | `SubagentStart` | Creates a subagent session row for the dispatched tdd-task |
+| `subagent-stop-tdd.sh` | `SubagentStop` | Runs `vitest-agent wrapup --kind tdd_handoff` and records the handoff note |
+| `post-tool-use-record.sh` | `PostToolUse` (all) | Records tool-call turns for session analytics |
+| `user-prompt-submit-record.sh` | `UserPromptSubmit` | Records user prompt turns |
+
+The auto-allow list for `pre-tool-use-mcp.sh` lives at `hooks/lib/safe-mcp-vitest-agent-ops.txt`. Destructive tools (`tdd_goal_delete`, `tdd_behavior_delete`) are intentionally absent and fall through to Claude Code's standard permission dialog.
+
+Structured error and debug logging for all hook scripts is provided by `hooks/lib/hook-debug.sh`: `hook_error` always appends to `/tmp/vitest-agent-hook-errors.log` (overrideable via `VITEST_AGENT_HOOK_ERROR_LOG`); `hook_debug` appends to `/tmp/vitest-agent-hook-debug.log` only when `VITEST_AGENT_HOOK_DEBUG=1` is set.
+
+### Agent
+
+| Agent | Invocation | Description |
+| --- | --- | --- |
+| `tdd-task` | `vitest-agent:tdd-task` | TDD orchestrator with `context:fork`. Drives red-green-refactor cycles with evidence-based phase transitions and mandatory MCP gates. Cannot write production code without a preceding failing test. |
 
 ### Skills
 
-Skills are invoked via `/skill <name>` in Claude Code.
-
 | Skill | Description |
 | --- | --- |
-| `tdd` | Red-green-refactor workflow using MCP tools |
+| `tdd` | Main TDD workflow: session lifecycle, phase transitions, goal/behavior hierarchy, channel events |
 | `debugging` | Systematic failure diagnosis using `test_history`, `test_errors`, `test_for_file` |
-| `coverage-improvement` | Systematic coverage improvement using `file_coverage`, `test_for_file`, `test_trends` |
-| `configuration` | Plugin setup and `AgentPlugin` option reference |
+| `coverage-improvement` | Systematic coverage improvement using `file_coverage`, `test_trends` |
+| `configuration` | `AgentPlugin` setup and option reference |
+| `interpret-test-failure` | Parse failure output, classify failure kind |
+| `derive-test-name-from-behavior` | Name a test from a behavior description |
+| `derive-test-shape-from-name` | Choose `it`, `describe/it`, parametric etc. from test name |
+| `verify-test-quality` | Check written test for escape hatches and weak assertions |
+| `run-and-classify` | Run tests via MCP, classify result, record artifact |
+| `record-hypothesis-before-fix` | Gate 2 — record hypothesis before any non-test file edit |
+| `commit-cycle` | Commit at green and refactor phase exit |
+| `revert-on-extended-red` | Revert if stuck in red for more than 5 turns or 3 failed runs |
+| `decompose-goal-into-behaviors` | Break a goal into atomic red-green-refactor behaviors |
+| `vitest-context` | Vitest-specific test context helpers |
 
 ### Commands
 
-Commands are invoked via `/<name>` in Claude Code.
-
 | Command | Description |
 | --- | --- |
-| `/setup` | Add `AgentPlugin` to the current project's vitest config |
+| `/setup` | Add `AgentPlugin` to the current project's `vitest.config.ts` |
 | `/configure [setting] [value]` | View or modify reporter settings |
+| `/tdd <goal>` | Launch a TDD session by dispatching the orchestrator with a goal |
 
 ## Prerequisites
 
-`vitest-agent-plugin` must be installed as a project dependency so
-the plugin's loader can spawn the MCP server through your package
-manager:
+`vitest-agent-plugin` must be installed as a project dependency so the plugin's loader can spawn the MCP server through your package manager:
 
 ```bash
 npm install --save-dev vitest-agent-plugin
+# or
+pnpm add -D vitest-agent-plugin
 ```
 
-The required peer dependencies (`vitest-agent-mcp` for the
-MCP bin and `vitest-agent-cli` for the CLI) are
-auto-installed by modern pnpm and npm. If your package manager is
-configured to skip peer deps (e.g. pnpm with `auto-install-peers: false`),
-install them explicitly:
+The required peer dependencies (`vitest-agent-mcp` for the MCP bin and `vitest-agent-cli` for the CLI) are auto-installed by modern pnpm and npm. If your package manager is configured to skip peer deps (e.g. pnpm with `auto-install-peers: false`), install them explicitly:
 
 ```bash
-pnpm add -D vitest-agent-reporter vitest-agent-cli vitest-agent-mcp
+pnpm add -D vitest-agent-plugin vitest-agent-cli vitest-agent-mcp
 ```
 
 Additional setup:
@@ -136,41 +139,38 @@ Additional setup:
 - `AgentPlugin` added to `vitest.config.ts` (use `/setup` to automate this)
 - Tests run at least once to populate the database
 
-## How It Works
+## How it works
 
-After each `vitest` run, `AgentReporter` writes structured data to a
-SQLite database under your XDG data directory (default
-`$XDG_DATA_HOME/vitest-agent-reporter/<workspaceName>/data.db`,
-falling back to `~/.local/share/vitest-agent-reporter/<workspaceName>/data.db`).
-The location is derived from your root `package.json` `name`, so two
-worktrees of the same repo share history; override it via
-`vitest-agent-reporter.config.toml` (`cacheDir` or `projectKey`) at
-the workspace root. The MCP server reads this database on demand --
-no background process required.
+After each `vitest` run, `AgentReporter` writes structured data to a SQLite database under your XDG data directory (default `$XDG_DATA_HOME/vitest-agent/<workspaceName>/data.db`, falling back to `~/.local/share/vitest-agent/<workspaceName>/data.db`). The location is derived from your root `package.json` `name`, so two worktrees of the same repo share history; override it via `vitest-agent.config.toml` (`cacheDir` or `projectKey`) at the workspace root. The MCP server reads this database on demand — no background process required.
 
-The `SessionStart` hook queries the CLI (`vitest-agent-reporter status`)
-at session start and injects a markdown summary with available tools and
-last-run status. The `PostToolUse` hook watches for failed test runs and
-suggests relevant MCP tools for analysis.
+The `SessionStart` hook queries the CLI at session start and injects a markdown summary with available tools, test status and an imperative preamble that directs the agent to use MCP tools and the TDD orchestrator.
 
 ## Development
 
-To dogfood this plugin while developing `vitest-agent-reporter`:
+To dogfood this plugin while developing `vitest-agent`:
 
 ```bash
 # Run Claude Code with this plugin loaded from the local directory
 claude --plugin-dir ./plugin
 
-# Or test hooks manually
-echo '{"session_id":"test","cwd":"'"$(pwd)"'","hook_event_name":"SessionStart"}' \
-  | bash plugin/hooks/session-start.sh
+# Test hooks manually using the bundled fixtures
+cat plugin/hooks/fixtures/post-tool-use-write-test.json \
+  | bash plugin/hooks/post-tool-use-tdd-artifact.sh
 
-echo '{"tool_input":{"command":"pnpm test"},"tool_result":{"exit_code":"1"}}' \
-  | bash plugin/hooks/post-test-run.sh
+# Enable debug logging for a manual run
+VITEST_AGENT_HOOK_DEBUG=1 \
+  cat plugin/hooks/fixtures/user-prompt-submit.json \
+  | bash plugin/hooks/user-prompt-submit-record.sh
+
+# Then inspect logs
+cat /tmp/vitest-agent-hook-debug.log
+cat /tmp/vitest-agent-hook-errors.log
 ```
+
+See `hooks/fixtures/README.md` for the full fixture inventory and substitution instructions.
 
 ## Repository
 
-- GitHub: <https://github.com/spencerbeggs/vitest-agent-reporter>
-- Issues: <https://github.com/spencerbeggs/vitest-agent-reporter/issues>
+- GitHub: <https://github.com/spencerbeggs/vitest-agent>
+- Issues: <https://github.com/spencerbeggs/vitest-agent/issues>
 - License: MIT

--- a/plugin/commands/configure.md
+++ b/plugin/commands/configure.md
@@ -1,10 +1,10 @@
 ---
-description: View or modify vitest-agent-reporter settings
+description: View or modify vitest-agent-plugin settings
 disable-model-invocation: true
 argument-hint: "[setting] [value]"
 ---
 
-# Configure vitest-agent-reporter
+# Configure vitest-agent-plugin
 
 View or modify the reporter configuration.
 

--- a/plugin/commands/setup.md
+++ b/plugin/commands/setup.md
@@ -1,33 +1,22 @@
 ---
-description: Set up vitest-agent-reporter in the current project
+description: Set up vitest-agent-plugin in the current project
 disable-model-invocation: true
 ---
 
-# Setup vitest-agent-reporter
+# Setup vitest-agent-plugin
 
-Set up the vitest-agent-reporter in this project. Follow these
-steps:
+Set up `vitest-agent-plugin` in this project. Follow these steps:
 
-1. **Check if vitest.config.ts exists.** If not, inform the user
-   they need a Vitest configuration first.
+1. **Check if vitest.config.ts exists.** If not, inform the user they need a Vitest configuration first.
 
-2. **Check if `vitest-agent-reporter` is installed.** Read the
-   project's `package.json`. If `vitest-agent-reporter` is not in
-   `dependencies` or `devDependencies`, install it as a dev
-   dependency using the project's package manager. The plugin's
-   MCP server loader requires the package to be present in the
-   project's `node_modules`.
+2. **Check if `vitest-agent-plugin` is installed.** Read the project's `package.json`. If `vitest-agent-plugin` is not in `dependencies` or `devDependencies`, install it as a dev dependency using the project's package manager. The plugin's MCP server loader requires the package to be present in the project's `node_modules`.
 
-3. **Check if AgentPlugin is already imported.** Read the vitest
-   config file and look for `AgentPlugin` or
-   `vitest-agent-reporter` imports. If already present, inform
-   the user it's already set up.
+3. **Check if AgentPlugin is already imported.** Read the vitest config file and look for `AgentPlugin` or `vitest-agent-plugin` imports. If already present, inform the user it's already set up.
 
-4. **Add the AgentPlugin import and configuration.** Edit the
-   vitest config to add:
+4. **Add the AgentPlugin import and configuration.** Edit the vitest config to add:
 
    ```typescript
-   import { AgentPlugin } from "vitest-agent-reporter";
+   import { AgentPlugin } from "vitest-agent-plugin";
    ```
 
    And add `AgentPlugin()` to the `plugins` array.

--- a/plugin/commands/tdd.md
+++ b/plugin/commands/tdd.md
@@ -12,20 +12,18 @@ arguments:
 
 I'll help you implement {{ goal }} using test-driven development.
 
-Before spawning the orchestrator, look up the current session id:
+Before spawning, complete two setup steps:
 
-1. Call `get_current_session_id({})` to retrieve the current Claude Code session ID.
-2. Note the returned `currentSessionId`.
+1. Call `session_list({ agentKind: "main", limit: 1 })` — capture the `cc_session_id` field from the first row as `ccSessionId`. Do **not** use `get_current_session_id()` — that in-memory ref can be stale if a prior subagent overwrote it.
+2. Call `TaskCreate({ subject: "TDD Session: {{ goal }}", description: "Behavior tasks will appear as the orchestrator decomposes the goal." })` — capture the returned task ID as `parentTaskId`.
 
-Then spawn the `plugin:vitest-agent:tdd-task` subagent **in the background** (`run_in_background: true`) with a prompt that includes:
+Then spawn `vitest-agent:tdd-task` **in the background** (`run_in_background: true`) with a prompt that includes:
 
 - The goal: `{{ goal }}`
-- The resolved `ccSessionId` from step 2
+- The `ccSessionId` from step 1
+- The `parentTaskId` from step 2
 
-After spawning:
-
-1. Create a parent task `TDD Session: {{ goal }}` with status `in_progress`.
-2. Tell the user behavior tasks will appear as the orchestrator decomposes the goal, then return control so they can continue working.
+Tell the user that behavior tasks will appear in the task panel as the orchestrator decomposes the goal, then return control.
 
 The subagent will:
 

--- a/plugin/hooks/elicitation-session-id.sh
+++ b/plugin/hooks/elicitation-session-id.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 INPUT=$(cat)
 SERVER=$(echo "$INPUT" | jq -r '.mcp_server_name // empty')
 # Accept "plugin:vitest-agent:mcp" (fully-qualified by CC) or the bare
-# "mcp" key for resilience. Also accept the legacy "vitest-reporter"
+# "mcp" key for resilience. Also accept the legacy "vitest-agent"
 # name in case an older plugin version is loaded.
 case "$SERVER" in
-  *":mcp" | "mcp" | *":vitest-reporter" | "vitest-reporter") ;;
+  *":mcp" | "mcp" | *":vitest-agent" | "vitest-agent") ;;
   *) echo '{}'; exit 0 ;;
 esac
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')

--- a/plugin/hooks/fixtures/README.md
+++ b/plugin/hooks/fixtures/README.md
@@ -1,0 +1,78 @@
+# Hook fixtures
+
+Synthetic payloads for manual hook invocation and debugging.
+
+## Usage
+
+Pipe a fixture directly to a hook script:
+
+```bash
+# From the repo root:
+cat plugin/hooks/fixtures/post-tool-use-write-test.json \
+  | bash plugin/hooks/post-tool-use-tdd-artifact.sh
+
+cat plugin/hooks/fixtures/post-tool-use-record-write.json \
+  | bash plugin/hooks/post-tool-use-record.sh
+
+cat plugin/hooks/fixtures/user-prompt-submit.json \
+  | bash plugin/hooks/user-prompt-submit-record.sh
+```
+
+To see errors and CLI output:
+
+```bash
+VITEST_AGENT_HOOK_DEBUG=1 \
+  cat plugin/hooks/fixtures/post-tool-use-write-test.json \
+  | bash plugin/hooks/post-tool-use-tdd-artifact.sh
+
+# Then inspect:
+cat /tmp/vitest-agent-hook-debug.log
+cat /tmp/vitest-agent-hook-errors.log
+```
+
+## Substitutions required
+
+The fixtures use a placeholder `SESSION_ID` for `session_id`. Before running,
+substitute a real open CC session ID from the database:
+
+```bash
+SESSION_ID=$(sqlite3 ~/.local/share/vitest-agent/vitest-agent/data.db \
+  "SELECT cc_session_id FROM sessions ORDER BY id DESC LIMIT 1;")
+
+sed "s/SESSION_ID/$SESSION_ID/g" plugin/hooks/fixtures/post-tool-use-write-test.json \
+  | bash plugin/hooks/post-tool-use-tdd-artifact.sh
+```
+
+Or set it inline:
+
+```bash
+cat plugin/hooks/fixtures/post-tool-use-write-test.json \
+  | jq --arg sid "YOUR_CC_SESSION_ID" '.session_id = $sid' \
+  | bash plugin/hooks/post-tool-use-tdd-artifact.sh
+```
+
+## Debug lifecycle capture
+
+To capture real payloads during a lifecycle run, set `VITEST_AGENT_HOOK_DEBUG=1`
+before reloading plugins. The log files are:
+
+- `/tmp/vitest-agent-hook-errors.log` — CLI failures (always written)
+- `/tmp/vitest-agent-hook-debug.log` — full input payloads + all CLI calls (debug mode)
+
+The error log persists across sessions; truncate before a fresh capture:
+
+```bash
+> /tmp/vitest-agent-hook-errors.log
+> /tmp/vitest-agent-hook-debug.log
+```
+
+## Files
+
+| File | Hook | Scenario |
+| --- | --- | --- |
+| `post-tool-use-write-test.json` | `post-tool-use-tdd-artifact.sh` | Write tool on a test file |
+| `post-tool-use-run-tests-pass.json` | `post-tool-use-tdd-artifact.sh` | `run_tests` MCP — passing run |
+| `post-tool-use-run-tests-fail.json` | `post-tool-use-tdd-artifact.sh` | `run_tests` MCP — failing run |
+| `post-tool-use-edit-prod.json` | `post-tool-use-tdd-artifact.sh` | Edit tool on a production file |
+| `post-tool-use-record-write.json` | `post-tool-use-record.sh` | Write tool turn recording |
+| `user-prompt-submit.json` | `user-prompt-submit-record.sh` | User prompt recording |

--- a/plugin/hooks/fixtures/post-tool-use-edit-prod.json
+++ b/plugin/hooks/fixtures/post-tool-use-edit-prod.json
@@ -1,0 +1,15 @@
+{
+	"session_id": "SESSION_ID",
+	"agent_type": "vitest-agent:tdd-task",
+	"cwd": "/Users/spencer/workspaces/spencerbeggs/vitest-agent",
+	"tool_name": "Edit",
+	"tool_use_id": "toolu_fixture_edit_prod_001",
+	"tool_input": {
+		"file_path": "/Users/spencer/workspaces/spencerbeggs/vitest-agent/playground/src/lifecycle.ts",
+		"old_string": "return a + b + 1;",
+		"new_string": "return a + b;"
+	},
+	"tool_response": {
+		"success": true
+	}
+}

--- a/plugin/hooks/fixtures/post-tool-use-record-write.json
+++ b/plugin/hooks/fixtures/post-tool-use-record-write.json
@@ -1,0 +1,13 @@
+{
+	"session_id": "SESSION_ID",
+	"cwd": "/Users/spencer/workspaces/spencerbeggs/vitest-agent",
+	"tool_name": "Write",
+	"tool_use_id": "toolu_fixture_record_write_001",
+	"tool_input": {
+		"file_path": "/Users/spencer/workspaces/spencerbeggs/vitest-agent/playground/src/lifecycle.test.ts",
+		"content": "import { describe, expect, it } from \"vitest\";\n"
+	},
+	"tool_response": {
+		"success": true
+	}
+}

--- a/plugin/hooks/fixtures/post-tool-use-run-tests-fail.json
+++ b/plugin/hooks/fixtures/post-tool-use-run-tests-fail.json
@@ -1,0 +1,17 @@
+{
+	"session_id": "SESSION_ID",
+	"agent_type": "vitest-agent:tdd-task",
+	"cwd": "/Users/spencer/workspaces/spencerbeggs/vitest-agent",
+	"tool_name": "mcp__plugin_vitest-agent_mcp__run_tests",
+	"tool_use_id": "toolu_fixture_run_tests_fail_001",
+	"tool_input": {
+		"project": "playground",
+		"files": ["playground/src/lifecycle.test.ts"]
+	},
+	"tool_response": [
+		{
+			"type": "text",
+			"text": "## ❌ Vitest -- 1 failed, 0 passed (1 total)\n\n```\nFAIL playground/src/lifecycle.test.ts > lifecycle > sum(1, 1) returns 2\nAssertionError: expected 3 to be 2\n```"
+		}
+	]
+}

--- a/plugin/hooks/fixtures/post-tool-use-run-tests-pass.json
+++ b/plugin/hooks/fixtures/post-tool-use-run-tests-pass.json
@@ -1,0 +1,17 @@
+{
+	"session_id": "SESSION_ID",
+	"agent_type": "vitest-agent:tdd-task",
+	"cwd": "/Users/spencer/workspaces/spencerbeggs/vitest-agent",
+	"tool_name": "mcp__plugin_vitest-agent_mcp__run_tests",
+	"tool_use_id": "toolu_fixture_run_tests_pass_001",
+	"tool_input": {
+		"project": "playground",
+		"files": ["playground/src/lifecycle.test.ts"]
+	},
+	"tool_response": [
+		{
+			"type": "text",
+			"text": "## ✅ Vitest -- 1 passed (1 total)\n\n```\n✓ playground/src/lifecycle.test.ts > lifecycle > sum(1, 1) returns 2\n```"
+		}
+	]
+}

--- a/plugin/hooks/fixtures/post-tool-use-write-test.json
+++ b/plugin/hooks/fixtures/post-tool-use-write-test.json
@@ -1,0 +1,14 @@
+{
+	"session_id": "SESSION_ID",
+	"agent_type": "vitest-agent:tdd-task",
+	"cwd": "/Users/spencer/workspaces/spencerbeggs/vitest-agent",
+	"tool_name": "Write",
+	"tool_use_id": "toolu_fixture_write_test_001",
+	"tool_input": {
+		"file_path": "/Users/spencer/workspaces/spencerbeggs/vitest-agent/playground/src/lifecycle.test.ts",
+		"content": "import { describe, expect, it } from \"vitest\";\nimport { sum } from \"./lifecycle.js\";\ndescribe(\"lifecycle\", () => {\n  it(\"sum(1, 1) returns 2\", () => {\n    expect(sum(1, 1)).toBe(2);\n  });\n});\n"
+	},
+	"tool_response": {
+		"success": true
+	}
+}

--- a/plugin/hooks/fixtures/user-prompt-submit.json
+++ b/plugin/hooks/fixtures/user-prompt-submit.json
@@ -1,0 +1,5 @@
+{
+	"session_id": "SESSION_ID",
+	"cwd": "/Users/spencer/workspaces/spencerbeggs/vitest-agent",
+	"prompt": "The test for sum is failing, can you fix it?"
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -168,9 +168,9 @@
 		],
 		"Elicitation": [
 			{
+				"matcher": "*",
 				"hooks": [
 					{
-						"matcher": "*",
 						"type": "command",
 						"command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/elicitation-session-id.sh\"",
 						"timeout": 5
@@ -180,9 +180,9 @@
 		],
 		"ElicitationResult": [
 			{
+				"matcher": "*",
 				"hooks": [
 					{
-						"matcher": "*",
 						"type": "command",
 						"command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/elicitation-result-record.sh\"",
 						"timeout": 5

--- a/plugin/hooks/lib/detect-pm.sh
+++ b/plugin/hooks/lib/detect-pm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # detect-pm.sh — shared package-manager detection for record-* hooks.
 #
-# Mirrors the JS detector in plugin/bin/mcp-server.mjs so the hook surface
+# Mirrors the PM detection in plugin/bin/start-mcp.sh so the hook surface
 # stays consistent for npm/pnpm/yarn/bun users (Decision 30).
 #
 # Usage:

--- a/plugin/hooks/lib/hook-debug.sh
+++ b/plugin/hooks/lib/hook-debug.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Shared error/debug logging for hooks.
+#
+# Error log (CLI failures, always-on): $VITEST_AGENT_HOOK_ERROR_LOG
+#   Default: /tmp/vitest-agent-hook-errors.log
+#
+# Debug log (full input + all CLI calls): $VITEST_AGENT_HOOK_DEBUG_LOG
+#   Set VITEST_AGENT_HOOK_DEBUG=1 to activate.
+#   Default: /tmp/vitest-agent-hook-debug.log
+#
+# Usage:
+#   . "$(dirname "$0")/lib/hook-debug.sh"
+#   hook_debug "HOOK" "message"    # debug mode only
+#   hook_error "HOOK" "message"    # always writes to error log
+
+_HOOK_ERR_LOG="${VITEST_AGENT_HOOK_ERROR_LOG:-/tmp/vitest-agent-hook-errors.log}"
+_HOOK_DBG_LOG="${VITEST_AGENT_HOOK_DEBUG_LOG:-/tmp/vitest-agent-hook-debug.log}"
+_HOOK_DEBUG="${VITEST_AGENT_HOOK_DEBUG:-0}"
+
+hook_debug() {
+	[ "$_HOOK_DEBUG" = "1" ] || return 0
+	printf '[%s] %s: %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$1" "$2" >> "$_HOOK_DBG_LOG"
+}
+
+hook_error() {
+	printf '[%s] %s: %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$1" "$2" >> "$_HOOK_ERR_LOG"
+}

--- a/plugin/hooks/lib/match-tdd-agent.sh
+++ b/plugin/hooks/lib/match-tdd-agent.sh
@@ -2,18 +2,14 @@
 # Shared helper for TDD-scoped hooks. Returns 0 if the supplied
 # agent_type value identifies the tdd-task subagent, else 1.
 #
-# Claude Code emits `.agent_type` in plugin-prefixed form
-# `plugin:<plugin-name>:<agent-name>` for plugin-bundled subagents, so
-# our agent (declared as `name: tdd-task` in the vitest-agent plugin)
-# shows up as `"plugin:vitest-agent:tdd-task"`. We also accept the bare
-# `"tdd-task"` slug for resilience if the agent is invoked from a
-# non-plugin context.
+# Claude Code emits `.agent_type` as `"vitest-agent:tdd-task"` in both
+# SubagentStart hook payloads and PostToolUse/PreToolUse payloads inside
+# the subagent's execution. The `plugin:` prefix form and bare `tdd-task`
+# slug have never been observed in practice.
 
 is_tdd_agent() {
 	case "$1" in
-		"plugin:vitest-agent:tdd-task") return 0 ;;
 		"vitest-agent:tdd-task") return 0 ;;
-		"tdd-task") return 0 ;;
 		*) return 1 ;;
 	esac
 }

--- a/plugin/hooks/post-tool-use-record.sh
+++ b/plugin/hooks/post-tool-use-record.sh
@@ -5,6 +5,10 @@ set -e
 
 # shellcheck source=lib/hook-output.sh
 . "$(dirname "$0")/lib/hook-output.sh"
+# shellcheck source=lib/hook-debug.sh
+. "$(dirname "$0")/lib/hook-debug.sh"
+
+_HOOK="post-tool-use-record"
 
 hook_json=$(cat)
 
@@ -17,6 +21,8 @@ success=$(jq -r '
 	| if . == null then "true" elif . == true then "true" else "false" end
 ' <<< "$hook_json")
 
+hook_debug "$_HOOK" "INPUT session_id=$cc_session_id tool=$tool_name cwd=$cwd"
+
 if [ -z "$cc_session_id" ] || [ -z "$cwd" ] || [ -z "$tool_name" ]; then
 	emit_noop
 	exit 0
@@ -26,6 +32,8 @@ fi
 . "$(dirname "$0")/lib/detect-pm.sh"
 pm_exec=$(detect_pm_exec "$cwd")
 
+hook_debug "$_HOOK" "pm_exec=$pm_exec"
+
 # 1. Always emit a tool_result turn.
 result_payload=$(jq -nc \
 	--arg tn "$tool_name" \
@@ -33,11 +41,12 @@ result_payload=$(jq -nc \
 	--argjson ok "$success" \
 	'{type: "tool_result", tool_name: $tn, success: $ok} + (if $tuid != "" then {tool_use_id: $tuid} else {} end)')
 
-cd "$cwd" >/dev/null && $pm_exec vitest-agent record turn \
+_turn_out=$(cd "$cwd" && $pm_exec vitest-agent record turn \
 	--cc-session-id "$cc_session_id" \
-	"$result_payload" \
-	>/dev/null 2>&1 \
-	|| true
+	"$result_payload" 2>&1) || {
+	hook_error "$_HOOK" "record turn tool_result rc=$? cc=$cc_session_id tool=$tool_name: $_turn_out"
+}
+hook_debug "$_HOOK" "record turn tool_result: $_turn_out"
 
 # 2. For Edit/Write/MultiEdit, additionally emit a file_edit turn.
 case "$tool_name" in
@@ -56,11 +65,12 @@ case "$tool_name" in
 			--arg fp "$file_path" \
 			--arg ek "$edit_kind" \
 			'{type: "file_edit", file_path: $fp, edit_kind: $ek}')
-		cd "$cwd" >/dev/null && $pm_exec vitest-agent record turn \
+		_edit_out=$(cd "$cwd" && $pm_exec vitest-agent record turn \
 			--cc-session-id "$cc_session_id" \
-			"$edit_payload" \
-			>/dev/null 2>&1 \
-			|| true
+			"$edit_payload" 2>&1) || {
+			hook_error "$_HOOK" "record turn file_edit rc=$? cc=$cc_session_id file=$file_path: $_edit_out"
+		}
+		hook_debug "$_HOOK" "record turn file_edit file=$file_path: $_edit_out"
 		;;
 esac
 

--- a/plugin/hooks/post-tool-use-tdd-artifact.sh
+++ b/plugin/hooks/post-tool-use-tdd-artifact.sh
@@ -11,6 +11,10 @@ set -e
 
 # shellcheck source=lib/hook-output.sh
 . "$(dirname "$0")/lib/hook-output.sh"
+# shellcheck source=lib/hook-debug.sh
+. "$(dirname "$0")/lib/hook-debug.sh"
+
+_HOOK="post-tool-use-tdd-artifact"
 
 hook_json=$(cat)
 
@@ -26,6 +30,8 @@ cc_session_id=$(echo "$hook_json" | jq -r '.session_id // ""')
 cwd=$(echo "$hook_json" | jq -r '.cwd // ""')
 tool_name=$(echo "$hook_json" | jq -r '.tool_name // ""')
 
+hook_debug "$_HOOK" "INPUT session_id=$cc_session_id tool=$tool_name cwd=$cwd"
+
 if [ -z "$cc_session_id" ] || [ -z "$cwd" ]; then
 	emit_noop
 	exit 0
@@ -34,6 +40,8 @@ fi
 # shellcheck source=lib/detect-pm.sh
 . "$(dirname "$0")/lib/detect-pm.sh"
 pm_exec=$(detect_pm_exec "$cwd")
+
+hook_debug "$_HOOK" "pm_exec=$pm_exec"
 
 recorded_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -49,24 +57,28 @@ case "$tool_name" in
 				kind="test_failed_run"
 			fi
 			# Backfill test_cases.created_turn_id (BUG-2) and get latest test
-			# case id for this session (BUG-1) in one call. Ignore errors.
+			# case id for this session (BUG-1) in one call.
 			test_case_id_arg=""
-			turns_out=$(cd "$cwd" >/dev/null && $pm_exec vitest-agent record test-case-turns \
-				--cc-session-id "$cc_session_id" 2>/dev/null || echo "")
-			if [ -n "$turns_out" ]; then
-				latest_id=$(echo "$turns_out" | jq -r '.latestTestCaseId // empty' 2>/dev/null || echo "")
+			_turns_out=$(cd "$cwd" && $pm_exec vitest-agent record test-case-turns \
+				--cc-session-id "$cc_session_id" 2>&1) || {
+				hook_error "$_HOOK" "record test-case-turns rc=$? cc=$cc_session_id: $_turns_out"
+			}
+			hook_debug "$_HOOK" "record test-case-turns: $_turns_out"
+			if [ -n "$_turns_out" ]; then
+				latest_id=$(echo "$_turns_out" | jq -r '.latestTestCaseId // empty' 2>/dev/null || echo "")
 				if [ -n "$latest_id" ] && [ "$latest_id" != "null" ]; then
 					test_case_id_arg="--test-case-id $latest_id"
 				fi
 			fi
 			# shellcheck disable=SC2086
-			cd "$cwd" >/dev/null && $pm_exec vitest-agent record tdd-artifact \
+			_artifact_out=$(cd "$cwd" && $pm_exec vitest-agent record tdd-artifact \
 				--cc-session-id "$cc_session_id" \
 				--artifact-kind "$kind" \
 				--recorded-at "$recorded_at" \
-				$test_case_id_arg \
-				>/dev/null 2>&1 \
-				|| true
+				$test_case_id_arg 2>&1) || {
+				hook_error "$_HOOK" "record tdd-artifact kind=$kind rc=$? cc=$cc_session_id: $_artifact_out"
+			}
+			hook_debug "$_HOOK" "record tdd-artifact kind=$kind: $_artifact_out"
 		fi
 		;;
 	mcp__plugin_vitest-agent_mcp__run_tests | mcp__vitest-agent_mcp__run_tests)
@@ -117,22 +129,26 @@ case "$tool_name" in
 			# case id for this session (BUG-1). For MCP run_tests, post-test-run.sh
 			# does NOT fire, so this is the only opportunity to backfill.
 			test_case_id_arg=""
-			turns_out=$(cd "$cwd" >/dev/null && $pm_exec vitest-agent record test-case-turns \
-				--cc-session-id "$cc_session_id" 2>/dev/null || echo "")
-			if [ -n "$turns_out" ]; then
-				latest_id=$(echo "$turns_out" | jq -r '.latestTestCaseId // empty' 2>/dev/null || echo "")
+			_turns_out=$(cd "$cwd" && $pm_exec vitest-agent record test-case-turns \
+				--cc-session-id "$cc_session_id" 2>&1) || {
+				hook_error "$_HOOK" "record test-case-turns rc=$? cc=$cc_session_id: $_turns_out"
+			}
+			hook_debug "$_HOOK" "record test-case-turns: $_turns_out"
+			if [ -n "$_turns_out" ]; then
+				latest_id=$(echo "$_turns_out" | jq -r '.latestTestCaseId // empty' 2>/dev/null || echo "")
 				if [ -n "$latest_id" ] && [ "$latest_id" != "null" ]; then
 					test_case_id_arg="--test-case-id $latest_id"
 				fi
 			fi
 			# shellcheck disable=SC2086
-			cd "$cwd" >/dev/null && $pm_exec vitest-agent record tdd-artifact \
+			_artifact_out=$(cd "$cwd" && $pm_exec vitest-agent record tdd-artifact \
 				--cc-session-id "$cc_session_id" \
 				--artifact-kind "$kind" \
 				--recorded-at "$recorded_at" \
-				$test_case_id_arg \
-				>/dev/null 2>&1 \
-				|| true
+				$test_case_id_arg 2>&1) || {
+				hook_error "$_HOOK" "record tdd-artifact kind=$kind rc=$? cc=$cc_session_id: $_artifact_out"
+			}
+			hook_debug "$_HOOK" "record tdd-artifact kind=$kind: $_artifact_out"
 		fi
 		;;
 	Edit|Write|MultiEdit)
@@ -149,13 +165,14 @@ case "$tool_name" in
 				kind="code_written"
 				;;
 		esac
-		cd "$cwd" >/dev/null && $pm_exec vitest-agent record tdd-artifact \
+		_artifact_out=$(cd "$cwd" && $pm_exec vitest-agent record tdd-artifact \
 			--cc-session-id "$cc_session_id" \
 			--artifact-kind "$kind" \
 			--file-path "$file_path" \
-			--recorded-at "$recorded_at" \
-			>/dev/null 2>&1 \
-			|| true
+			--recorded-at "$recorded_at" 2>&1) || {
+			hook_error "$_HOOK" "record tdd-artifact kind=$kind rc=$? cc=$cc_session_id file=$file_path: $_artifact_out"
+		}
+		hook_debug "$_HOOK" "record tdd-artifact kind=$kind file=$file_path: $_artifact_out"
 		;;
 esac
 

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -9,6 +9,10 @@ set -euo pipefail
 
 # shellcheck source=lib/hook-output.sh
 . "$(dirname "$0")/lib/hook-output.sh"
+# shellcheck source=lib/hook-debug.sh
+. "$(dirname "$0")/lib/hook-debug.sh"
+
+_HOOK="session-start"
 
 # Read and discard the JSON envelope to avoid broken-pipe; we re-read
 # session_id and cwd below.
@@ -42,15 +46,19 @@ fi
 project=$(jq -r '.name // "unknown"' < "$PROJECT_DIR/package.json" 2>/dev/null || echo "unknown")
 started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-cd "$PROJECT_DIR" >/dev/null && $pm_exec vitest-agent record session-start \
+hook_debug "$_HOOK" "INPUT session_id=$cc_session_id PROJECT_DIR=$PROJECT_DIR pm_exec=$pm_exec"
+
+# shellcheck disable=SC2086
+_session_out=$(cd "$PROJECT_DIR" && $pm_exec vitest-agent record session-start \
 	--cc-session-id "$cc_session_id" \
 	--project "$project" \
 	--cwd "$PROJECT_DIR" \
 	--agent-kind main \
 	--started-at "$started_at" \
-	$triage_flag \
-	>/dev/null 2>&1 \
-	|| true
+	$triage_flag 2>&1) || {
+	hook_error "$_HOOK" "record session-start rc=$? cc=$cc_session_id PROJECT_DIR=$PROJECT_DIR: $_session_out"
+}
+hook_debug "$_HOOK" "record session-start: $_session_out"
 
 # 4. Build the additionalContext markdown.
 #

--- a/plugin/hooks/subagent-start-tdd.sh
+++ b/plugin/hooks/subagent-start-tdd.sh
@@ -11,6 +11,10 @@ set -e
 
 # shellcheck source=lib/hook-output.sh
 . "$(dirname "$0")/lib/hook-output.sh"
+# shellcheck source=lib/hook-debug.sh
+. "$(dirname "$0")/lib/hook-debug.sh"
+
+_HOOK="subagent-start-tdd"
 
 hook_json=$(cat)
 
@@ -46,16 +50,19 @@ pm_exec=$(detect_pm_exec "$cwd")
 project=$(jq -r '.name // "unknown"' < "$cwd/package.json" 2>/dev/null || echo "unknown")
 started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-cd "$cwd" >/dev/null && $pm_exec vitest-agent record session-start \
+hook_debug "$_HOOK" "INPUT session_id=$cc_session_id parent=$parent_cc_session_id synthetic_key=$subagent_session_key cwd=$cwd pm_exec=$pm_exec"
+
+_session_out=$(cd "$cwd" && $pm_exec vitest-agent record session-start \
 	--cc-session-id "$subagent_session_key" \
 	--project "$project" \
 	--cwd "$cwd" \
 	--agent-kind subagent \
 	--agent-type tdd-task \
 	${parent_cc_session_id:+--parent-cc-session-id "$cc_session_id"} \
-	--started-at "$started_at" \
-	>/dev/null 2>&1 \
-	|| true
+	--started-at "$started_at" 2>&1) || {
+	hook_error "$_HOOK" "record session-start rc=$? synthetic_key=$subagent_session_key: $_session_out"
+}
+hook_debug "$_HOOK" "record session-start: $_session_out"
 
 emit_noop
 exit 0

--- a/plugin/hooks/user-prompt-submit-record.sh
+++ b/plugin/hooks/user-prompt-submit-record.sh
@@ -11,12 +11,18 @@ set -e
 
 # shellcheck source=lib/hook-output.sh
 . "$(dirname "$0")/lib/hook-output.sh"
+# shellcheck source=lib/hook-debug.sh
+. "$(dirname "$0")/lib/hook-debug.sh"
+
+_HOOK="user-prompt-submit-record"
 
 hook_json=$(cat)
 
 cc_session_id=$(jq -r '.session_id // ""' <<< "$hook_json")
 cwd=$(jq -r '.cwd // ""' <<< "$hook_json")
 prompt=$(jq -r '.prompt // ""' <<< "$hook_json")
+
+hook_debug "$_HOOK" "INPUT session_id=$cc_session_id cwd=$cwd prompt_len=${#prompt}"
 
 if [ -z "$cc_session_id" ] || [ -z "$cwd" ] || [ -z "$prompt" ]; then
 	emit_noop
@@ -27,17 +33,21 @@ fi
 . "$(dirname "$0")/lib/detect-pm.sh"
 pm_exec=$(detect_pm_exec "$cwd")
 
+hook_debug "$_HOOK" "pm_exec=$pm_exec"
+
 # 1. Record the prompt as a user_prompt turn.
 # cc_message_id is intentionally omitted: the Claude Code envelope does not
 # expose a per-message id, and stuffing the session id there breaks downstream
 # "find the message that started this thread" queries against the
 # UserPromptPayload schema's contract.
 payload=$(jq -nc --arg p "$prompt" '{type: "user_prompt", prompt: $p}')
-cd "$cwd" >/dev/null && $pm_exec vitest-agent record turn \
+
+_turn_out=$(cd "$cwd" && $pm_exec vitest-agent record turn \
 	--cc-session-id "$cc_session_id" \
-	"$payload" \
-	>/dev/null 2>&1 \
-	|| true
+	"$payload" 2>&1) || {
+	hook_error "$_HOOK" "record turn user_prompt rc=$? cc=$cc_session_id: $_turn_out"
+}
+hook_debug "$_HOOK" "record turn user_prompt: $_turn_out"
 
 # 2. Compute the nudge (empty when the prompt isn't failure-related).
 nudge=$(cd "$cwd" && $pm_exec vitest-agent wrapup \

--- a/plugin/skills/configuration/SKILL.md
+++ b/plugin/skills/configuration/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: configuration
-description: Guide vitest-agent-reporter configuration including thresholds, targets, output format, and plugin options. Use when setting up or modifying the reporter configuration.
+description: Guide vitest-agent-plugin configuration including thresholds, targets, output format, and plugin options. Use when setting up or modifying the plugin configuration.
 disable-model-invocation: true
 ---
 
-# Vitest Agent Reporter Configuration
+# Vitest Agent Plugin Configuration
 
 ## Plugin Options (vitest.config.ts)
 
-The reporter is configured via the `AgentPlugin` in your Vitest
-config:
+The plugin is configured via `AgentPlugin` in your Vitest config:
 
 ```typescript
-import { AgentPlugin } from "vitest-agent-reporter";
+import { AgentPlugin } from "vitest-agent-plugin";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugin/skills/coverage-improvement/SKILL.md
+++ b/plugin/skills/coverage-improvement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coverage-improvement
-description: Guide systematic coverage improvement using vitest-agent-reporter MCP tools. Use when improving code coverage, targeting uncovered lines, or working toward coverage targets.
+description: Guide systematic coverage improvement using vitest-agent MCP tools. Use when improving code coverage, targeting uncovered lines, or working toward coverage targets.
 ---
 
 # Improving Code Coverage

--- a/plugin/skills/debugging/SKILL.md
+++ b/plugin/skills/debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging
-description: Guide debugging test failures using vitest-agent-reporter MCP tools. Use when tests are failing, investigating flaky tests, or diagnosing persistent failures.
+description: Guide debugging test failures using vitest-agent MCP tools. Use when tests are failing, investigating flaky tests, or diagnosing persistent failures.
 ---
 
 # Debugging Test Failures

--- a/plugin/skills/tdd/SKILL.md
+++ b/plugin/skills/tdd/SKILL.md
@@ -9,7 +9,14 @@ Three MCP calls are required protocol. Skipping any one of them is a named viola
 
 ## For the main agent: dispatch the tdd-task agent
 
-If you are the main agent: dispatch the `plugin:vitest-agent:tdd-task` subagent. Pass the `goal` and your current `ccSessionId` explicitly in the launch prompt. Do not attempt TDD yourself — the tdd-task agent carries the required MCP tools and skill context for evidence-based phase transitions.
+If you are the main agent, complete these steps before spawning:
+
+1. Call `session_list({ agentKind: "main", limit: 1 })` — capture the `cc_session_id` field from the first row as `ccSessionId`. (The DB value comes directly from the SessionStart hook payload and is immune to in-memory contamination from prior subagent runs. Do **not** use `get_current_session_id()` — that in-memory ref can be stale if a prior subagent called `set_current_session_id` with its own key.)
+2. Call `TaskCreate({ subject: "TDD Session: <objective>", description: "Behavior tasks will appear as the orchestrator decomposes the goal." })` — capture the returned task ID as `parentTaskId`.
+3. Initialize: `goalById = new Map()` (keyed by goal ID, each entry `{ ordinal, taskId? }`), `behaviorById = new Map()` (keyed by behavior ID, each entry `{ goalOrdinal, behaviorOrdinal, taskId }`).
+4. Spawn `vitest-agent:tdd-task` **in the background**, passing `goal`, `ccSessionId`, and `parentTaskId` in the launch prompt.
+
+Do not attempt TDD yourself — the tdd-task agent carries the required MCP tools and skill context for evidence-based phase transitions.
 
 ### Channel-event handling (main agent)
 
@@ -28,9 +35,9 @@ Event handlers:
 | `goals_ready` | Record each `{id, ordinal, goal}` in `goalById`. No tasks yet — wait for `behaviors_ready` so the rendered labels carry both goal and behavior ordinals. |
 | `goal_added` | Append the new goal to `goalById` (mid-session addition after the initial batch). |
 | `goal_started` | No-op (the goal's behaviors will start producing `behavior_started` events). |
-| `behaviors_ready` | For each behavior under the named `goalId`, `TaskCreate({ content: "[G<goalOrdinal+1>.B<behaviorOrdinal+1>] <behavior>", status: "pending", parentTaskId })`. Store the returned task id in `behaviorById`. |
-| `behavior_added` | `TaskCreate` a single sibling labeled `[G<n>.B<m>] <behavior>` and store its id. |
-| `behavior_started` | `TaskUpdate({ id: <behavior taskId>, status: "in_progress" })`. |
+| `behaviors_ready` | Record each behavior's ordinals in `behaviorById` (`{ goalOrdinal, behaviorOrdinal }`). **No tasks yet** — `TaskCreate` is deferred to `behavior_started` so that abandoned sessions (which fire `behaviors_ready` but never `behavior_started`) don't leave orphaned pending tasks in the panel. |
+| `behavior_added` | Append `{ goalOrdinal, behaviorOrdinal }` to `behaviorById`. No task yet. |
+| `behavior_started` | `TaskCreate({ subject: "[G<n>.B<m>] <behavior>", description: "...", activeForm: "Running behavior" })` — capture the returned task id and store it in `behaviorById`. Then immediately `TaskUpdate({ id: <taskId>, status: "in_progress" })`. |
 | `phase_transition` | `TaskUpdate({ id: <behavior taskId>, content: "[G<n>.B<m>] <behavior> · <toPhase>" })` so the user sees the current phase inline on the task label. |
 | `behavior_completed` | `TaskUpdate({ id: <behavior taskId>, status: "completed" })`. |
 | `behavior_abandoned` | `TaskUpdate({ id: <behavior taskId>, status: "cancelled" })`; surface the `reason` to the user as context. |

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"files": [],
-	"references": [{ "path": "./packages/reporter" }, { "path": "./playground" }]
+	"compilerOptions": {
+		"composite": true,
+		"declaration": true,
+		"module": "node20",
+		"outDir": "dist",
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"strictNullChecks": true,
+		"target": "es2023"
+	},
+	"exclude": ["node_modules", "dist"],
+	"include": ["lib/**/*.ts", "types/**/*.d.ts"]
 }


### PR DESCRIPTION
Replaces get_current_session_id() with session_list({ agentKind: "main", limit: 1 }) in the tdd skill, /tdd command and dogfood skill. The in-memory ref was being overwritten by context:fork subagents with their synthetic session key, causing all PostToolUse artifact writes to fail with "no open TDD session" errors.

Defers TaskCreate from behaviors_ready to behavior_started so abandoned sessions no longer leave orphaned pending tasks in the CC task panel.

Changes:

- hook-debug.sh added to hooks/lib/ with hook_error (always-on) and hook_debug (env-gated via VITEST_AGENT_HOOK_DEBUG=1), replacing || true error suppression in recording hooks
- hooks/fixtures/ added with six synthetic JSON payloads for manual hook invocation during development
- Dead agent_type forms removed from match-tdd-agent.sh (plugin:vitest-agent:tdd-task and bare tdd-task confirmed never observed in hook payloads)
- plugin/README.md rewritten with correct loader filename (start-mcp.sh), package name (vitest-agent-plugin), allowlist filename, XDG path prefix and complete hooks/agents/skills tables

Test plan:

- Run /dogfood --lifecycle and verify both phase transitions granted on first attempt (no evidence_not_in_phase_window denials)
- Confirm acceptance_metrics({}) returns phase_evidence_integrity: 100%
- Confirm no orphaned pending tasks appear in the CC task panel during the run
- Verify hook errors surface in /tmp/vitest-agent-hook-errors.log on failure

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>