### PR TITLE
docs: add agent-operability docs to the MCP corpus and guide site

### DIFF
--- a/.changeset/agent-operability-patterns.md
+++ b/.changeset/agent-operability-patterns.md
@@ -1,0 +1,7 @@
+---
+"@vitest-agent/mcp": patch
+---
+
+## Documentation
+
+Adds four agent-facing patterns to the `vitest-agent://patterns/` corpus: an operating-as-an-agent orientation index, a run_tests operability reference, a silencing-leaking-output cookbook, and a known-issues-and-caveats troubleshooting page. Closes the dogfooding documentation gaps reported in #101, #102, and #103.

--- a/.claude/design/refs.json
+++ b/.claude/design/refs.json
@@ -16,8 +16,8 @@
 		{
 			"source": "CLAUDE.md",
 			"target": ".claude/design/vitest-agent/components/docs-site.md",
-			"hash": "26cbcc47e61a1b9bcd4b766177ea92d432d4abd6beb3f2c2222a63a97ac4c96e",
-			"recordedAt": "2026-06-17"
+			"hash": "903361390bc3666fbf58d0f7829791053b7aac79d7308a4fe16cffecd47baffb",
+			"recordedAt": "2026-06-26"
 		},
 		{
 			"source": "CLAUDE.md",
@@ -76,7 +76,7 @@
 		{
 			"source": "packages/mcp/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/components/mcp.md",
-			"hash": "9abd94f363bc2d9038eb629a68518f251ec650852142f7349a55e1645f7e2158",
+			"hash": "7afcaf533bf8f0bb5145c3f5aa1ccec1ed887460d2a625bdbc171277972bc4f9",
 			"recordedAt": "2026-06-26"
 		},
 		{
@@ -244,8 +244,8 @@
 		{
 			"source": "website/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/components/docs-site.md",
-			"hash": "26cbcc47e61a1b9bcd4b766177ea92d432d4abd6beb3f2c2222a63a97ac4c96e",
-			"recordedAt": "2026-06-17"
+			"hash": "903361390bc3666fbf58d0f7829791053b7aac79d7308a4fe16cffecd47baffb",
+			"recordedAt": "2026-06-26"
 		}
 	]
 }

--- a/.claude/design/vitest-agent/components/docs-site.md
+++ b/.claude/design/vitest-agent/components/docs-site.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: documentation
 created: 2026-05-27
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-26
+last-synced: 2026-06-26
 completeness: 85
 related:
   - ../architecture.md
@@ -29,7 +29,7 @@ The site is not one of the seven publishable packages and does not version in lo
 
 Top nav is two entries, **Guide** and **Packages**, wired in `website/docs/en/_nav.json` with a per-package dropdown under Packages.
 
-- `/guide` (`website/docs/en/guide/`) is the learning spine: getting-started, concepts and how-to pages. This is the narrative path a new user follows.
+- `/guide` (`website/docs/en/guide/`) is the learning spine: getting-started, concepts, how-to and operating-as-an-agent pages. This is the narrative path a reader follows — the first three groups target a human user, the operating-as-an-agent group targets an agent driving the tool (mirroring the agent-operability patterns the MCP server serves under `vitest-agent://patterns/`).
 - Each of the seven packages owns a directory under `website/docs/en/<short>/` (`plugin`, `sdk`, `mcp`, `cli`, `reporter`, `ui`, `sidecar`) holding an Overview `index.mdx`, hand-written deep-dive pages and a generated `api/` subtree.
 - `/packages` (`website/docs/en/packages/`) is the ecosystem map that orients a reader across the package family.
 

--- a/.claude/design/vitest-agent/components/mcp.md
+++ b/.claude/design/vitest-agent/components/mcp.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-05-06
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-26
+last-synced: 2026-06-26
 completeness: 92
 related:
   - ../architecture.md
@@ -415,8 +415,7 @@ under two URI schemes:
 
 - `vitest://docs/` — the vendored upstream Vitest documentation snapshot
   at `packages/mcp/public/vendor/vitest-docs/`.
