### PR TITLE
fix: stop perf_hooks buffer leak and node_modules test discovery

### DIFF
--- a/.changeset/firm-module-exclude.md
+++ b/.changeset/firm-module-exclude.md
@@ -1,0 +1,7 @@
+---
+"@vitest-agent/plugin": patch
+---
+
+## Bug Fixes
+
+- `AgentPlugin.discover()` no longer picks up or runs test files inside `node_modules`. The custom `test.exclude` emitted for packages with a `__test__` directory now preserves Vitest's default `**/node_modules/**` exclusion.

--- a/.changeset/quiet-buffer-drain.md
+++ b/.changeset/quiet-buffer-drain.md
@@ -1,0 +1,7 @@
+---
+"@vitest-agent/reporter": patch
+---
+
+## Bug Fixes
+
+- Fixes `MaxPerformanceEntryBufferExceededWarning` on long test runs. React 19's development reconciler emits a `performance.measure()` per component render and nothing drained the global user-timing buffer; the live renderer now clears it after each render cycle.

--- a/.claude/design/refs.json
+++ b/.claude/design/refs.json
@@ -10,8 +10,8 @@
 		{
 			"source": "CLAUDE.md",
 			"target": ".claude/design/vitest-agent/components/discover.md",
-			"hash": "24eb6988c9b0144e5668172672ead607ad7cf09714da82a75bc57fef872db2ef",
-			"recordedAt": "2026-06-17"
+			"hash": "d68af2c74a4a1bb12083927da5f2d8fb239a07efe72331587765df4314398853",
+			"recordedAt": "2026-06-26"
 		},
 		{
 			"source": "CLAUDE.md",
@@ -100,8 +100,8 @@
 		{
 			"source": "packages/plugin/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/components/discover.md",
-			"hash": "24eb6988c9b0144e5668172672ead607ad7cf09714da82a75bc57fef872db2ef",
-			"recordedAt": "2026-06-17"
+			"hash": "d68af2c74a4a1bb12083927da5f2d8fb239a07efe72331587765df4314398853",
+			"recordedAt": "2026-06-26"
 		},
 		{
 			"source": "packages/plugin/CLAUDE.md",
@@ -154,8 +154,8 @@
 		{
 			"source": "packages/sdk/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/components/discover.md",
-			"hash": "24eb6988c9b0144e5668172672ead607ad7cf09714da82a75bc57fef872db2ef",
-			"recordedAt": "2026-06-17"
+			"hash": "d68af2c74a4a1bb12083927da5f2d8fb239a07efe72331587765df4314398853",
+			"recordedAt": "2026-06-26"
 		},
 		{
 			"source": "packages/sdk/CLAUDE.md",

--- a/.claude/design/vitest-agent/components/discover.md
+++ b/.claude/design/vitest-agent/components/discover.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-05-07
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-26
+last-synced: 2026-06-26
 completeness: 95
 related:
   - ../components.md
@@ -155,15 +155,7 @@ passed.
   (ts|tsx|js|jsx) get ["e2e"], files ending in .int.(test|spec).
   (ts|tsx|js|jsx) get ["int"], everything else falls through to
   ["unit"].
-- **buildProject.** Scans the package's `src/` and `__test__/`
-  directories for test files via `findTestFiles`. Returns null if
-  neither directory contains a match. Otherwise emits a
-  `TestProjectInlineConfiguration` with `extends: true`, the test name
-  set from the package name, `environment: "node"`, absolute include
-  globs covering whichever of `src/` and `__test__/` produced matches,
-  an exclude list for the helper subdirectories `utils`, `fixtures`,
-  and `snapshots` inside `__test__/`, and a `setupFiles` entry for
-  `vitest.setup.(ts|tsx|js|jsx)` at the package root when present.
+- **buildProject.** Scans the package's `src/` and `__test__/` directories for test files via `findTestFiles`. Returns null if neither directory contains a match. Otherwise emits a `TestProjectInlineConfiguration` with `extends: true`, the test name set from the package name, `environment: "node"`, absolute include globs covering whichever of `src/` and `__test__/` produced matches, an exclude list, and a `setupFiles` entry for `vitest.setup.(ts|tsx|js|jsx)` at the package root when present. The exclude list prepends Vitest's `configDefaults.exclude` (`**/node_modules/**`, `**/.git/**`) ahead of the helper-subdirectory globs (`utils`, `fixtures` and `snapshots` inside `__test__/`). The prepend is load-bearing: a custom `test.exclude` replaces Vitest's defaults rather than merging, so without it the broad `__test__/**` include re-walks into nested `__test__/.../node_modules/**` and Vitest runs dependencies' own test files (e.g. zod's tests under fixture `node_modules`).
 
 The include globs use absolute paths so the same configs work whether
 the consuming vitest.config.ts lives at the monorepo root or inside a

--- a/packages/plugin/__test__/discover-strategy.test.ts
+++ b/packages/plugin/__test__/discover-strategy.test.ts
@@ -246,6 +246,12 @@ describe("DefaultDiscoverStrategy.buildProject()", () => {
 		expect(exclude?.some((p) => p.includes("__test__/utils"))).toBe(true);
 		expect(exclude?.some((p) => p.includes("__test__/fixtures"))).toBe(true);
 		expect(exclude?.some((p) => p.includes("__test__/snapshots"))).toBe(true);
+		// A custom `test.exclude` REPLACES Vitest's defaults rather than merging,
+		// so it must re-state `**/node_modules/**` and `**/.git/**` — otherwise
+		// the broad `__test__/**` include glob re-walks into nested
+		// `__test__/.../node_modules/**` and runs dependencies' own test files.
+		expect(exclude?.some((p) => p.includes("node_modules"))).toBe(true);
+		expect(exclude?.some((p) => p.includes(".git"))).toBe(true);
 	});
 
 	it("should return config covering both src and __test__ globs for hybrid package", async () => {

--- a/packages/plugin/src/utils/discover-strategy.ts
+++ b/packages/plugin/src/utils/discover-strategy.ts
@@ -2,6 +2,7 @@ import { stat } from "node:fs/promises";
 import { join, sep } from "node:path";
 import type { TestTagDefinition } from "@vitest/runner";
 import type { TestProjectInlineConfiguration } from "vitest/config";
+import { configDefaults } from "vitest/config";
 import { findTestFiles } from "./find-test-files.js";
 import { Tag } from "./tag.js";
 
@@ -279,9 +280,14 @@ export class DefaultDiscoverStrategy extends DiscoverStrategy {
 			include.push(join(input.path, "__test__/**/*.{test,spec}.{ts,tsx,js,jsx}"));
 		}
 
-		// Exclude helper subdirs inside __test__/ when __test__ is present (absolute paths)
+		// Exclude helper subdirs inside __test__/ when __test__ is present (absolute paths).
+		// A custom `test.exclude` REPLACES Vitest's defaults rather than merging, so we
+		// must re-state `configDefaults.exclude` (`**/node_modules/**`, `**/.git/**`)
+		// alongside the helper dirs. Without it, the broad `__test__/**` include glob
+		// re-walks into nested `__test__/.../node_modules/**` and Vitest runs
+		// dependencies' own test files (e.g. zod's tests under fixture node_modules).
 		const exclude: string[] | undefined = hasTestDir
-			? TEST_DIR_HELPER_DIRS.map((d) => join(input.path, `__test__/${d}/**`))
+			? [...configDefaults.exclude, ...TEST_DIR_HELPER_DIRS.map((d) => join(input.path, `__test__/${d}/**`))]
 			: undefined;
 
 		// Detect setup file

--- a/packages/reporter/__test__/live-ink-renderer.test.ts
+++ b/packages/reporter/__test__/live-ink-renderer.test.ts
@@ -472,6 +472,42 @@ describe("createLiveInk — terminal-event commit via unmount", () => {
 });
 
 // ---------------------------------------------------------------------------
+// perf_hooks buffer hygiene (issue #97)
+// ---------------------------------------------------------------------------
+
+describe("createLiveInk — user-timing buffer hygiene", () => {
+	it("drains the global measure/mark buffer after each rendered event so React's dev-build measures don't leak", () => {
+		// React 19's *development* reconciler — the build Ink loads whenever
+		// NODE_ENV !== "production" (the norm under Vitest) — emits a
+		// `performance.measure()` per component render for its Component
+		// Performance Track. Nothing consumes the global user-timing buffer, so
+		// the live mount's per-event + per-spinner-tick rerenders accumulate
+		// until Node prints `MaxPerformanceEntryBufferExceededWarning` (#97).
+		// The renderer must drain the buffer after each event it renders.
+		performance.clearMeasures();
+		performance.clearMarks();
+		const { stream } = captureStream();
+		const live = createLiveInk({ stream });
+		muteStderr(() => {
+			live.event(runStarted);
+			// Simulate the dev reconciler flooding the global buffer between our
+			// render calls.
+			for (let i = 0; i < 1000; i++) {
+				performance.measure(`react-render-${i}`);
+				performance.mark(`react-mark-${i}`);
+			}
+			expect(performance.getEntriesByType("measure").length).toBeGreaterThan(0);
+			// Processing an event triggers a render; the renderer drains afterward.
+			live.event({ _tag: "ModuleStarted", modulePath: "a.test.ts", startedAt: "T0" });
+			expect(performance.getEntriesByType("measure").length).toBe(0);
+			expect(performance.getEntriesByType("mark").length).toBe(0);
+			live.event(runFinished);
+		});
+		live.unmount();
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Mount does not wipe the screen
 // ---------------------------------------------------------------------------
 

--- a/packages/reporter/src/LiveInkRenderer.tsx
+++ b/packages/reporter/src/LiveInkRenderer.tsx
@@ -98,6 +98,34 @@ export interface LiveInkRenderer {
 type InkInstance = ReturnType<typeof inkRender>;
 
 /**
+ * Drain the global user-timing buffer after a render.
+ *
+ * React 19's *development* reconciler — the build Ink loads whenever
+ * `NODE_ENV !== "production"`, which is the norm under Vitest — emits a
+ * `performance.measure()` into the global user-timing buffer on every
+ * component render for its "Component Performance Track" DevTools feature.
+ * Nothing in a Node process consumes that buffer, so across a long run the
+ * live mount's per-event and per-spinner-tick rerenders pile up millions of
+ * `measure` entries until Node prints `MaxPerformanceEntryBufferExceededWarning`
+ * (issue #97). The renderer owns every render call, so it drains the buffer
+ * right after each one, bounding it to a single render's worth of entries.
+ *
+ * Clearing the whole measure/mark buffer is safe here: this runs in the
+ * Vitest main process, where test code executes in forked workers (separate
+ * perf buffers) and nothing downstream reads these entries. Guarded against
+ * runtimes that lack the user-timing API and never allowed to throw — buffer
+ * hygiene must not derail a run.
+ */
+const drainRenderPerfEntries = (): void => {
+	try {
+		performance.clearMeasures?.();
+		performance.clearMarks?.();
+	} catch {
+		// best-effort
+	}
+};
+
+/**
  * Create a {@link LiveInkRenderer} that drives a live Ink mount for
  * `consoleMode: "stream"`. Call `event(e)` for each `RunEvent` published
  * by the plugin; the renderer mounts on `RunStarted`, rerenders on each
@@ -181,6 +209,7 @@ export const createLiveInk = (options: CreateLiveInkOptions = {}): LiveInkRender
 			if (instance === null) return;
 			try {
 				instance.rerender(frameElement());
+				drainRenderPerfEntries();
 			} catch {
 				instance = null;
 				stopClock();
@@ -290,6 +319,13 @@ export const createLiveInk = (options: CreateLiveInkOptions = {}): LiveInkRender
 				}
 				firstRunStarted = false;
 			}
+
+			// Drain the user-timing buffer once per event, after every render
+			// path above (mount, event-path rerender, the terminal unmount's
+			// final React commit, and the degraded `renderToString`). React's
+			// dev reconciler emits a `performance.measure()` per render; left
+			// alone the buffer grows unbounded across a run (issue #97).
+			drainRenderPerfEntries();
 		},
 		unmount(): void {
 			tearDown();


### PR DESCRIPTION
## Summary

Two bug fixes on this branch.

### perf_hooks measure-buffer leak (closes #97)

React 19.2's **development** reconciler — the build Ink loads whenever `NODE_ENV !== "production"`, which is the norm under Vitest — emits a `performance.measure()` into the global user-timing buffer on every component render (its "Component Performance Track" feature, gated only on `supportsUserTiming`, always true in Node). The live `stream` reporter re-renders once per `RunEvent` plus every 80ms spinner tick, and nothing drained the buffer — so a long run climbed past 1,000,000 entries and Node printed `MaxPerformanceEntryBufferExceededWarning`.

**Fix** (`packages/reporter/src/LiveInkRenderer.tsx`): a new `drainRenderPerfEntries()` clears the user-timing buffer after each render — in the spinner clock tick and once at the end of every `event()` (which also covers the mount, the terminal unmount's final React commit, and the degraded `renderToString` path). Bounds the buffer to one render's worth of entries. Safe because it runs in the Vitest main process, where test code executes in forked workers with separate buffers.

### node_modules test discovery

When a package has a `__test__/` directory, `DefaultDiscoverStrategy.buildProject` emits a custom `test.exclude`. In Vitest a custom `exclude` **replaces** the defaults (`**/node_modules/**`, `**/.git/**`) rather than merging — and the emitted list only had the helper-dir globs, so the broad `__test__/**/*.{test,spec}.*` include re-walked into nested `__test__/.../node_modules/**` and Vitest ran dependencies' own test files (e.g. zod's tests under fixture `node_modules`).

**Fix** (`packages/plugin/src/utils/discover-strategy.ts`): the emitted exclude now prepends `configDefaults.exclude` so `node_modules`/`.git` are always re-stated alongside the helper-dir ignores.

## Testing

- New failing-then-passing tests for both fixes (TDD).
- `@vitest-agent/reporter` + `@vitest-agent/plugin`: 311/311 pass, typecheck clean, Biome + markdownlint clean.

## Changesets

- `@vitest-agent/reporter`: patch
- `@vitest-agent/plugin`: patch

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>