-- `vitest-agent://patterns/` — the curated testing-patterns library at
-  `packages/mcp/public/patterns/`.
+- `vitest-agent://patterns/` — the curated patterns library at `packages/mcp/public/patterns/`, spanning two pattern classes: testing patterns (testing Effect services, schemas, authoring a custom reporter) and agent-operability guidance (operating the tool as an agent, running tests via MCP, silencing leaking output, known issues). The `_meta.json` manifest is the authoritative per-pattern list.
 
 Each scheme has an index URI and a per-page template URI. Both per-page
 templates register a `list` callback that decodes the source manifest
@@ -437,10 +436,7 @@ enough.
 - `vitest://` carries vendored upstream content — a snapshot of
   `vitest-dev/vitest`'s `docs/` tree at a pinned tag. The scheme name
   signals provenance.
-- `vitest-agent://` carries content authored *for* this project — opinions
-  about testing Effect services, testing schemas, authoring a custom
-  reporter. Splitting the schemes makes it impossible to conflate
-  vendored content with curated guidance, even at a glance.
+- `vitest-agent://` carries content authored *for* this project — opinions about testing Effect services, testing schemas and authoring a custom reporter, plus agent-operability guidance for driving the tool itself (an `audience: ["assistant"]` read-first orientation index and its supporting cookbook / troubleshooting pages). Splitting the schemes makes it impossible to conflate vendored content with curated guidance, even at a glance.
 
 **Path-traversal guarding.** `paths.ts`'s `resolveResourcePath` enforces
 three invariants: no null bytes, no absolute paths, and the resolved path

--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -106,7 +106,10 @@ src/
 public/               -- package-root corpus mirrored into the build
                          output by @savvy-web/bundler's syncPublicDir
   vendor/vitest-docs/  -- vendored upstream Vitest docs snapshot
-  patterns/           -- curated testing patterns library
+  patterns/           -- curated patterns corpus: Effect-testing
+                         patterns + agent-operability guides
+                         (operating-as-an-agent, running tests via
+                         MCP, output silencing, known issues)
 
 lib/scripts/          -- snapshot-maintenance TS pipeline (fetch /
                          build / validate). Refresh via the

--- a/packages/mcp/public/patterns/_meta.json
+++ b/packages/mcp/public/patterns/_meta.json
@@ -26,6 +26,42 @@
 				"audience": ["assistant"],
 				"priority": 0.7
 			}
+		},
+		{
+			"slug": "running-tests-via-mcp",
+			"title": "Running Tests via the MCP run_tests Tool",
+			"summary": "Scope runs with project/files/tags (there is no `filter` param), read the four-variant return shape, and understand why subset runs 'fail' coverage thresholds.",
+			"annotations": {
+				"audience": ["assistant"],
+				"priority": 0.9
+			}
+		},
+		{
+			"slug": "silencing-leaking-output-in-tests",
+			"title": "Silencing Leaking Log / Build Output in Tests",
+			"summary": "Decision tree mapping each noise source (Effect logger, console.*, rsbuild, tsdown, API Extractor) to its silencing technique, with an assert-on-output guardrail.",
+			"annotations": {
+				"audience": ["assistant"],
+				"priority": 0.8
+			}
+		},
+		{
+			"slug": "known-issues-and-caveats",
+			"title": "Known Issues & Instrumentation Caveats",
+			"summary": "Distinguishes real vitest-agent issues (DataStoreError UNIQUE race) from upstream Vitest caveats (coverage-dir ENOENT), already-fixed bugs (perf_hooks), and misconceptions (discovery-cache staleness).",
+			"annotations": {
+				"audience": ["assistant"],
+				"priority": 0.7
+			}
+		},
+		{
+			"slug": "operating-vitest-agent-as-an-agent",
+			"title": "Operating vitest-agent as an Agent",
+			"summary": "Read first: the front-loaded facts an agent needs (no run_tests filter param, coverage-in-subset behavior, console output is config-driven not env-driven, attribution is auto-recovered) with links to the deeper patterns.",
+			"annotations": {
+				"audience": ["assistant"],
+				"priority": 0.95
+			}
 		}
 	]
 }

--- a/packages/mcp/public/patterns/known-issues-and-caveats.md
+++ b/packages/mcp/public/patterns/known-issues-and-caveats.md
@@ -1,0 +1,52 @@
+# Known Issues & Instrumentation Caveats
+
+## When to use
+
+A test run surfaced an error or oddity that looks like a vitest-agent bug.
+Check it against this list first — several are upstream Vitest behavior, an
+already-shipped fix, or a misconception, not something to investigate as a
+consumer-side problem.
+
+## `DataStoreError` on a UNIQUE collision — live, retry
+
+A concurrent agent registration (on `idempotency_key`) or two concurrent turn
+writes (on `(session_id, turn_no)`) can race the persistence layer's
+check-then-insert and surface a `DataStoreError` carrying
+`UNIQUE constraint failed`. It is not a consumer bug and not data corruption —
+retry the operation. The SELECT pre-check narrows but does not close the race.
+
+## `coverage/.tmp … ENOENT coverage-0.json` — inherent Vitest, not a bug
+
+Running Vitest in two processes at once (for example a CLI run alongside the
+`vitest-vscode` extension) makes them share Vitest's default
+`coverage.reportsDirectory`, and one process can delete the temp dir the other
+is writing. vitest-agent never sets `reportsDirectory`, so this is an upstream
+multi-process Vitest caveat. Give each concurrent process its own
+`coverage.reportsDirectory` (or serialize them).
+
+## `MaxPerformanceEntryBufferExceededWarning` — resolved, stop chasing it
+
+This `perf_hooks` warning on long runs was fixed in a shipped
+`@vitest-agent/reporter` release: React 19's development reconciler emits a
+`performance.measure()` per render, and the live renderer now drains Node's
+user-timing buffer after each render cycle. If you still see it, update
+`@vitest-agent/reporter`. Do not investigate it as a fault in your own repo.
+
+## Stale test counts — re-run, there is no warm cache
+
+Moving or adding test files does not require an MCP restart. Discovery is
+re-walked fresh on every Vitest run; the MCP serves counts from the database,
+which only updates when tests are re-run. Stale numbers mean the tests have not
+been re-run — not that a discovery cache is warm. Restarting the MCP would not
+refresh them.
+
+## A run that rebuilds `dist/` mid-run — expected
+
+A host project's Vitest `globalSetup` may call `AgentPlugin.runScript(...)`
+(for example `pnpm turbo run build:dev`), which can transiently tear down and
+rebuild `dist/` during the run. This is the host project's configuration, not a
+broken workspace.
+
+## See also
+
+- `vitest-agent://patterns/running-tests-via-mcp` — why subset runs "fail" coverage thresholds

--- a/packages/mcp/public/patterns/operating-vitest-agent-as-an-agent.md
+++ b/packages/mcp/public/patterns/operating-vitest-agent-as-an-agent.md
@@ -1,0 +1,53 @@
+# Operating vitest-agent as an Agent
+
+## When to use
+
+Read this first when you are an agent driving a project that uses
+`@vitest-agent/*`. It front-loads the handful of facts that otherwise cost
+trial-and-error, then points you at the deeper patterns.
+
+## The facts that save the most time
+
+1. **Run tests with `run_tests`, not Bash `vitest`.** `run_tests` persists
+   results, classifications, coverage, and history and fires the post-tool-use
+   hooks. Shelling out to `vitest` bypasses all of that.
+2. **`run_tests` has no `filter` parameter.** Scope with `project` (the Vitest
+   project name), `files` (globs), or `tags`. An unknown key like `filter` is
+   silently dropped, so the whole suite runs.
+3. **Subset runs "fail" coverage thresholds by design.** A single-file run
+   exiting with `ERROR: Coverage … does not meet global threshold` is expected
+   — global thresholds applied to partial coverage. There is no per-run
+   coverage toggle in `run_tests`; it inherits your `vitest.config`. For
+   isolated inspection use the CLI: `vitest run <file> --coverage.enabled=false`.
+4. **You cannot see stray `console.log` through `run_tests`** — it null-routes
+   Vitest's stdout. Console behavior is configured via the plugin's `console`
+   matrix (e.g. `console: { agent: "passthrough" }`), **not** environment
+   variables. To see intercepted output, run Vitest directly with
+   `--disableConsoleIntercept` (a native Vitest flag).
+5. **Session attribution is recovered for you.** The SessionStart hook writes
+   the `VITEST_AGENT_*` identity into the environment and the SDK recovers it —
+   you never set those vars by hand. The only behavioral knobs are
+   `VITEST_REPORTER_LOG_LEVEL`, `VITEST_REPORTER_LOG_FILE`, and `NO_COLOR`.
+6. **Stale counts mean tests were not re-run**, not a warm cache. Discovery
+   re-walks per Vitest run; the MCP serves counts from the database.
+7. **Some "leaks" are guardrail tests** that assert on their own output. Do not
+   silence output a test captures and `expect`s on.
+
+## Environment, briefly
+
+You do not configure vitest-agent through environment variables. The
+`VITEST_AGENT_*` vars (chat id, conversation id, agent ids, project dir,
+sidecar bin) are attribution plumbing written by the Claude Code plugin's
+SessionStart hook and recovered automatically. The only vars you might set for
+diagnostics are `VITEST_REPORTER_LOG_LEVEL` / `VITEST_REPORTER_LOG_FILE` (a
+diagnostic log file, separate from the console reporter) and `NO_COLOR`.
+
+## Where to go next
+
+| You want to… | Read |
+| --- | --- |
+| Scope a run, read the return shape, understand coverage-in-subset | `vitest-agent://patterns/running-tests-via-mcp` |
+| Silence noisy log/build output in tests | `vitest-agent://patterns/silencing-leaking-output-in-tests` |
+| Tell tooling noise apart from real failures | `vitest-agent://patterns/known-issues-and-caveats` |
+| Read the full console-mode matrix (human prose) | <https://vitest-agent.dev/guide/console-modes> |
+| The human-facing version of this page | <https://vitest-agent.dev/guide/operating-as-an-agent> |

--- a/packages/mcp/public/patterns/running-tests-via-mcp.md
+++ b/packages/mcp/public/patterns/running-tests-via-mcp.md
@@ -1,0 +1,58 @@
+# Running Tests via the MCP `run_tests` Tool
+
+## When to use
+
+You want to execute the Vitest suite (or a subset) from an agent. Always prefer `run_tests` over shelling out to `vitest` — it persists results, classifications, coverage, and history to the project database and drives the post-tool-use hooks. Re-running `vitest` over Bash bypasses all of that.
+
+## Scoping a run — there is no `filter` parameter
+
+`run_tests` accepts exactly these inputs:
+
+| Field | Type | Default | Scopes by |
+| --- | --- | --- | --- |
+| `files` | `string[]` | `[]` | Vitest file patterns: exact paths or globs |
+| `project` | `string` | unset | The Vitest **project name** from your config |
+| `tags` | `{ all?: string[]; any?: string[]; none?: string[] }` | unset | Vitest tag expression |
+| `passWithNoTests` | `boolean` | config value | Per-call override of `test.passWithNoTests` |
+| `timeout` | `number` (seconds) | `120` | Per-call run timeout |
+
+There is **no** `filter` field. Passing one (`run_tests({ filter: "@my/pkg" })`) is silently dropped — the call then runs with no filters, so the **entire** suite executes. To scope to one package, pass its Vitest project name as `project`; to scope to one file, pass it in `files`.
+
+`project` matches the project **name** defined in `vitest.config.ts`, not the npm package name. They often differ — check your config for the actual project name.
+
+`tags` sub-filters AND together (with each other and with `project`/`files`): `all` → `"a and b"`, `any` → `"(a or b)"`, `none` → `"not a and not b"`.
+
+## Return shape
+
+`run_tests` returns one of four variants — discriminate on `kind`:
+
+| `kind` | Fields | Meaning |
+| --- | --- | --- |
+| `"ok"` | `report`, `classifications` (map of test full-name → `stable`/`new-failure`/`persistent`/`flaky`/`recovered`), optional `project` | The run completed |
+| `"no-match"` | `filter` (the resolved `project`/`files`/`tags`/`resolvedExpression`) | A filter was supplied but matched zero tests |
+| `"timeout"` | `timeoutSeconds` | Exceeded the timeout |
+| `"error"` | `message` | The run errored |
+
+A `no-match` is filter-driven: it fires when you supplied a filter and zero tests matched. Treat it as a finding (typo in `project`/`files`?) rather than a pass.
+
+## Coverage on subset runs reads as a failure — by design
+
+A single-file or single-project run will commonly exit non-zero with:
+
+```text
+ERROR: Coverage for lines (59.91%) does not meet global threshold (70%)
+```
+
+This is expected: your global coverage thresholds are applied to a partial run, so partial coverage "fails" them. It is not a real test failure.
+
+`run_tests` has **no per-run coverage toggle** — it deliberately inherits your `vitest.config` `coverage.enabled` (forcing it off here used to override intentional "coverage on by default" setups). For clean isolated inspection, drop to the CLI:
+
+```bash
+vitest run path/to/one.test.ts --coverage.enabled=false
+```
+
+## See also
+
+- `vitest-agent://patterns/operating-vitest-agent-as-an-agent` — the orientation index
+- `vitest-agent://patterns/known-issues-and-caveats` — coverage-dir races and other instrumentation caveats
+- `vitest://docs/config/index` — Vitest's native config reference

--- a/packages/mcp/public/patterns/silencing-leaking-output-in-tests.md
+++ b/packages/mcp/public/patterns/silencing-leaking-output-in-tests.md
@@ -1,0 +1,91 @@
+# Silencing Leaking Log / Build Output in Tests
+
+## When to use
+
+A test run is polluted with stray log lines, build-tool banners, or framework
+diagnostics that drown the signal. The fix differs per source — identify the
+source first, then apply the matching technique.
+
+## Guardrail: do not silence output a test asserts on
+
+Before silencing anything, confirm the test does not capture and `expect` on
+the output. Some tests deliberately spy on `process.stdout.write` /
+`process.stderr.write` (or `console.*`) and assert on `.mock.calls` to verify
+what a formatter emits. Silencing those breaks the assertion. If you see a
+`vi.spyOn(process.stdout, "write")` whose `.mock.calls` are asserted, that
+output is the test subject — leave it alone.
+
+## Decision tree
+
+| Source (what the noise looks like) | Technique |
+| --- | --- |
+| Effect default logger (`timestamp=… level=INFO message=…`) | Provide a silent logger layer |
+| Plain `console.log` / `console.warn` / `console.error` | Spy + mock the method |
+| rsbuild (`info build started…`, file-size table) | Set `@rsbuild/core` logger level to silent |
+| tsdown / rolldown (`ℹ entry:`, `✔ Build complete`) | Pass `logLevel: "silent"` to the build |
+| API Extractor (`(ae-missing-release-tag)` to stderr) | Pass an `onMessage` handler that marks messages handled |
+
+## Effect default logger
+
+Provide a silent logger at the run/layer boundary. This mirrors how the SDK's
+own `LoggerLive` builds its silent variant (`packages/sdk/src/layers/LoggerLive.ts`):
+
+```typescript
+import { Effect, Logger } from "effect";
+
+const silent = Logger.replace(Logger.defaultLogger, Logger.none);
+
+await Effect.runPromise(program.pipe(Effect.provide(silent)));
+```
+
+`Logger.minimumLogLevel(LogLevel.None)` is an equivalent gate.
+
+## Plain `console.*`
+
+```typescript
+import { beforeEach, vi } from "vitest";
+
+beforeEach(() => {
+ vi.spyOn(console, "warn").mockImplementation(() => {});
+ vi.spyOn(console, "error").mockImplementation(() => {});
+});
+```
+
+## rsbuild reporter
+
+rsbuild writes through its own `logger` singleton, **not** `console.*`, so
+console mocks miss it. Set the level and restore it:
+
+```typescript
+import { logger } from "@rsbuild/core";
+
+const prev = logger.level;
+logger.level = "silent";
+try {
+ await build();
+} finally {
+ logger.level = prev;
+}
+```
+
+## tsdown / rolldown
+
+Pass `logLevel: "silent"` to the build call (or inject a no-op output writer).
+
+## API Extractor
+
+Mark diagnostics handled so they are not printed — this is the production quiet
+path:
+
+```typescript
+extractorResult = Extractor.invoke(config, {
+ messageCallback: (message) => {
+  message.handled = true;
+ },
+});
+```
+
+## See also
+
+- `vitest-agent://patterns/known-issues-and-caveats` — distinguishing tooling noise from real failures
+- `vitest://docs/api/vi` — the `vi.spyOn` / mock API

--- a/website/docs/en/guide/_meta.json
+++ b/website/docs/en/guide/_meta.json
@@ -80,5 +80,19 @@
 		"type": "file",
 		"name": "wire-ci-reporting",
 		"label": "CI reporting"
+	},
+	{
+		"type": "section-header",
+		"label": "Operating as an agent"
+	},
+	{
+		"type": "file",
+		"name": "operating-as-an-agent",
+		"label": "Operating as an agent"
+	},
+	{
+		"type": "file",
+		"name": "known-issues",
+		"label": "Known issues"
 	}
 ]

--- a/website/docs/en/guide/known-issues.mdx
+++ b/website/docs/en/guide/known-issues.mdx
@@ -1,0 +1,46 @@
+---
+title: Known issues
+description: Verified status of common error signatures — which are real vitest-agent issues, which are upstream Vitest caveats, which are already fixed, and which are misconceptions.
+---
+
+# Known issues
+
+When a run surfaces an error that looks like a vitest-agent bug, check it here
+first. Several common signatures are upstream Vitest behavior, an
+already-shipped fix, or a misconception.
+
+## `DataStoreError` on a UNIQUE collision
+
+**Status: live.** Concurrent agent registration (on `idempotency_key`) or
+concurrent turn writes (on `(session_id, turn_no)`) can race the persistence
+layer's check-then-insert and surface a `DataStoreError` carrying
+`UNIQUE constraint failed`. It is not data corruption — retry the operation.
+
+## `coverage/.tmp … ENOENT coverage-0.json`
+
+**Status: inherent Vitest, not a vitest-agent bug.** Two Vitest processes
+running at once (for example a CLI run alongside the `vitest-vscode` extension)
+share Vitest's default `coverage.reportsDirectory`, and one can delete the temp
+dir the other is using. vitest-agent never sets `reportsDirectory`. Give each
+concurrent process its own `coverage.reportsDirectory`, or serialize them.
+
+## `MaxPerformanceEntryBufferExceededWarning`
+
+**Status: resolved.** Fixed in a shipped `@vitest-agent/reporter` release — the
+live renderer now drains Node's user-timing buffer after each render cycle, so
+React 19's development-reconciler `performance.measure()` entries no longer
+accumulate. Update `@vitest-agent/reporter` if you still see it.
+
+## Stale test counts after moving or adding files
+
+**Status: misconception.** There is no warm discovery cache to invalidate.
+Discovery re-walks on every run; the MCP serves counts from the database, which
+updates only when tests are re-run. Re-run the tests — restarting the MCP does
+nothing here.
+
+## A run that rebuilds `dist/` mid-run
+
+**Status: expected.** A host project's Vitest `globalSetup` can call
+`AgentPlugin.runScript(...)` (for example `pnpm turbo run build:dev`), which may
+transiently rebuild `dist/` during the run. That is the host project's
+configuration, not a broken workspace.

--- a/website/docs/en/guide/operating-as-an-agent.mdx
+++ b/website/docs/en/guide/operating-as-an-agent.mdx
@@ -1,0 +1,59 @@
+---
+title: Operating as an agent
+description: The facts an AI agent needs first to drive a vitest-agent project — run_tests scoping, coverage-in-subset behavior, console output, and the env vars the SDK recovers automatically.
+---
+
+# Operating as an agent
+
+If you are an AI agent (or configuring one) driving a project that uses
+`@vitest-agent/*`, this page front-loads the handful of facts that otherwise
+cost trial-and-error. The agent-facing versions of these pages are also served
+through the MCP corpus at `vitest-agent://patterns/` so they are discoverable
+from inside a session.
+
+## The facts that save the most time
+
+1. **Run tests with the `run_tests` MCP tool, not Bash `vitest`.** It persists
+   results, classifications, coverage, and history and fires the post-tool-use
+   hooks. Shelling out bypasses all of that.
+2. **`run_tests` has no `filter` parameter.** Scope a run with `project` (the
+   Vitest project name), `files` (globs), or `tags`. An unknown key is silently
+   dropped, so the whole suite runs.
+3. **Subset runs "fail" coverage thresholds by design.** A single-file run that
+   exits with `ERROR: Coverage … does not meet global threshold` is expected.
+   There is no per-run coverage toggle in `run_tests`; it inherits your
+   `vitest.config`. For isolated inspection use
+   `vitest run <file> --coverage.enabled=false`.
+4. **Stray `console.log` is invisible through `run_tests`** — it null-routes
+   Vitest's stdout. Console behavior is set by the plugin's
+   [`console` matrix](/guide/console-modes), not by environment variables. Use
+   Vitest's native `--disableConsoleIntercept` to see intercepted output.
+5. **Session attribution is recovered for you** from the environment the
+   Claude Code plugin's SessionStart hook writes; you never set `VITEST_AGENT_*`
+   vars by hand.
+6. **Stale counts mean tests were not re-run**, not a warm cache. Discovery
+   re-walks per run; the MCP serves counts from the database.
+7. **Some "leaks" are guardrail tests** that assert on their own output — do not
+   silence them.
+
+## Environment variables
+
+You do not configure vitest-agent through environment variables. The
+`VITEST_AGENT_*` family is attribution plumbing written by the SessionStart
+hook and recovered automatically. The only variables you might set yourself:
+
+| Variable | Effect |
+| --- | --- |
+| `VITEST_REPORTER_LOG_LEVEL` | Level of the diagnostic logger (separate from the console reporter) |
+| `VITEST_REPORTER_LOG_FILE` | File the diagnostic logger writes to |
+| `NO_COLOR` | Disables ANSI color in rendered output |
+
+There is no environment variable that toggles coverage or changes the console
+mode — those are configuration, not environment.
+
+## Deeper references
+
+- [Console modes](/guide/console-modes) — the full per-executor matrix
+- [Known issues](/guide/known-issues) — telling tooling noise from real failures
+- MCP corpus (from inside a session): `vitest-agent://patterns/running-tests-via-mcp`,
+  `vitest-agent://patterns/silencing-leaking-output-in-tests`


### PR DESCRIPTION
## What

Closes three dogfooding documentation gaps reported by an agent consuming `@vitest-agent/*` in another workspace: #101 (silencing-output cookbook), #102 (run_tests operability + env-var reference), and #103 (an orientation index + known-issues page).

Agent-operator docs land on two surfaces, cross-linked:

**MCP patterns corpus** (`packages/mcp/public/patterns/`, served via `vitest-agent://patterns/` — the surface the filing agent actually searched):

- `operating-vitest-agent-as-an-agent` — read-first orientation index (priority 0.95)
- `running-tests-via-mcp` — `run_tests` operability reference
- `silencing-leaking-output-in-tests` — cookbook
- `known-issues-and-caveats` — troubleshooting

**Website guide** (`website/docs/en/guide/`, new "Operating as an agent" section): `operating-as-an-agent.mdx` (hub + env-var table) and `known-issues.mdx`.

## Why it's a correction pass, not transcription

A research pass verified every claim against current source/git. Several of the issues' assertions were wrong or stale, and the docs document the verified facts instead:

- `run_tests` has **no `filter` parameter** — the filing agent's `filter` key was silently dropped, running the whole suite. Scope with `project` / `files` / `tags`.
- There are **no console-bypass env vars** — console output is config-driven (the `console` matrix); `--disableConsoleIntercept` is a Vitest-native flag.
- The `perf_hooks` buffer leak is **already fixed** (#97 / 3cfd166) — documented as resolved so agents stop chasing it.
- "Discovery-cache staleness" is a **misconception** — counts come from the DB and refresh when tests re-run.
- The `DataStoreError` UNIQUE race is **real and unfixed** (documented, not fixed here); the coverage-dir ENOENT is **inherent Vitest**.

## Verification

Every page markdownlint-clean; all 7 corpus slugs resolve and the manifest decodes; the full RSPress site builds with both new pages rendering; the `@vitest-agent/mcp` changeset passes `savvy changeset check` + `lint`. Design docs (`mcp.md`, `docs-site.md`), `packages/mcp/CLAUDE.md`, and `refs.json` were updated by the finalize doc-agents.

Closes #101, #102, #103

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>
