### PR TITLE
feat: console-leak detection for run_tests + VITEST_AGENT_CONSOLE escape hatch

### DIFF
--- a/.changeset/brave-cranes-wander.md
+++ b/.changeset/brave-cranes-wander.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/cli": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/brave-dogs-leap.md
+++ b/.changeset/brave-dogs-leap.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/plugin": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/brave-foxes-dream.md
+++ b/.changeset/brave-foxes-dream.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/reporter": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/bright-jets-rise.md
+++ b/.changeset/bright-jets-rise.md
@@ -1,0 +1,22 @@
+---
+"@vitest-agent/mcp": minor
+---
+
+## Features
+
+### Console Leak Signal in run_tests
+
+The `run_tests` tool now collects stray console output during the test run and folds it into the `AgentReport` as an optional `consoleLeaks` field. The structured signal includes:
+
+- Total write count across the run
+- Per-file stdout/stderr split with up to 10 attributable test names per file
+- A truncated first-line sample of the first write seen per file
+- A `truncated` flag when more than 25 files produced stray output
+
+The tool's markdown output includes a one-line warning when leaks are present:
+
+```text
+⚠ N stray console writes across M+ files (see consoleLeaks)
+```
+
+No configuration is required. The signal is omitted entirely on runs with no stray output.

--- a/.changeset/calm-trees-leap.md
+++ b/.changeset/calm-trees-leap.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sidecar-darwin-arm64": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/clean-owls-glow.md
+++ b/.changeset/clean-owls-glow.md
@@ -1,0 +1,27 @@
+---
+"@vitest-agent/sdk": minor
+---
+
+## Features
+
+### Console Leak Detection API
+
+New public types and utilities for collecting and aggregating stray console output from a Vitest run into a structured signal.
+
+`ConsoleLeaks` and `ConsoleLeakFile` are Effect Schema types:
+
+```ts
+import { ConsoleLeaks, ConsoleLeakFile } from "@vitest-agent/sdk";
+// ConsoleLeaks: { total: number; byFile: ConsoleLeakFile[]; truncated?: boolean }
+// ConsoleLeakFile: { file: string; stdout: number; stderr: number; tests?: string[]; sample?: string }
+```
+
+`buildConsoleLeaks(entries)` aggregates a `ConsoleLeakEntry[]` into a `ConsoleLeaks` signal — bucketing by file, splitting stdout/stderr counts, capturing a truncated first-line sample per file, and sorting by total writes descending. The file list is capped at 25 entries with a `truncated` flag when more are present. Returns `undefined` on a clean run so a report carries no signal when no stray console calls occurred.
+
+`collectConsoleLeakEntries(files)` walks a `ConsoleLeakTask[]` tree (the shape returned by `vitest.state.getFiles()`) into flat `ConsoleLeakEntry` values, attributing each captured write to its enclosing file and test name.
+
+`AgentReport` gains an optional `consoleLeaks` field typed as `ConsoleLeaks | undefined`, populated by the `run_tests` MCP tool when stray writes are detected during the run.
+
+## Bug Fixes
+
+`@vitest-agent/sdk/testing` now exports the 79 constituent types that appear in `DataStore` and `DataReader` method signatures — errors, schemas, and identity types that API Extractor flagged as forgotten exports from the testing entry point. Both the value and type sides of each Effect Schema const+type pair are covered. The entry point is now complete with zero new suppressions.

--- a/.changeset/happy-foxes-ponder.md
+++ b/.changeset/happy-foxes-ponder.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/mcp": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/lucky-foxes-laugh.md
+++ b/.changeset/lucky-foxes-laugh.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sidecar-win32-x64": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/mild-cups-wake.md
+++ b/.changeset/mild-cups-wake.md
@@ -1,0 +1,19 @@
+---
+"@vitest-agent/plugin": minor
+---
+
+## Features
+
+### VITEST_AGENT_CONSOLE Env Var
+
+Set `VITEST_AGENT_CONSOLE` to override the console mode that `AgentPlugin` resolves from the `console` option matrix for a single Vitest invocation. Accepted values mirror the per-executor slots:
+
+- `human` executor: `passthrough`, `silent`, `stream`, `agent`
+- `agent` executor: `passthrough`, `silent`, `agent`
+- `ci` executor: `passthrough`, `silent`, `ci-annotations`
+
+An invalid value for the detected executor is silently ignored and a diagnostic is written to stderr, leaving the config-derived mode in effect. This is an escape hatch for CI pipelines, local debugging sessions, and test setups where modifying `vitest.config.ts` is not practical.
+
+## Bug Fixes
+
+`CoverageOptions` is now exported from the `@vitest-agent/plugin` entry point. The interface appears in `CoverageAnalyzer`'s public method signatures and was reachable through type inference but not directly importable. The package now reports zero API Extractor errors with no new suppressions.

--- a/.changeset/silver-cats-dance.md
+++ b/.changeset/silver-cats-dance.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sidecar": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/silver-cups-rest.md
+++ b/.changeset/silver-cups-rest.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sdk": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/silver-trees-laugh.md
+++ b/.changeset/silver-trees-laugh.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sidecar-linux-arm64": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/swift-trees-leap.md
+++ b/.changeset/swift-trees-leap.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/ui": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/wild-cups-fly.md
+++ b/.changeset/wild-cups-fly.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sidecar-linux-x64": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From    | To      |
+| ------------------ | ------------- | ------- | ------- | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/silk": "^1.3.2",
+		"@savvy-web/silk": "^1.3.4",
 		"@vitest-agent/cli": "workspace:*",
 		"@vitest-agent/mcp": "workspace:*",
 		"@vitest-agent/plugin": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
 		"effect": "catalog:silk"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",

--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -124,7 +124,7 @@ lib/scripts/          -- snapshot-maintenance TS pipeline (fetch /
 | `bin.ts` | `resolveProjectDir()` precedence: `VITEST_AGENT_REPORTER_PROJECT_DIR` -> `CLAUDE_PROJECT_DIR` -> `process.cwd()`. Resolves `dbPath` via `resolveDataPath(projectDir)` then constructs the `ManagedRuntime` |
 | `context.ts` | tRPC `McpContext` carrying the `ManagedRuntime` so procedures call `ctx.runtime.runPromise(effect)` |
 | `router.ts` | Aggregates all tool procedures; testable via `createCallerFactory(appRouter)` without starting the MCP server |
-| `tools/run-tests.ts` | `spawnSync("vitest run", ...)` with configurable timeout (default 120s) |
+| `tools/run-tests.ts` | In-process `createVitest` (`vitest/node`) + `localVitest.start()` with configurable timeout (default 120s); builds the `AgentReport` from `result.testModules` and folds `consoleLeaks` from the post-run `state.getFiles()` task-tree walk |
 | `tools/note.ts` | Single action-keyed tool covering all six note operations (`create`/`list`/`get`/`update`/`delete`/`search`) via the `action` discriminator |
 | `tools/tdd-task.ts` | Action-keyed `tdd_task` tool with `start`/`end`/`get`/`resume` (replaces the 1.x `tdd_session_*` family; the underlying SQLite columns retain the `tdd_tasks` naming). `start` and `end` are idempotent via the middleware registry |
 | `tools/tdd-goal.ts`, `tools/tdd-behavior.ts` | Action-keyed CRUD for the Objective→Goal→Behavior hierarchy. `create` actions are idempotent on `(sessionId, goal)` / `(goalId, behavior)`. The `delete` action is denied to the orchestrator at the plugin's `pre-tool-use/tdd-restricted.sh` hook (the `tool_input.action` matcher); the consolidated tools are listed in `safe-mcp-vitest-agent-ops.txt` so non-delete actions auto-allow |
@@ -199,10 +199,12 @@ lib/scripts/          -- snapshot-maintenance TS pipeline (fetch /
   as one argv element. The new TS script preserves this invariant
   inherited from the 1.x `update-vitest-snapshot.mjs`. Don't regress
   this when editing the script.
-- **`run_tests` uses `spawnSync` deliberately.** The MCP server
-  cannot process other tool requests during a test run; this is
-  acceptable because agents wait for results before proceeding.
-  See Decision 21.
+- **`run_tests` runs Vitest in-process via `createVitest`.** It imports
+  `createVitest` from `vitest/node`, awaits `localVitest.start(...)`, and
+  reads results (including `localVitest.state.getFiles()`, which the
+  `consoleLeaks` task-tree walk depends on) before the call returns. The
+  in-process run blocks the MCP server for its duration; this is acceptable
+  because agents wait for results before proceeding. See Decision 21.
 
 ## When working in this package
 

--- a/packages/mcp/__test__/fixtures/console-leak-project/leaky.test.ts
+++ b/packages/mcp/__test__/fixtures/console-leak-project/leaky.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "vitest";
+
+test("leaks when fetching", () => {
+	console.log("DEBUG cache miss for key abc");
+	console.error("WARN deprecated path used");
+	expect(1).toBe(1);
+});

--- a/packages/mcp/__test__/fixtures/console-leak-project/package.json
+++ b/packages/mcp/__test__/fixtures/console-leak-project/package.json
@@ -1,0 +1,1 @@
+{ "name": "console-leak-fixture", "private": true, "type": "module" }

--- a/packages/mcp/__test__/fixtures/console-leak-project/vitest.config.ts
+++ b/packages/mcp/__test__/fixtures/console-leak-project/vitest.config.ts
@@ -1,0 +1,14 @@
+import { AgentPlugin } from "@vitest-agent/plugin";
+import { defineConfig } from "vitest/config";
+
+// Force the silent/stripped-reporter topology regardless of executor so the
+// e2e proves the task-tree walk works where onConsoleLog would have been
+// gated. "silent" strips Vitest's reporters; task.logs is still populated
+// by Vitest's internal console interception. `discoverStrategy: false`
+// disables the inject-tags Vite transform — the fixture does not wire
+// `AgentPlugin.discover()`, and the transform's injected tags are undeclared
+// here, which otherwise drops every test at collection.
+export default defineConfig({
+	plugins: [AgentPlugin({ discoverStrategy: false, console: { human: "silent", agent: "silent", ci: "silent" } })],
+	test: { coverage: { enabled: false } },
+});

--- a/packages/mcp/__test__/run-tests-console-leaks.e2e.test.ts
+++ b/packages/mcp/__test__/run-tests-console-leaks.e2e.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect } from "vitest";
+import type { McpContext } from "../src/context.js";
+import { createCallerFactory, createCurrentSessionIdRef, createSessionContextRef } from "../src/context.js";
+import { appRouter } from "../src/router.js";
+import { test } from "./integration/utils/fixtures.js";
+
+const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "console-leak-project");
+let xdgDir: string;
+
+beforeAll(() => {
+	// Isolate AgentPlugin DB writes into a throwaway XDG dir so the fixture
+	// run does not collide with the monorepo's own data.db.
+	xdgDir = mkdtempSync(join(tmpdir(), "va-leak-xdg-"));
+	process.env.XDG_DATA_HOME = xdgDir;
+});
+
+afterAll(() => {
+	delete process.env.XDG_DATA_HOME;
+	rmSync(xdgDir, { recursive: true, force: true });
+});
+
+const makeCaller = (runtime: unknown) =>
+	createCallerFactory(appRouter)({
+		runtime: runtime as McpContext["runtime"],
+		cwd: fixtureDir,
+		currentSessionId: createCurrentSessionIdRef(null),
+		sessionContext: createSessionContextRef(),
+	});
+
+describe("run_tests folds console leaks into the report under the real reporter topology (e2e)", () => {
+	test("a leaking passing test surfaces consoleLeaks with attribution and sample", { timeout: 120_000 }, async ({
+		runtime,
+	}) => {
+		const caller = makeCaller(runtime);
+		const result = await caller.run_tests({});
+
+		expect(result.kind).toBe("ok");
+		if (result.kind !== "ok") return;
+
+		const leaks = result.report.consoleLeaks;
+		expect(leaks).toBeDefined();
+		expect(leaks?.total).toBe(2);
+
+		const file = leaks?.byFile.find((f) => f.file.endsWith("leaky.test.ts"));
+		expect(file).toBeDefined();
+		expect(file?.stdout).toBe(1);
+		expect(file?.stderr).toBe(1);
+		expect(file?.tests).toContain("leaks when fetching");
+		expect(file?.sample).toContain("DEBUG cache miss for key abc");
+	});
+});

--- a/packages/mcp/__test__/run-tests-console-leaks.test.ts
+++ b/packages/mcp/__test__/run-tests-console-leaks.test.ts
@@ -1,0 +1,37 @@
+import type { AgentReport, ConsoleLeaks } from "@vitest-agent/sdk";
+import { describe, expect, it } from "vitest";
+import { formatReportMarkdown } from "../src/tools/run-tests.js";
+
+const baseReport: AgentReport = {
+	timestamp: "2026-06-26T00:00:00.000Z",
+	reason: "passed",
+	summary: { total: 1, passed: 1, failed: 0, skipped: 0, duration: 5 },
+	failed: [],
+	unhandledErrors: [],
+	failedFiles: [],
+};
+
+describe("formatReportMarkdown console-leak line", () => {
+	it("emits a plural warning line for multiple writes/files", () => {
+		const consoleLeaks: ConsoleLeaks = {
+			total: 7,
+			byFile: [
+				{ file: "a.test.ts", stdout: 5, stderr: 0 },
+				{ file: "b.test.ts", stdout: 2, stderr: 0 },
+			],
+		};
+		const md = formatReportMarkdown({ ...baseReport, consoleLeaks });
+		expect(md).toContain("7 stray console writes across 2 files");
+		expect(md).toContain("consoleLeaks");
+	});
+
+	it("uses singular for exactly one write in one file", () => {
+		const consoleLeaks: ConsoleLeaks = { total: 1, byFile: [{ file: "a.test.ts", stdout: 1, stderr: 0 }] };
+		const md = formatReportMarkdown({ ...baseReport, consoleLeaks });
+		expect(md).toContain("1 stray console write across 1 file");
+	});
+
+	it("emits nothing when consoleLeaks is absent", () => {
+		expect(formatReportMarkdown(baseReport)).not.toContain("stray console");
+	});
+});

--- a/packages/mcp/__test__/run-tests-console-leaks.test.ts
+++ b/packages/mcp/__test__/run-tests-console-leaks.test.ts
@@ -21,8 +21,19 @@ describe("formatReportMarkdown console-leak line", () => {
 			],
 		};
 		const md = formatReportMarkdown({ ...baseReport, consoleLeaks });
+		expect(md).toContain("⚠");
 		expect(md).toContain("7 stray console writes across 2 files");
 		expect(md).toContain("consoleLeaks");
+	});
+
+	it("renders the file count as a floor (N+) when byFile was truncated", () => {
+		const consoleLeaks: ConsoleLeaks = {
+			total: 60,
+			byFile: Array.from({ length: 25 }, (_, i) => ({ file: `f${i}.test.ts`, stdout: 1, stderr: 0 })),
+			truncated: true,
+		};
+		const md = formatReportMarkdown({ ...baseReport, consoleLeaks });
+		expect(md).toContain("60 stray console writes across 25+ files");
 	});
 
 	it("uses singular for exactly one write in one file", () => {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,7 +47,7 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",

--- a/packages/mcp/public/patterns/_meta.json
+++ b/packages/mcp/public/patterns/_meta.json
@@ -57,7 +57,7 @@
 		{
 			"slug": "operating-vitest-agent-as-an-agent",
 			"title": "Operating vitest-agent as an Agent",
-			"summary": "Read first: the front-loaded facts an agent needs (no run_tests filter param, coverage-in-subset behavior, console output is config-driven not env-driven, attribution is auto-recovered) with links to the deeper patterns.",
+			"summary": "Read first: the front-loaded facts an agent needs (no run_tests filter param, coverage-in-subset behavior, consoleLeaks signal in run_tests output, VITEST_AGENT_CONSOLE CLI escape hatch, attribution is auto-recovered) with links to the deeper patterns.",
 			"annotations": {
 				"audience": ["assistant"],
 				"priority": 0.95

--- a/packages/mcp/public/patterns/operating-vitest-agent-as-an-agent.md
+++ b/packages/mcp/public/patterns/operating-vitest-agent-as-an-agent.md
@@ -19,11 +19,14 @@ trial-and-error, then points you at the deeper patterns.
    — global thresholds applied to partial coverage. There is no per-run
    coverage toggle in `run_tests`; it inherits your `vitest.config`. For
    isolated inspection use the CLI: `vitest run <file> --coverage.enabled=false`.
-4. **You cannot see stray `console.log` through `run_tests`** — it null-routes
-   Vitest's stdout. Console behavior is configured via the plugin's `console`
-   matrix (e.g. `console: { agent: "passthrough" }`), **not** environment
-   variables. To see intercepted output, run Vitest directly with
-   `--disableConsoleIntercept` (a native Vitest flag).
+4. **Stray `console.*` is surfaced by `run_tests` as a signal, not raw logs.**
+   The `ok` result's `report.consoleLeaks` field lists writes by file with
+   counts, optional per-test attribution, and a truncated sample. `run_tests`
+   still null-routes Vitest's stdout; the signal captures what was printed
+   without forwarding raw log lines into agent context. To see the raw output
+   for a flagged file, run Vitest on the CLI:
+   `VITEST_AGENT_CONSOLE=passthrough pnpm test`. Details at
+   `vitest-agent://patterns/running-tests-via-mcp`.
 5. **Session attribution is recovered for you.** The SessionStart hook writes
    the `VITEST_AGENT_*` identity into the environment and the SDK recovers it —
    you never set those vars by hand. The only behavioral knobs are
@@ -38,9 +41,15 @@ trial-and-error, then points you at the deeper patterns.
 You do not configure vitest-agent through environment variables. The
 `VITEST_AGENT_*` vars (chat id, conversation id, agent ids, project dir,
 sidecar bin) are attribution plumbing written by the Claude Code plugin's
-SessionStart hook and recovered automatically. The only vars you might set for
-diagnostics are `VITEST_REPORTER_LOG_LEVEL` / `VITEST_REPORTER_LOG_FILE` (a
-diagnostic log file, separate from the console reporter) and `NO_COLOR`.
+SessionStart hook and recovered automatically. The vars you might set:
+
+- `VITEST_REPORTER_LOG_LEVEL` / `VITEST_REPORTER_LOG_FILE` — diagnostic
+  logger (separate from the console reporter).
+- `NO_COLOR` — disables ANSI color in rendered output.
+- `VITEST_AGENT_CONSOLE=passthrough` — overrides the resolved console mode
+  for the active executor on a CLI `vitest` run. Useful when investigating
+  files flagged by `report.consoleLeaks`. Invalid-for-slot values warn to
+  stderr and are ignored.
 
 ## Where to go next
 

--- a/packages/mcp/public/patterns/running-tests-via-mcp.md
+++ b/packages/mcp/public/patterns/running-tests-via-mcp.md
@@ -51,6 +51,51 @@ This is expected: your global coverage thresholds are applied to a partial run, 
 vitest run path/to/one.test.ts --coverage.enabled=false
 ```
 
+## Stray console output — `report.consoleLeaks`
+
+When the run produces stray `console.*` output, the `report` object on an
+`"ok"` result carries an optional `consoleLeaks` field. It is omitted
+entirely when the run produced no user console output.
+
+Shape:
+
+- `total` — total stray console writes across the run
+- `byFile` — one entry per file that produced writes:
+  - `file` — the test file path
+  - `stdout` — writes to stdout-class streams (`log`, `info`, `debug`)
+  - `stderr` — writes to stderr-class streams (`error`, `warn`)
+  - `tests` (optional) — test names where writes were attributed
+  - `sample` (optional) — truncated excerpt of the first write in this file
+- `truncated` (optional) — `true` when `byFile` was capped
+
+Use `byFile[].file` to locate which files to investigate and `sample` to
+find the call site, without dumping full log content into agent context.
+The markdown summary line also surfaces the leak count inline (e.g.
+`⚠ 3 stray console writes across 2 files (see consoleLeaks)`).
+
+### Console-output visibility by surface
+
+| Surface | Sees stray `console.*` | Per-test attribution |
+| --- | --- | --- |
+| `run_tests` (MCP) | yes — `consoleLeaks` signal (counts + sample) | per file, per test where resolvable |
+| Human at a TTY | yes — Vitest's own `stdout \|` / `stderr \|` lines | yes (TTY only) |
+| Piped shell (default) | no — agent-shaped summary suppresses it | n/a |
+| Piped shell + `VITEST_AGENT_CONSOLE=passthrough` | yes — raw passthrough | no (raw, unlabeled) |
+
+### `VITEST_AGENT_CONSOLE` — CLI escape hatch
+
+To see raw console output for a file that `consoleLeaks` flagged, run
+Vitest directly on the CLI with the override set:
+
+```bash
+VITEST_AGENT_CONSOLE=passthrough pnpm test
+```
+
+This overrides the plugin's resolved console mode to `passthrough` for
+the active executor — Vitest's own reporters emit console output
+unfiltered. An invalid value for the current executor slot warns to
+stderr and is ignored.
+
 ## See also
 
 - `vitest-agent://patterns/operating-vitest-agent-as-an-agent` — the orientation index

--- a/packages/mcp/src/tools/run-tests.ts
+++ b/packages/mcp/src/tools/run-tests.ts
@@ -1,7 +1,14 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { Writable } from "node:stream";
-import type { AgentReport, VitestModuleError } from "@vitest-agent/sdk";
-import { AgentReport as AgentReportSchema, DataReader, DataStore, buildAgentReport } from "@vitest-agent/sdk";
+import type { AgentReport, ConsoleLeakTask, VitestModuleError } from "@vitest-agent/sdk";
+import {
+	AgentReport as AgentReportSchema,
+	DataReader,
+	DataStore,
+	buildAgentReport,
+	buildConsoleLeaks,
+	collectConsoleLeakEntries,
+} from "@vitest-agent/sdk";
 import { Effect, ParseResult, Schema } from "effect";
 import { publicProcedure } from "../context.js";
 
@@ -323,6 +330,13 @@ export function formatReportMarkdown(report: AgentReport, classifications?: Read
 		lines.push(`\nProject: ${report.project}`);
 	}
 
+	if (report.consoleLeaks !== undefined) {
+		const cl = report.consoleLeaks;
+		const writes = `${cl.total} stray console write${cl.total === 1 ? "" : "s"}`;
+		const files = `${cl.byFile.length} file${cl.byFile.length === 1 ? "" : "s"}`;
+		lines.push(`\n⚠ ${writes} across ${files} (see consoleLeaks)`);
+	}
+
 	for (const mod of report.failed) {
 		lines.push(`\n### \u274C \`${mod.file}\``);
 		// Module-level errors (collection / load / hook failures) carry no
@@ -534,7 +548,11 @@ export const runTests = publicProcedure
 					const reason =
 						unhandledErrors.length > 0 || result.testModules.some((m) => m.state() === "failed") ? "failed" : "passed";
 
-					const report = buildAgentReport(testModules, unhandledErrors, reason, { omitPassingTests: true });
+					const baseReport = buildAgentReport(testModules, unhandledErrors, reason, { omitPassingTests: true });
+					const leaks = buildConsoleLeaks(
+						collectConsoleLeakEntries(localVitest.state.getFiles() as unknown as ConsoleLeakTask[]),
+					);
+					const report = leaks !== undefined ? { ...baseReport, consoleLeaks: leaks } : baseReport;
 
 					// Read stored classifications from DB (written by the reporter via
 					// classifyTest() during vitest.start). This avoids reimplementing

--- a/packages/mcp/src/tools/run-tests.ts
+++ b/packages/mcp/src/tools/run-tests.ts
@@ -333,7 +333,10 @@ export function formatReportMarkdown(report: AgentReport, classifications?: Read
 	if (report.consoleLeaks !== undefined) {
 		const cl = report.consoleLeaks;
 		const writes = `${cl.total} stray console write${cl.total === 1 ? "" : "s"}`;
-		const files = `${cl.byFile.length} file${cl.byFile.length === 1 ? "" : "s"}`;
+		// byFile is capped (see buildConsoleLeaks); when truncated the file count
+		// is a floor, so render "N+ files" rather than understating it.
+		const plural = cl.byFile.length !== 1 || cl.truncated === true;
+		const files = `${cl.byFile.length}${cl.truncated === true ? "+" : ""} file${plural ? "s" : ""}`;
 		lines.push(`\n⚠ ${writes} across ${files} (see consoleLeaks)`);
 	}
 

--- a/packages/plugin/__test__/resolve-console-mode-env.test.ts
+++ b/packages/plugin/__test__/resolve-console-mode-env.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveConsoleMode } from "../src/plugin.js";
+
+const ENV = "VITEST_AGENT_CONSOLE";
+
+describe("resolveConsoleMode VITEST_AGENT_CONSOLE override", () => {
+	const original = process.env[ENV];
+	beforeEach(() => {
+		delete process.env[ENV];
+	});
+	afterEach(() => {
+		if (original === undefined) delete process.env[ENV];
+		else process.env[ENV] = original;
+		vi.restoreAllMocks();
+	});
+
+	it("falls back to per-executor defaults when unset", () => {
+		expect(resolveConsoleMode({}, "human", "terminal")).toBe("passthrough");
+		expect(resolveConsoleMode({}, "agent", "agent-shell")).toBe("agent");
+	});
+
+	it("overrides config when set to a valid mode for the slot", () => {
+		process.env[ENV] = "passthrough";
+		// agent default is "agent"; the override forces passthrough.
+		expect(resolveConsoleMode({ console: { agent: "silent" } }, "agent", "agent-shell")).toBe("passthrough");
+	});
+
+	it("honors silent override on the human slot", () => {
+		process.env[ENV] = "silent";
+		expect(resolveConsoleMode({}, "human", "terminal")).toBe("silent");
+	});
+
+	it("warns and ignores a value invalid for the active slot", () => {
+		const warn = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		process.env[ENV] = "stream"; // not valid for the agent slot
+		expect(resolveConsoleMode({}, "agent", "agent-shell")).toBe("agent");
+		expect(warn).toHaveBeenCalledOnce();
+		expect(String(warn.mock.calls[0][0])).toContain("VITEST_AGENT_CONSOLE");
+	});
+});

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -46,7 +46,7 @@
 		"workspaces-effect": "^1.2.0"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -73,6 +73,7 @@ export { ReporterLive } from "./layers/ReporterLive.js";
 
 export { CoverageAnalyzerLive } from "./layers/CoverageAnalyzerLive.js";
 export { CoverageAnalyzerTest } from "./layers/CoverageAnalyzerTest.js";
+export type { CoverageOptions } from "./services/CoverageAnalyzer.js";
 export { CoverageAnalyzer } from "./services/CoverageAnalyzer.js";
 
 // --- ConfigValidation service ---

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -2,29 +2,29 @@ import { execSync } from "node:child_process";
 import type { TestTagDefinition } from "@vitest/runner";
 import { CURRENT_REPORTER_VERSION } from "@vitest-agent/reporter";
 import type {
-	AgentConsoleMode,
 	AgentPluginOptions,
-	CiConsoleMode,
 	ConsoleMode,
 	CoverageLevelName,
 	Environment,
 	Executor,
-	HumanConsoleMode,
 	OutputFormat,
 	RunEvent,
 	Transport,
 	VitestAgentReporterFactory,
 } from "@vitest-agent/sdk";
 import {
+	AgentConsoleMode,
 	CURRENT_SDK_VERSION,
+	CiConsoleMode,
 	CoverageLevel,
 	EnvironmentDetector,
 	EnvironmentDetectorLive,
+	HumanConsoleMode,
 	formatFatalError,
 	resolveLogLevel,
 } from "@vitest-agent/sdk";
 import type { Layer } from "effect";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import type { TestProjectInlineConfiguration } from "vitest/config";
 import type { VitestPluginContext } from "vitest/node";
 import { ConfigValidationLive } from "./layers/ConfigValidationLive.js";
@@ -98,11 +98,24 @@ export interface AgentPluginConstructorOptions extends AgentPluginOptions {
  *
  * @internal
  */
-function resolveConsoleMode(
+export function resolveConsoleMode(
 	options: AgentPluginConstructorOptions,
 	executor: Executor,
 	_env: Environment,
 ): ConsoleMode {
+	const override = process.env.VITEST_AGENT_CONSOLE;
+	if (override !== undefined && override !== "") {
+		// Each per-slot Schema.is call is a narrowed Literal check.  Forming a
+		// single ternary-produced union of the three Literal schemas confuses
+		// tsgo (annotations-method contravariance), so the three guards stay
+		// separate.
+		if (executor === "human" && Schema.is(HumanConsoleMode)(override)) return override;
+		if (executor === "agent" && Schema.is(AgentConsoleMode)(override)) return override;
+		if (executor !== "human" && executor !== "agent" && Schema.is(CiConsoleMode)(override)) return override;
+		process.stderr.write(
+			`[vitest-agent:plugin] ignoring invalid VITEST_AGENT_CONSOLE="${override}" for ${executor} executor\n`,
+		);
+	}
 	const console = options.console;
 	if (executor === "human") {
 		return (console?.human as HumanConsoleMode | undefined) ?? "passthrough";

--- a/packages/plugin/src/services/CoverageAnalyzer.ts
+++ b/packages/plugin/src/services/CoverageAnalyzer.ts
@@ -2,10 +2,19 @@ import type { CoverageBaselines, CoverageReport, ResolvedThresholds } from "@vit
 import type { Effect, Option } from "effect";
 import { Context } from "effect";
 
+/**
+ * Options passed to `CoverageAnalyzer.process` and `CoverageAnalyzer.processScoped`.
+ *
+ * @public
+ */
 export interface CoverageOptions {
+	/** Resolved coverage thresholds to check the report against. */
 	readonly thresholds: ResolvedThresholds;
+	/** Per-file or global coverage targets for policy enforcement. */
 	readonly targets?: ResolvedThresholds;
+	/** Persisted baselines used to compute coverage trends. */
 	readonly baselines?: CoverageBaselines;
+	/** When true, include files with zero coverage rather than omitting them. */
 	readonly includeBareZero: boolean;
 }
 

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -44,7 +44,7 @@
 		"react": "catalog:silk"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/node": "catalog:silk",
 		"@types/react": "catalog:silk",

--- a/packages/sdk/__test__/build-console-leaks.test.ts
+++ b/packages/sdk/__test__/build-console-leaks.test.ts
@@ -1,0 +1,65 @@
+import type { ConsoleLeakEntry } from "@vitest-agent/sdk";
+import { buildConsoleLeaks } from "@vitest-agent/sdk";
+import { describe, expect, it } from "vitest";
+
+const entry = (over: Partial<ConsoleLeakEntry>): ConsoleLeakEntry => ({
+	file: "a.test.ts",
+	type: "stdout",
+	content: "x",
+	...over,
+});
+
+describe("buildConsoleLeaks", () => {
+	it("returns undefined for no entries", () => {
+		expect(buildConsoleLeaks([])).toBeUndefined();
+	});
+
+	it("buckets by file, splits stdout/stderr, and totals writes", () => {
+		const leaks = buildConsoleLeaks([
+			entry({ file: "a.test.ts", type: "stdout" }),
+			entry({ file: "a.test.ts", type: "stderr" }),
+			entry({ file: "b.test.ts", type: "stdout" }),
+		]);
+		expect(leaks?.total).toBe(3);
+		const a = leaks?.byFile.find((f) => f.file === "a.test.ts");
+		expect(a).toMatchObject({ stdout: 1, stderr: 1 });
+		expect(leaks?.byFile.find((f) => f.file === "b.test.ts")).toMatchObject({ stdout: 1, stderr: 0 });
+	});
+
+	it("sorts files by total descending", () => {
+		const leaks = buildConsoleLeaks([
+			entry({ file: "quiet.test.ts" }),
+			entry({ file: "loud.test.ts" }),
+			entry({ file: "loud.test.ts" }),
+			entry({ file: "loud.test.ts" }),
+		]);
+		expect(leaks?.byFile[0].file).toBe("loud.test.ts");
+	});
+
+	it("collects attributable test names and omits tests when none", () => {
+		const leaks = buildConsoleLeaks([entry({ file: "a.test.ts", test: "leaks here" }), entry({ file: "b.test.ts" })]);
+		expect(leaks?.byFile.find((f) => f.file === "a.test.ts")?.tests).toEqual(["leaks here"]);
+		expect(leaks?.byFile.find((f) => f.file === "b.test.ts")?.tests).toBeUndefined();
+	});
+
+	it("captures the first sample per file as one trimmed, truncated line", () => {
+		const leaks = buildConsoleLeaks([entry({ file: "a.test.ts", content: `  ${"D".repeat(200)}\nsecond line` })]);
+		const sample = leaks?.byFile[0].sample ?? "";
+		expect(sample.endsWith("…")).toBe(true);
+		expect(sample).not.toContain("second line");
+		expect(sample.length).toBe(161); // 160 chars + ellipsis
+	});
+
+	it("caps to 25 files and sets truncated", () => {
+		const entries = Array.from({ length: 30 }, (_, i) => entry({ file: `f${i}.test.ts` }));
+		const leaks = buildConsoleLeaks(entries);
+		expect(leaks?.total).toBe(30);
+		expect(leaks?.byFile.length).toBe(25);
+		expect(leaks?.truncated).toBe(true);
+	});
+
+	it("caps test names per file to 10", () => {
+		const entries = Array.from({ length: 12 }, (_, i) => entry({ file: "a.test.ts", test: `t${i}` }));
+		expect(buildConsoleLeaks(entries)?.byFile[0].tests?.length).toBe(10);
+	});
+});

--- a/packages/sdk/__test__/build-console-leaks.test.ts
+++ b/packages/sdk/__test__/build-console-leaks.test.ts
@@ -62,4 +62,17 @@ describe("buildConsoleLeaks", () => {
 		const entries = Array.from({ length: 12 }, (_, i) => entry({ file: "a.test.ts", test: `t${i}` }));
 		expect(buildConsoleLeaks(entries)?.byFile[0].tests?.length).toBe(10);
 	});
+
+	it("backfills the sample from a later write when the first is whitespace-only", () => {
+		const leaks = buildConsoleLeaks([
+			entry({ file: "a.test.ts", content: "   \n" }),
+			entry({ file: "a.test.ts", content: "DEBUG real content" }),
+		]);
+		expect(leaks?.byFile[0].sample).toBe("DEBUG real content");
+	});
+
+	it("omits sample when every write for a file is whitespace-only", () => {
+		const leaks = buildConsoleLeaks([entry({ file: "a.test.ts", content: "   " })]);
+		expect(leaks?.byFile[0].sample).toBeUndefined();
+	});
 });

--- a/packages/sdk/__test__/collect-console-leak-entries.test.ts
+++ b/packages/sdk/__test__/collect-console-leak-entries.test.ts
@@ -1,0 +1,71 @@
+import type { ConsoleLeakTask } from "@vitest-agent/sdk";
+import { collectConsoleLeakEntries } from "@vitest-agent/sdk";
+import { describe, expect, it } from "vitest";
+
+describe("collectConsoleLeakEntries", () => {
+	it("returns an empty array for files with no logs", () => {
+		const files: ConsoleLeakTask[] = [{ type: "suite", name: "a.test.ts", tasks: [{ type: "test", name: "t" }] }];
+		expect(collectConsoleLeakEntries(files)).toEqual([]);
+	});
+
+	it("attributes a file-level log to the file with no test", () => {
+		const files: ConsoleLeakTask[] = [
+			{ type: "suite", name: "a.test.ts", logs: [{ type: "stdout", content: "setup log" }], tasks: [] },
+		];
+		expect(collectConsoleLeakEntries(files)).toEqual([{ file: "a.test.ts", type: "stdout", content: "setup log" }]);
+	});
+
+	it("attributes a test-level log to the file + test fullTestName", () => {
+		const files: ConsoleLeakTask[] = [
+			{
+				type: "suite",
+				name: "a.test.ts",
+				tasks: [
+					{
+						type: "test",
+						name: "leaks",
+						fullTestName: "group > leaks",
+						logs: [{ type: "stderr", content: "boom" }],
+					},
+				],
+			},
+		];
+		expect(collectConsoleLeakEntries(files)).toEqual([
+			{ file: "a.test.ts", test: "group > leaks", type: "stderr", content: "boom" },
+		]);
+	});
+
+	it("recurses through nested suites and preserves order", () => {
+		const files: ConsoleLeakTask[] = [
+			{
+				type: "suite",
+				name: "a.test.ts",
+				logs: [{ type: "stdout", content: "file-1" }],
+				tasks: [
+					{
+						type: "suite",
+						name: "inner",
+						tasks: [
+							{ type: "test", name: "t1", fullTestName: "inner > t1", logs: [{ type: "stdout", content: "test-1" }] },
+						],
+					},
+				],
+			},
+		];
+		expect(collectConsoleLeakEntries(files)).toEqual([
+			{ file: "a.test.ts", type: "stdout", content: "file-1" },
+			{ file: "a.test.ts", test: "inner > t1", type: "stdout", content: "test-1" },
+		]);
+	});
+
+	it("falls back to the test name when fullTestName is absent", () => {
+		const files: ConsoleLeakTask[] = [
+			{
+				type: "suite",
+				name: "a.test.ts",
+				tasks: [{ type: "test", name: "bare", logs: [{ type: "stdout", content: "x" }] }],
+			},
+		];
+		expect(collectConsoleLeakEntries(files)[0]?.test).toBe("bare");
+	});
+});

--- a/packages/sdk/__test__/console-leaks-schema.test.ts
+++ b/packages/sdk/__test__/console-leaks-schema.test.ts
@@ -1,0 +1,33 @@
+import { ConsoleLeaks } from "@vitest-agent/sdk";
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+describe("ConsoleLeaks schema", () => {
+	it("round-trips a full value through encode/decode", () => {
+		const value: ConsoleLeaks = {
+			total: 7,
+			byFile: [
+				{
+					file: "packages/x/foo.test.ts",
+					stdout: 5,
+					stderr: 2,
+					tests: ["leaks when fetching"],
+					sample: "DEBUG cache miss",
+				},
+			],
+			truncated: true,
+		};
+		const encoded = Schema.encodeSync(ConsoleLeaks)(value);
+		const decoded = Schema.decodeUnknownSync(ConsoleLeaks)(encoded);
+		expect(decoded).toEqual(value);
+	});
+
+	it("decodes a minimal value (optional fields omitted)", () => {
+		const decoded = Schema.decodeUnknownSync(ConsoleLeaks)({
+			total: 1,
+			byFile: [{ file: "a.test.ts", stdout: 1, stderr: 0 }],
+		});
+		expect(decoded.byFile[0].tests).toBeUndefined();
+		expect(decoded.truncated).toBeUndefined();
+	});
+});

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -50,7 +50,7 @@
 		"xdg-effect": "^2.0.1"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -107,6 +107,7 @@ export * from "./utils/canonicalize-git-url.js";
 export * from "./utils/classify-test.js";
 export * from "./utils/compress-lines.js";
 export * from "./utils/compute-trend.js";
+export * from "./utils/console-leaks.js";
 export * from "./utils/detect-pm.js";
 export { isTimeoutError } from "./utils/detect-timeout.js";
 export * from "./utils/ensure-migrated.js";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -67,6 +67,7 @@ export * from "./schemas/CacheManifest.js";
 export * from "./schemas/ChannelEvent.js";
 export * from "./schemas/Common.js";
 export * from "./schemas/Config.js";
+export * from "./schemas/ConsoleLeaks.js";
 export * from "./schemas/Coverage.js";
 export * from "./schemas/CoverageLevel.js";
 export * from "./schemas/CoverageTargets.js";

--- a/packages/sdk/src/schemas/AgentReport.ts
+++ b/packages/sdk/src/schemas/AgentReport.ts
@@ -1,5 +1,6 @@
 import { Schema } from "effect";
 import { ReportError, TestClassification, TestRunReason, TestState } from "./Common.js";
+import { ConsoleLeaks } from "./ConsoleLeaks.js";
 import { CoverageReport } from "./Coverage.js";
 
 /**
@@ -78,6 +79,7 @@ export const AgentReport = Schema.Struct({
 			value: TagCountEntry,
 		}),
 	),
+	consoleLeaks: Schema.optional(ConsoleLeaks),
 }).annotations({ identifier: "AgentReport" });
 /** @public */
 export type AgentReport = typeof AgentReport.Type;

--- a/packages/sdk/src/schemas/ConsoleLeaks.ts
+++ b/packages/sdk/src/schemas/ConsoleLeaks.ts
@@ -1,0 +1,29 @@
+import { Schema } from "effect";
+
+/**
+ * Per-file stray-console-output detail. Counts are of console writes
+ * (one `console.*` call), not lines.
+ * @public
+ */
+export const ConsoleLeakFile = Schema.Struct({
+	file: Schema.String,
+	stdout: Schema.Number,
+	stderr: Schema.Number,
+	tests: Schema.optional(Schema.Array(Schema.String)),
+	sample: Schema.optional(Schema.String),
+}).annotations({ identifier: "ConsoleLeakFile" });
+/** @public */
+export type ConsoleLeakFile = typeof ConsoleLeakFile.Type;
+
+/**
+ * Aggregate stray-console-output signal for a single test run. Omitted from
+ * a report entirely when the run produced no user console output.
+ * @public
+ */
+export const ConsoleLeaks = Schema.Struct({
+	total: Schema.Number,
+	byFile: Schema.Array(ConsoleLeakFile),
+	truncated: Schema.optional(Schema.Boolean),
+}).annotations({ identifier: "ConsoleLeaks" });
+/** @public */
+export type ConsoleLeaks = typeof ConsoleLeaks.Type;

--- a/packages/sdk/src/testing/index.ts
+++ b/packages/sdk/src/testing/index.ts
@@ -2,6 +2,10 @@ import { Effect, Layer } from "effect";
 import { DataStore } from "../services/DataStore.js";
 import { makeTestLayer } from "./layers.js";
 
+// Re-export all types that appear in DataStore / DataReader method signatures
+// so that API Extractor can resolve them from the testing entry point.
+// Agent errors
+export { AgentNotFoundError, RegistrationConflictError } from "../errors/AgentErrors.js";
 export { DataStoreError } from "../errors/DataStoreError.js";
 export type { IllegalStatusTransitionEntity, TddTaskEndOutcome } from "../errors/TddErrors.js";
 export {
@@ -11,11 +15,93 @@ export {
 	TddTaskAlreadyEndedError,
 	TddTaskNotFoundError,
 } from "../errors/TddErrors.js";
+// Agent schemas — classes carry both value and type
+export { Agent, IdempotencyHit } from "../schemas/Agent.js";
+// AgentReport schema — Schema const+type pair
+export { AgentReport } from "../schemas/AgentReport.js";
+// Baselines schema — Schema const+type pair
+export { CoverageBaselines } from "../schemas/Baselines.js";
+// CacheManifest schema — Schema const+type pair
+export { CacheManifest } from "../schemas/CacheManifest.js";
+// Coverage schemas — Schema const+type pairs
+export { CoverageReport, FileCoverageReport } from "../schemas/Coverage.js";
+// History schema — Schema const+type pair
+export { HistoryRecord } from "../schemas/History.js";
+// Identity schemas — Schema const+type pairs; `export { X }` covers both
+export { AgentId, ChatId } from "../schemas/Identity.js";
+// Tdd schemas — Schema const+type pairs
+export { BehaviorDetail, BehaviorRow, BehaviorStatus, GoalDetail, GoalRow, GoalStatus } from "../schemas/Tdd.js";
+// Trend schemas — Schema const+type pairs
+export { TrendEntry, TrendRecord } from "../schemas/Trends.js";
+// DataReader read/output types (all interfaces — type-only)
+export type {
+	AcceptanceMetrics,
+	CitedArtifactRow,
+	CommitChangesEntry,
+	CurrentTddPhase,
+	FailureSignatureDetail,
+	FlakyTest,
+	HypothesisDetail,
+	ModuleListEntry,
+	NoteRow,
+	PersistentFailure,
+	ProjectRunSummary,
+	SessionDetail,
+	SettingsListEntry,
+	SettingsRow,
+	SuiteListEntry,
+	TagInventoryRow,
+	TddArtifactDetail,
+	TddArtifactRow,
+	TddPhaseDetail,
+	TddTaskDetail,
+	TddTaskSummary,
+	TestError,
+	TestListEntry,
+	TurnSearchOptions,
+	TurnSummary,
+} from "../services/DataReader.js";
 // Re-export service tags and error types whose names appear in the bundled
 // declaration signatures so rslib can resolve them without inlining them as
 // non-exported interfaces (which causes TS4023 in consumers).
 export { DataReader } from "../services/DataReader.js";
+// DataStore write-input types (all interfaces / type aliases — type-only)
+export type {
+	AssociateRunSessionInput,
+	ChangeKind,
+	CreateBehaviorInput,
+	CreateGoalInput,
+	EndTddTaskInput,
+	FailureSignatureWriteInput,
+	FileCoverageInput,
+	HypothesisInput,
+	IdempotentResponseInput,
+	ModuleInput,
+	NoteInput,
+	RegisterAgentInput,
+	RunChangedFile,
+	RunInvocationMethod,
+	SessionInput,
+	SettingsInput,
+	StackFrameInput,
+	SuiteInput,
+	TddTaskInput,
+	TestCaseInput,
+	TestErrorInput,
+	TestRunInput,
+	TurnInput,
+	UpdateBehaviorInput,
+	UpdateGoalInput,
+	ValidateHypothesisInput,
+	WriteCommitInput,
+	WriteRunChangedFilesInput,
+	WriteTddArtifactInput,
+	WriteTddPhaseInput,
+	WriteTddPhaseOutput,
+} from "../services/DataStore.js";
 export { DataStore } from "../services/DataStore.js";
+// Phase-transition pure types (no runtime values)
+export type { ArtifactKind, CitedArtifact, Phase } from "../utils/validate-phase-transition.js";
 export { DataStoreTestLayer, makeTestLayer } from "./layers.js";
 
 /** @public */

--- a/packages/sdk/src/utils/console-leaks.ts
+++ b/packages/sdk/src/utils/console-leaks.ts
@@ -1,0 +1,74 @@
+import type { ConsoleLeakFile, ConsoleLeaks } from "../schemas/ConsoleLeaks.js";
+
+const SAMPLE_MAX_CHARS = 160;
+const MAX_FILES = 25;
+const MAX_TESTS_PER_FILE = 10;
+
+/**
+ * A single captured stray console write, attributed to a file (and a test
+ * when the write happened inside one). Fed to buildConsoleLeaks.
+ * @public
+ */
+export interface ConsoleLeakEntry {
+	readonly file: string;
+	readonly test?: string;
+	readonly type: "stdout" | "stderr";
+	readonly content: string;
+}
+
+interface FileAcc {
+	stdout: number;
+	stderr: number;
+	tests: Set<string>;
+	sample?: string;
+}
+
+function truncateSample(content: string): string {
+	const firstLine = content.split("\n", 1)[0] ?? "";
+	const trimmed = firstLine.trim();
+	return trimmed.length > SAMPLE_MAX_CHARS ? `${trimmed.slice(0, SAMPLE_MAX_CHARS)}…` : trimmed;
+}
+
+/**
+ * Aggregate raw console-leak entries into a ConsoleLeaks signal:
+ * bucket by file, split stdout/stderr, collect attributable test names,
+ * capture one truncated sample per file, sort by total writes descending,
+ * and cap the file list. Returns `undefined` when there are no entries so a
+ * clean run attaches nothing.
+ * @public
+ */
+export function buildConsoleLeaks(entries: ReadonlyArray<ConsoleLeakEntry>): ConsoleLeaks | undefined {
+	if (entries.length === 0) return undefined;
+
+	const byFile = new Map<string, FileAcc>();
+	for (const e of entries) {
+		let acc = byFile.get(e.file);
+		if (acc === undefined) {
+			acc = { stdout: 0, stderr: 0, tests: new Set() };
+			byFile.set(e.file, acc);
+		}
+		if (e.type === "stdout") acc.stdout++;
+		else acc.stderr++;
+		if (e.test !== undefined && e.test !== "") acc.tests.add(e.test);
+		if (acc.sample === undefined) acc.sample = truncateSample(e.content);
+	}
+
+	const files: ConsoleLeakFile[] = [];
+	for (const [file, acc] of byFile) {
+		files.push({
+			file,
+			stdout: acc.stdout,
+			stderr: acc.stderr,
+			...(acc.tests.size > 0 ? { tests: [...acc.tests].slice(0, MAX_TESTS_PER_FILE) } : {}),
+			...(acc.sample !== undefined && acc.sample !== "" ? { sample: acc.sample } : {}),
+		});
+	}
+	files.sort((a, b) => b.stdout + b.stderr - (a.stdout + a.stderr));
+
+	const truncated = files.length > MAX_FILES;
+	return {
+		total: entries.length,
+		byFile: truncated ? files.slice(0, MAX_FILES) : files,
+		...(truncated ? { truncated: true } : {}),
+	};
+}

--- a/packages/sdk/src/utils/console-leaks.ts
+++ b/packages/sdk/src/utils/console-leaks.ts
@@ -72,3 +72,45 @@ export function buildConsoleLeaks(entries: ReadonlyArray<ConsoleLeakEntry>): Con
 		...(truncated ? { truncated: true } : {}),
 	};
 }
+
+/**
+ * Structural subset of a Vitest runner task (File / Suite / Test) carrying
+ * captured console output. Modeled locally so this util needs no `vitest`
+ * dependency. `logs` is attached to tasks by Vitest's console interception
+ * regardless of which reporter is active, which is why the walk survives
+ * reporter stripping in agent mode.
+ * @public
+ */
+export interface ConsoleLeakTask {
+	readonly type?: string;
+	readonly name?: string;
+	readonly fullTestName?: string;
+	readonly logs?: ReadonlyArray<{ readonly type: "stdout" | "stderr"; readonly content: string }>;
+	readonly tasks?: ReadonlyArray<ConsoleLeakTask>;
+}
+
+/**
+ * Walk a Vitest `File[]` task tree (from `vitest.state.getFiles()`) into flat
+ * {@link ConsoleLeakEntry} values. Each task `log` becomes one entry attributed
+ * to its enclosing file and, when the log sits on a test task, that test's name.
+ * @public
+ */
+export function collectConsoleLeakEntries(files: ReadonlyArray<ConsoleLeakTask>): ConsoleLeakEntry[] {
+	const entries: ConsoleLeakEntry[] = [];
+	const visit = (task: ConsoleLeakTask, file: string, test: string | undefined): void => {
+		const currentTest = task.type === "test" ? (task.fullTestName ?? task.name ?? test) : test;
+		for (const log of task.logs ?? []) {
+			entries.push({
+				file,
+				...(currentTest !== undefined ? { test: currentTest } : {}),
+				type: log.type,
+				content: log.content,
+			});
+		}
+		for (const child of task.tasks ?? []) visit(child, file, currentTest);
+	};
+	for (const file of files) {
+		visit(file, file.name ?? "(unknown)", undefined);
+	}
+	return entries;
+}

--- a/packages/sdk/src/utils/console-leaks.ts
+++ b/packages/sdk/src/utils/console-leaks.ts
@@ -50,7 +50,13 @@ export function buildConsoleLeaks(entries: ReadonlyArray<ConsoleLeakEntry>): Con
 		if (e.type === "stdout") acc.stdout++;
 		else acc.stderr++;
 		if (e.test !== undefined && e.test !== "") acc.tests.add(e.test);
-		if (acc.sample === undefined) acc.sample = truncateSample(e.content);
+		// Capture the first NON-EMPTY sample. A first write whose first line is
+		// whitespace-only truncates to "", so we leave sample unset and let a
+		// later content-bearing write fill it rather than locking in a blank.
+		if (acc.sample === undefined) {
+			const candidate = truncateSample(e.content);
+			if (candidate !== "") acc.sample = candidate;
+		}
 	}
 
 	const files: ConsoleLeakFile[] = [];
@@ -60,7 +66,7 @@ export function buildConsoleLeaks(entries: ReadonlyArray<ConsoleLeakEntry>): Con
 			stdout: acc.stdout,
 			stderr: acc.stderr,
 			...(acc.tests.size > 0 ? { tests: [...acc.tests].slice(0, MAX_TESTS_PER_FILE) } : {}),
-			...(acc.sample !== undefined && acc.sample !== "" ? { sample: acc.sample } : {}),
+			...(acc.sample !== undefined ? { sample: acc.sample } : {}),
 		});
 	}
 	files.sort((a, b) => b.stdout + b.stderr - (a.stdout + a.stderr));

--- a/packages/sidecar-darwin-arm64/package.json
+++ b/packages/sidecar-darwin-arm64/package.json
@@ -26,7 +26,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",

--- a/packages/sidecar-linux-arm64/package.json
+++ b/packages/sidecar-linux-arm64/package.json
@@ -26,7 +26,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",

--- a/packages/sidecar-linux-x64/package.json
+++ b/packages/sidecar-linux-x64/package.json
@@ -26,7 +26,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",

--- a/packages/sidecar-win32-x64/package.json
+++ b/packages/sidecar-win32-x64/package.json
@@ -26,7 +26,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -31,7 +31,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,7 @@
 		"effect": "catalog:silk"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/node": "catalog:silk",
 		"@types/react": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",

--- a/playground/package.json
+++ b/playground/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.0",
+		"@savvy-web/bundler": "^0.11.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"typescript": "catalog:silk",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ catalogs:
       version: 19.2.3
     '@typescript/native-preview':
       specifier: ^7.0.0-dev.20260621.1
-      version: 7.0.0-dev.20260624.1
+      version: 7.0.0-dev.20260626.1
     '@vitest/coverage-istanbul':
       specifier: ^4.1.9
       version: 4.1.9
@@ -98,8 +98,8 @@ importers:
   .:
     devDependencies:
       '@savvy-web/silk':
-        specifier: ^1.3.2
-        version: 1.3.2(2ba4e64278962102559ddd9ad7b767cd)
+        specifier: ^1.3.4
+        version: 1.3.4(eb764a782732e619ef27a7ba08f4864d)
       '@vitest-agent/cli':
         specifier: workspace:*
         version: link:packages/cli/dist/dev/pkg
@@ -114,7 +114,7 @@ importers:
         version: 4.22.4
       vitest:
         specifier: catalog:silk
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/cli:
     dependencies:
@@ -150,14 +150,14 @@ importers:
         version: 3.21.4
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       '@vitest/coverage-v8':
         specifier: catalog:silk
         version: 4.1.9(vitest@4.1.9)
@@ -166,7 +166,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: catalog:silk
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     publishDirectory: dist/dev/pkg
 
   packages/mcp:
@@ -206,14 +206,14 @@ importers:
         version: 4.4.3
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       '@vitest/coverage-v8':
         specifier: catalog:silk
         version: 4.1.9(vitest@4.1.9)
@@ -222,7 +222,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: catalog:silk
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     publishDirectory: dist/dev/pkg
 
   packages/plugin:
@@ -274,17 +274,17 @@ importers:
         version: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       '@vitest/coverage-istanbul':
         specifier: catalog:silk
         version: 4.1.9(vitest@4.1.9)
@@ -302,10 +302,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.0
-        version: 8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: catalog:silk
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     publishDirectory: dist/dev/pkg
 
   packages/reporter:
@@ -345,20 +345,20 @@ importers:
         version: 19.2.7
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@types/react':
         specifier: catalog:silk
         version: 19.2.17
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       '@vitest/coverage-istanbul':
         specifier: ^4.1.8
         version: 4.1.9(vitest@4.1.9)
@@ -373,10 +373,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.0
-        version: 8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: catalog:silk
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     publishDirectory: dist/dev/pkg
 
   packages/sdk:
@@ -428,14 +428,14 @@ importers:
         version: 2.0.1(4b99e7aa355a094dc1986218f72d3bb6)
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       '@vitest/coverage-v8':
         specifier: catalog:silk
         version: 4.1.9(vitest@4.1.9)
@@ -444,20 +444,20 @@ importers:
         version: 6.0.3
       vitest:
         specifier: catalog:silk
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     publishDirectory: dist/dev/pkg
 
   packages/sidecar:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       '@vitest/coverage-v8':
         specifier: catalog:silk
         version: 4.1.9(vitest@4.1.9)
@@ -466,7 +466,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: catalog:silk
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@vitest-agent/sidecar-darwin-arm64':
         specifier: workspace:*
@@ -485,14 +485,14 @@ importers:
   packages/sidecar-darwin-arm64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       '@vitest-agent/sdk':
         specifier: workspace:*
         version: link:../sdk/dist/dev/pkg
@@ -504,14 +504,14 @@ importers:
   packages/sidecar-linux-arm64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       '@vitest-agent/sdk':
         specifier: workspace:*
         version: link:../sdk/dist/dev/pkg
@@ -523,14 +523,14 @@ importers:
   packages/sidecar-linux-x64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       '@vitest-agent/sdk':
         specifier: workspace:*
         version: link:../sdk/dist/dev/pkg
@@ -542,14 +542,14 @@ importers:
   packages/sidecar-win32-x64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       '@vitest-agent/sdk':
         specifier: workspace:*
         version: link:../sdk/dist/dev/pkg
@@ -568,17 +568,17 @@ importers:
         version: 3.21.4
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@types/react':
         specifier: catalog:silk
         version: 19.2.17
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       ink:
         specifier: ^7.1.0
         version: 7.1.0(@types/react@19.2.17)(react@19.2.7)
@@ -593,38 +593,38 @@ importers:
         version: 6.0.3
       vitest:
         specifier: catalog:silk
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     publishDirectory: dist/dev/pkg
 
   playground:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.0
-        version: 0.11.0(36acce83ee6775ca598bc1f62f00e2b5)
+        specifier: ^0.11.1
+        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       typescript:
         specifier: catalog:silk
         version: 6.0.3
       vitest:
         specifier: catalog:silk
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
   website:
     devDependencies:
       '@rspress/core':
-        specifier: ^2.0.14
-        version: 2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        specifier: ^2.0.15
+        version: 2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-sitemap':
-        specifier: ^2.0.14
-        version: 2.0.14(@rspress/core@2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        specifier: ^2.0.15
+        version: 2.0.15(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
       '@types/node':
         specifier: ^26.0.0
-        version: 26.0.0
+        version: 26.0.1
       '@types/react':
         specifier: catalog:silk
         version: 19.2.17
@@ -633,7 +633,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260624.1
+        version: 7.0.0-dev.20260626.1
       react:
         specifier: catalog:silk
         version: 19.2.7
@@ -641,11 +641,11 @@ importers:
         specifier: catalog:silk
         version: 19.2.7(react@19.2.7)
       rspress-plugin-api-extractor:
-        specifier: ^0.3.0
-        version: 0.3.0(faaf363626e1ec069cd26041faf1e463)
+        specifier: ^0.3.2
+        version: 0.3.2(a0bd9bb2b4f856558ba95aaae869221b)
       rspress-plugin-mermaid:
         specifier: ^1.0.1
-        version: 1.0.1(@rspress/core@2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 1.0.1(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
 
 packages:
 
@@ -1273,8 +1273,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1409,97 +1409,97 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@rolldown/binding-android-arm64@1.1.2':
-    resolution: {integrity: sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==}
+  '@rolldown/binding-android-arm64@1.1.3':
+    resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.2':
-    resolution: {integrity: sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==}
+  '@rolldown/binding-darwin-arm64@1.1.3':
+    resolution: {integrity: sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.2':
-    resolution: {integrity: sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw==}
+  '@rolldown/binding-darwin-x64@1.1.3':
+    resolution: {integrity: sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.2':
-    resolution: {integrity: sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==}
+  '@rolldown/binding-freebsd-x64@1.1.3':
+    resolution: {integrity: sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
-    resolution: {integrity: sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
+    resolution: {integrity: sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.2':
-    resolution: {integrity: sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.3':
+    resolution: {integrity: sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.2':
-    resolution: {integrity: sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==}
+  '@rolldown/binding-linux-arm64-musl@1.1.3':
+    resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
-    resolution: {integrity: sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
+    resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.2':
-    resolution: {integrity: sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.3':
+    resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.2':
-    resolution: {integrity: sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==}
+  '@rolldown/binding-linux-x64-gnu@1.1.3':
+    resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.1.2':
-    resolution: {integrity: sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==}
+  '@rolldown/binding-linux-x64-musl@1.1.3':
+    resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.1.2':
-    resolution: {integrity: sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==}
+  '@rolldown/binding-openharmony-arm64@1.1.3':
+    resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.2':
-    resolution: {integrity: sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==}
+  '@rolldown/binding-wasm32-wasi@1.1.3':
+    resolution: {integrity: sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.2':
-    resolution: {integrity: sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.3':
+    resolution: {integrity: sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.2':
-    resolution: {integrity: sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==}
+  '@rolldown/binding-win32-x64-msvc@1.1.3':
+    resolution: {integrity: sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1602,19 +1602,19 @@ packages:
       '@rspack/core':
         optional: true
 
-  '@rspress/core@2.0.14':
-    resolution: {integrity: sha512-k59i08zwBGgHrjHw8CK1m4CeTrKPvZRmV54bxubQl6AdDdmhJK6WrNg3UthwWmd38scKtqF40ATXDE8RMiNcNA==}
+  '@rspress/core@2.0.15':
+    resolution: {integrity: sha512-epLmUXYscNRw/GtQZx2oknoBE9wKbCrUGEOrQEDI4Qq8X32GdM4d7itzuHsliY7q3IbffKx8rMVbvlmygEocTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  '@rspress/plugin-sitemap@2.0.14':
-    resolution: {integrity: sha512-Gpone22PvXGfGRSyi/WM8IXgsvKhNspXqHjtPD3g62jX8SJL3kpj2YZ2V28WEkg672fICauUYXrpre74Rddcsw==}
+  '@rspress/plugin-sitemap@2.0.15':
+    resolution: {integrity: sha512-z1hbyGP79ZXdSGJxiWw7ZjmX8qW0q9nXMDxr14cVEg/wdj7ToVzGtZHw0wvTPE0YiKG3BMiGkVNfE1rdOaPXiQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rspress/core': ^2.0.10
 
-  '@rspress/shared@2.0.14':
-    resolution: {integrity: sha512-sCe9tAo+s9tR4DmFSjMyHOxQvhzTSYXkkMUfVEo5w+uMCNXXGAIC6D0xAVDMHq1jIFF9ix47VxzlCo+CYNS14g==}
+  '@rspress/shared@2.0.15':
+    resolution: {integrity: sha512-o8aYwEzNuTmWnmKe91ntPv+34u3RbtAe+rcK9XC5MANOlgncwOaCs3bUa8/B1/llwyLoNgrpi+VB9bEiU11ZRQ==}
 
   '@rushstack/node-core-library@5.23.1':
     resolution: {integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==}
@@ -1646,8 +1646,8 @@ packages:
   '@rushstack/ts-command-line@5.3.10':
     resolution: {integrity: sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==}
 
-  '@savvy-web/bundler@0.11.0':
-    resolution: {integrity: sha512-d6uBICQgvsRv/Ybpl6ro/QFx5GTTPS6U24Cb5iIJnY7d1s/1JD+RCCLsXi+f5c04wBFeQe8B3Oslk6A3jhnrlw==}
+  '@savvy-web/bundler@0.11.2':
+    resolution: {integrity: sha512-2at7loxxkIP63mFCWD1aBQje0g9EUzrvYrMoPyCSbn+z4rCZ+5HiCCD2mi4BWbGopcy6JtK5IOLrQblHbvUGJw==}
     peerDependencies:
       '@types/node': ^26.0.0
       '@types/react': ^19.2.0
@@ -1666,29 +1666,29 @@ packages:
       react-dom:
         optional: true
 
-  '@savvy-web/cli@1.3.2':
-    resolution: {integrity: sha512-RKzzXVfNkE/XVDRYzc1zlSgLFBSQBEqHYpU0zkW3yN09QaA1KNXHw+ivNlbR7mjaHclYStzNq7fqIPm/UTCXSw==}
+  '@savvy-web/cli@1.3.4':
+    resolution: {integrity: sha512-+ZiHXjCiS5QHZtDAaxRlz7w/eiuwu7Q710adWcUUT6hdhQP3mWx3C3+neZvk2C9CgLYkSLX0HOBUjB3EJedjAw==}
     hasBin: true
 
-  '@savvy-web/mcp@1.3.2':
-    resolution: {integrity: sha512-XvDV90gGa/7a3KCwQQ1crpTh9hLZO0T1AU3EK1FEjC8UD/XQP6pGIYE/oPV1NL4Ve9afakK/gDAMvK2NjALGXQ==}
+  '@savvy-web/mcp@1.3.4':
+    resolution: {integrity: sha512-Oemf5C5Oydeof6jBPtrz3EqWn6OofEMp3aUN2Z511lSUKaFpFo379jusd2KPUYSWRJNIpsqDnUi9Mbs8I277zQ==}
     hasBin: true
 
-  '@savvy-web/silk-effects@1.5.0':
-    resolution: {integrity: sha512-bqW6Ubb7/AZ24xL/jY3H+PFrd+TDQozrvLZqxIOyX6rJv86+NN+e5A46vhoQ7mGiwg6FGXvUj+nsQzDrU2LDwA==}
+  '@savvy-web/silk-effects@1.5.1':
+    resolution: {integrity: sha512-dPSzT8nd2YbG39Ow+OaWwv6dAl5b7aBeORjVRh64wcUiWPnacmShpkUmduWEUXpbU8CrzBo9IjtJ8a9DrGQoVA==}
     peerDependencies:
       '@effect/platform': '>=0.96.0'
       effect: '>=3.21.0'
 
-  '@savvy-web/silk@1.3.2':
-    resolution: {integrity: sha512-10OZkS/TjXGKvkP+I6pNOs1qyUtuR3zVrxD11H/D1mma/3JbLNu1Uyf5lTpbEuo/b1js5xpwRCWBqdXONreXQQ==}
+  '@savvy-web/silk@1.3.4':
+    resolution: {integrity: sha512-mjNO3WCUFGK9nP9eEtgv7h1hD4oYC6cRbVe/g0/4CNaEm7LeyEodrs/p15qGZuoqkOsCWkOzdVu81tpGxTgi5w==}
     peerDependencies:
-      '@biomejs/biome': 2.4.16
+      '@biomejs/biome': ~2.5.0
       '@changesets/cli': ^2.31.0
       '@commitlint/cli': ^21.0.1
       '@commitlint/config-conventional': ^21.0.2
-      '@savvy-web/cli': 1.3.2
-      '@savvy-web/mcp': 1.3.2
+      '@savvy-web/cli': 1.3.4
+      '@savvy-web/mcp': 1.3.4
       '@types/node': ^26.0.0
       '@typescript/native-preview': ^7.0.0-dev.20260612.1
       commitizen: ^4.3.0
@@ -1702,47 +1702,47 @@ packages:
       '@biomejs/biome':
         optional: true
 
-  '@savvy-web/tsdown-plugins@0.11.0':
-    resolution: {integrity: sha512-6LRCrkSyjebMbUAGOpx0AAzBEVDO4ySR7H+GoM35coSQcL9G/qU6oItOE1VGJ10WNVdMkUyW/fwU7od8cy7+JQ==}
+  '@savvy-web/tsdown-plugins@0.11.2':
+    resolution: {integrity: sha512-N1JJefs2uPvAhJzxshavZUVVQunhaU72nIpUJlKOK8ddY+Mkad8p+LCUxuhOfCV8aGvVUTgvc24+aFky+babxg==}
     peerDependencies:
       effect: '>=3.21.0'
 
-  '@shikijs/core@4.2.0':
-    resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
+  '@shikijs/core@4.3.0':
+    resolution: {integrity: sha512-EooU3i9F6IAE8kEu+AnGf9DFZWkQBZ+hJn3tLVbsH+61mtQiva5biai66fAA6nvFPXkLgvrh7BrR7YcJU83xQQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-javascript@4.2.0':
-    resolution: {integrity: sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==}
+  '@shikijs/engine-javascript@4.3.0':
+    resolution: {integrity: sha512-hTv/KiFf2tpiqlACPiztGGurEARWIutB8YUhcrA1pUC7VzzwKO+g5crUocrLztrZ5ro5Z4hbXg7bYclETn3gSQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@4.2.0':
-    resolution: {integrity: sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==}
+  '@shikijs/engine-oniguruma@4.3.0':
+    resolution: {integrity: sha512-1vMdN3gHfnKfLYwecUI2ITJI4RhHt96xEaJumVn7Heb0IlJ8WQMIH0Voak+2j22BpSNKdnOfB/pCTPnPm2gq7A==}
     engines: {node: '>=20'}
 
-  '@shikijs/langs@4.2.0':
-    resolution: {integrity: sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==}
+  '@shikijs/langs@4.3.0':
+    resolution: {integrity: sha512-rnlqFbBRSys9bT4gl/5rw9RnS0W/I84ZldXPkO7cvlEMoV85TyF/aU01N7/NbSR776RNLjrJKjfFUXJR6wN1Cg==}
     engines: {node: '>=20'}
 
-  '@shikijs/primitive@4.2.0':
-    resolution: {integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==}
+  '@shikijs/primitive@4.3.0':
+    resolution: {integrity: sha512-CPkz64PTa5diRW1ggzMZH9VM/du4RNChYgVtgqrFcgruvIybmCvySv8GkiHSczUHXYuuR8TdKEwFx+UnZMpgdg==}
     engines: {node: '>=20'}
 
-  '@shikijs/rehype@4.2.0':
-    resolution: {integrity: sha512-ST3EWye/dwF1gWskczJNBnwFtDzEQ9ceytXZtyc/GfwR5V0qJrkoSGZO55O3SAKDDsXkTDcsfwd9pVe7ROlAHg==}
+  '@shikijs/rehype@4.3.0':
+    resolution: {integrity: sha512-1kk1N9scCNHeAtJICq0Me5rUxawKN+aGIlm8PZZ68zr4unYPnD3goHZ+HyPwSwbsRkT/OXkcY1JifKBH/FG88g==}
     engines: {node: '>=20'}
 
-  '@shikijs/themes@4.2.0':
-    resolution: {integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==}
+  '@shikijs/themes@4.3.0':
+    resolution: {integrity: sha512-Avgt05YiT+Y3prjIc9lmQxhJzHBcCfR6cjiFW4OyaMBbt2A6trX5rfjUzx+Vj/mE9qpArYjatnqo9XPjQNW/AQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/twoslash@4.2.0':
-    resolution: {integrity: sha512-PG/F0tMyt4zAvHVBL7Ehtk/ZpI2Rq3PwaXRYJaOO41eIK/iV9GOO/20jZhQkScOdcP6aFwHC2/x/GxmeR4tMlA==}
+  '@shikijs/twoslash@4.3.0':
+    resolution: {integrity: sha512-9tM/GWduKcWCU2jJIUqJZBxnyX/6iXtWov5rWmqcTnokHWIOxBL6nktx+HuzqB7/v3ApTahKT/TfRqBl+mFsOQ==}
     engines: {node: '>=20'}
     peerDependencies:
       typescript: '>=5.5.0'
 
-  '@shikijs/types@4.2.0':
-    resolution: {integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==}
+  '@shikijs/types@4.3.0':
+    resolution: {integrity: sha512-oc8b9U2SYvofKZk8e/737nIX0qwf6eV2vHFATeObAu7r+mUVpLs8Re0BmVkIjAWAYgkmG/CzLNo7rzuBzRu/wQ==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -1781,33 +1781,33 @@ packages:
     peerDependencies:
       tsdown: 0.22.3
 
-  '@turbo/darwin-64@2.9.18':
-    resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
+  '@turbo/darwin-64@2.10.0':
+    resolution: {integrity: sha512-EwvHThXzpY0KGd1/NAmuewI5D+aVa3Rl/OlxE36yfjUKb/+ySrfJrSlEFt8aD1OXwnnaHnQnPKHFndor0Zxlsg==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.18':
-    resolution: {integrity: sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==}
+  '@turbo/darwin-arm64@2.10.0':
+    resolution: {integrity: sha512-9d2fTyyG0lf5Wq1bwJA9qUaeecViMkLcdctWaMMmCkxZ/JqypmqOwK3W6vmejeKVgkr06gSoiX8bD+xN5Jpxcg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.18':
-    resolution: {integrity: sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==}
+  '@turbo/linux-64@2.10.0':
+    resolution: {integrity: sha512-sZBtjMuufitanjzi6UssoUpJMnnPlLMcdcJj3m3ptNsSq31Xh7MnjhwA5nWvLDTfEFg8GPcbYFXMo8vSdKRfqQ==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.18':
-    resolution: {integrity: sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==}
+  '@turbo/linux-arm64@2.10.0':
+    resolution: {integrity: sha512-vkq/Z8R+1DQ+kifWFa810IjRy2NNBVvha3cg9sWA3nFh6nnGrHSMnnJKrzH7c/No9kq4Jb55Ru44YKsCSBgrKg==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.18':
-    resolution: {integrity: sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==}
+  '@turbo/windows-64@2.10.0':
+    resolution: {integrity: sha512-CRUEguLWxFQHptYZS7HjPhNhAFawfea07iR+xAQ5e4klgLrPCMdexBkXwSCwOxqTFknJ7RZFN3gOaADsw+Gttg==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.18':
-    resolution: {integrity: sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==}
+  '@turbo/windows-arm64@2.10.0':
+    resolution: {integrity: sha512-dVHGaf9F8twzgibcBqKoADT/LLqf9++jDb+hq/LPWWaOmRpp4M+/pVOm7vy4z9D++xg8eaxWLT0+wQxFwhYu9A==}
     cpu: [arm64]
     os: [win32]
 
@@ -1869,8 +1869,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@26.0.0':
-    resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
+  '@types/node@26.0.1':
+    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1892,50 +1892,50 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260624.1':
-    resolution: {integrity: sha512-g8CqDkYCHTCYdhBHXs5cMraBurOS+KrcMFxE0SsaKZoI6Tnp+le1aWvxUBbzNKJYyThHJqb/1mLopzEJxJCuKA==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260626.1':
+    resolution: {integrity: sha512-VDPHf8RZRzsBH6cgArK1u9sH8MODMNkvkNczEt1EXpOLfZeplIhcpKld5Zc9Da8/S9YB4768rjfBkdFokxBu+Q==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260624.1':
-    resolution: {integrity: sha512-P00JVvSV90eioYDuINAKmOSA8yhFTWLq6RvS5lrCfUuDlcgr2kSOgZAfFHIksHBVz6ZXpAXpa0dHPmc5SJ3Ymw==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260626.1':
+    resolution: {integrity: sha512-bi7iQZe2A90cFJ3EQnigezEI7F0e5vX6E/QUGluQ1mKZmcbbQCdAwDMDQFV8Z6w3xNrk9AYyNQbvq0DtzJX46w==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260624.1':
-    resolution: {integrity: sha512-cppM2yTZ/Gd1hOXy8NEJcUBxJ0O0zl9CU3OU1ZWZ/OHWWX/ukEzCCr94SUwJhjIWOylBCpIYkrvYoTwxNa94XQ==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260626.1':
+    resolution: {integrity: sha512-/iptuCYiucdY0HK0nE5ydRjIx0KOf3AY7fieRaQHA4X9/s4ey37rc/58aBX3dtx0x2EhlzpXT5f0ikYY65Zynw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260624.1':
-    resolution: {integrity: sha512-eWHELvfQMkVRjafMd+3ATgM9p9yAergJaM4AOY8AekCNWnHFwUrp/ohh+ryyMUIqque5jjb/kuTiOiGj728I2Q==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260626.1':
+    resolution: {integrity: sha512-ilB0Ew5GWLrqMklNVrMdCEyNePypoEMnd4l5aUopnDRebgtXmtu0RE2GDl9LOTZ1BwlbXsuYAkEHt18Ta25hxg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260624.1':
-    resolution: {integrity: sha512-FaB8rS+rKYz4nDrEsHsF3b4cn7eCKCYroMJReA375OuQ6PHcmCNQ6QlVetA0dfFBxTTgejmoKyfw9xgAA5P4Yw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260626.1':
+    resolution: {integrity: sha512-4o80l1+RoJLkR1G4KOZjTYN1yOAGbq0K2CAP0zF35MPnD8O559Tw8OMuYA+XPpEFE0fkb7mmcxL8J9cxM/kAbw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260624.1':
-    resolution: {integrity: sha512-BgkqbCmSHDb5UxqWaFlFFJ/DHNT3lEUO4W8627ap6+QthJZuXk2imiHAX3PgYXC6en9fLLyR6jjcseAa4CCshg==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260626.1':
+    resolution: {integrity: sha512-xHxewRWY74zJnwt4bj+Kdf6Owfs6L0Fbggb37psSa6CvofqcvSI3AyuwiBNjC0T8Eb/d/BMMXttbPJ4XXqMpXQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260624.1':
-    resolution: {integrity: sha512-WaZ+ue63NgB2j/lqjirfevh/TqcsCxSqnKhGGiRnlxHyYIBcoq+x7KngyEnyGIaywJE1PcFeXA+2EMSIPlSEiQ==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260626.1':
+    resolution: {integrity: sha512-Iuf5nqTY4m5kxEvraDpieEf0XS6gDdjBBkw3g74pseznhpMeDFzgRvVCbSaf2pdjBNGugZbiBDVTEOclmD9cjA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260624.1':
-    resolution: {integrity: sha512-ogwfNo1xuAutOF8RbTCo3Ut0q/65u2ucOeHizi6O14q+3vnelNS+u8qVC2QWXubMcwtuN5E9cbfPslvGC4kdwA==}
+  '@typescript/native-preview@7.0.0-dev.20260626.1':
+    resolution: {integrity: sha512-2RC5omeJPqWKebi5zM3nkMSrTpKpq2zLB3SfceqmFZY3vMCXtIJSE6IpA/AszlKQmNcbT/kWscmgE/PXEvnguQ==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -2072,11 +2072,12 @@ packages:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
-  api-extractor-llms@0.1.0:
-    resolution: {integrity: sha512-K+0zrIqaXl6ffDGGUkm85pM3bhWsgtUCF+GlK+/mUo3x/P/9i5XhmmsUKFrFcD2IqP5Jk3SqALhaLd+3itojIQ==}
+  api-extractor-llms@0.2.0:
+    resolution: {integrity: sha512-6jUoKlc1rbOTMCxXFhKEP8kGTAC29jBQ4wujHG80T8KQcVEWXV6eG4xVAGaObb3dhuyqAm6MZu48Vl2UphozBQ==}
+    engines: {node: '>=24.11.0'}
     peerDependencies:
       '@types/node': ^26.0.0
-      '@typescript/native-preview': ^7.0.0-dev.20260513.1
+      '@typescript/native-preview': ^7.0.0-dev.20260612.1
       typescript: ^6.0.0
 
   argparse@1.0.10:
@@ -2136,8 +2137,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.38:
-    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
+  baseline-browser-mapping@2.10.40:
+    resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2875,8 +2876,8 @@ packages:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.5.2:
@@ -3044,6 +3045,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-from-package@0.0.0:
@@ -3658,8 +3660,8 @@ packages:
     engines: {node: '>=22.22.1'}
     hasBin: true
 
-  listr2@10.2.1:
-    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
+  listr2@10.2.2:
+    resolution: {integrity: sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==}
     engines: {node: '>=22.13.0'}
 
   locate-path@5.0.0:
@@ -4141,8 +4143,8 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
-  node-releases@2.0.48:
-    resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
+  node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
 
   non-layered-tidy-tree-layout@2.0.2:
@@ -4348,8 +4350,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -4361,8 +4363,8 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
     engines: {node: '>= 0.6'}
 
   raw-body@3.0.2:
@@ -4574,8 +4576,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.1.2:
-    resolution: {integrity: sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==}
+  rolldown@1.1.3:
+    resolution: {integrity: sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4583,8 +4585,8 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  rspress-plugin-api-extractor@0.3.0:
-    resolution: {integrity: sha512-+X+l+G5IaYf/DzYYh/A2xplYuRB/HzWEHVbajlMwkrN806efiXZKm+6T6JQRzT8oIJO1xPmugtRfetzowTCKjQ==}
+  rspress-plugin-api-extractor@0.3.2:
+    resolution: {integrity: sha512-7wtXVZ5j7KSPctn1EtdtfTZor7Qfr+ulQzYc0md4L27ZM1hqFYkw0THp3Mka86lffdFe/DzVAkGMNRvul79+aA==}
     engines: {node: '>=24.11.0'}
     peerDependencies:
       '@rspress/core': ^2.0.0
@@ -4697,12 +4699,12 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
-  shiki@4.2.0:
-    resolution: {integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==}
+  shiki@4.3.0:
+    resolution: {integrity: sha512-NKKjWzR6LIGL3sXBrWDw9sDS9cxx42/DkysaNqJEeOWE8Kix5gpak0bc00OfDVEO4oyXSyz8+aRaqKoBD1yo7A==}
     engines: {node: '>=20'}
 
   side-channel-list@1.0.1:
@@ -5011,8 +5013,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.9.18:
-    resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
+  turbo@2.10.0:
+    resolution: {integrity: sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw==}
     hasBin: true
 
   twoslash-protocol@0.3.9:
@@ -5584,7 +5586,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.0(@types/node@26.0.0)':
+  '@changesets/cli@2.31.0(@types/node@26.0.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -5600,7 +5602,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@26.0.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@26.0.1)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -5705,12 +5707,12 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@commitlint/cli@21.1.0(@types/node@26.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
+  '@commitlint/cli@21.1.0(@types/node@26.0.1)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-conventional': 21.1.0
       '@commitlint/format': 21.1.0
       '@commitlint/lint': 21.1.0
-      '@commitlint/load': 21.1.0(@types/node@26.0.0)(typescript@6.0.3)
+      '@commitlint/load': 21.1.0(@types/node@26.0.1)(typescript@6.0.3)
       '@commitlint/read': 21.1.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 21.1.0
       tinyexec: 1.2.4
@@ -5755,14 +5757,14 @@ snapshots:
       '@commitlint/rules': 21.1.0
       '@commitlint/types': 21.1.0
 
-  '@commitlint/load@21.1.0(@types/node@26.0.0)(typescript@6.0.3)':
+  '@commitlint/load@21.1.0(@types/node@26.0.1)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 21.1.0
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.1.0
       '@commitlint/types': 21.1.0
       cosmiconfig: 9.0.2(typescript@6.0.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.0.0)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.0.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
       es-toolkit: 1.48.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -6040,12 +6042,12 @@ snapshots:
     dependencies:
       hono: 4.12.27
 
-  '@inquirer/external-editor@1.0.3(@types/node@26.0.0)':
+  '@inquirer/external-editor@1.0.3(@types/node@26.0.1)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@istanbuljs/schema@0.1.6': {}
 
@@ -6071,7 +6073,7 @@ snapshots:
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
       find-up: 4.1.0
       fs-extra: 8.1.0
 
@@ -6120,23 +6122,23 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
 
-  '@microsoft/api-extractor-model@7.33.8(@types/node@26.0.0)':
+  '@microsoft/api-extractor-model@7.33.8(@types/node@26.0.1)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@26.0.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@26.0.1)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.58.9(@types/node@26.0.0)':
+  '@microsoft/api-extractor@7.58.9(@types/node@26.0.1)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.8(@types/node@26.0.0)
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@26.0.1)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@26.0.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@26.0.1)
       '@rushstack/rig-package': 0.7.3
-      '@rushstack/terminal': 0.24.0(@types/node@26.0.0)
-      '@rushstack/ts-command-line': 5.3.10(@types/node@26.0.0)
+      '@rushstack/terminal': 0.24.0(@types/node@26.0.1)
+      '@rushstack/ts-command-line': 5.3.10(@types/node@26.0.1)
       diff: 8.0.4
       minimatch: 10.2.5
       resolve: 1.22.12
@@ -6202,7 +6204,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
@@ -6306,53 +6308,53 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@rolldown/binding-android-arm64@1.1.2':
+  '@rolldown/binding-android-arm64@1.1.3':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.2':
+  '@rolldown/binding-darwin-arm64@1.1.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.2':
+  '@rolldown/binding-darwin-x64@1.1.3':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.2':
+  '@rolldown/binding-freebsd-x64@1.1.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.2':
+  '@rolldown/binding-linux-arm64-gnu@1.1.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.2':
+  '@rolldown/binding-linux-arm64-musl@1.1.3':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.2':
+  '@rolldown/binding-linux-s390x-gnu@1.1.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.2':
+  '@rolldown/binding-linux-x64-gnu@1.1.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.2':
+  '@rolldown/binding-linux-x64-musl@1.1.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.2':
+  '@rolldown/binding-openharmony-arm64@1.1.3':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.2':
+  '@rolldown/binding-wasm32-wasi@1.1.3':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.2':
+  '@rolldown/binding-win32-arm64-msvc@1.1.3':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.2':
+  '@rolldown/binding-win32-x64-msvc@1.1.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -6432,14 +6434,14 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
       '@rsbuild/core': 2.0.15
       '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
-      '@rspress/shared': 2.0.14
-      '@shikijs/rehype': 4.2.0
+      '@rspress/shared': 2.0.15
+      '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
       '@unhead/react': 2.1.15(react@19.2.7)
       body-scroll-lock: 4.0.0-beta.0
@@ -6467,7 +6469,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
       scroll-into-view-if-needed: 3.1.0
-      shiki: 4.2.0
+      shiki: 4.3.0
       unified: 11.0.5
       unist-util-remove: 4.0.0
       unist-util-visit: 5.1.0
@@ -6482,20 +6484,20 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@rspress/plugin-sitemap@2.0.14(@rspress/core@2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rspress/plugin-sitemap@2.0.15(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))':
     dependencies:
-      '@rspress/core': 2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
-  '@rspress/shared@2.0.14':
+  '@rspress/shared@2.0.15':
     dependencies:
       '@rsbuild/core': 2.0.15
-      '@shikijs/rehype': 4.2.0
+      '@shikijs/rehype': 4.3.0
       unified: 11.0.5
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rushstack/node-core-library@5.23.1(@types/node@26.0.0)':
+  '@rushstack/node-core-library@5.23.1(@types/node@26.0.1)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -6506,43 +6508,43 @@ snapshots:
       resolve: 1.22.12
       semver: 7.7.4
     optionalDependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@26.0.0)':
+  '@rushstack/problem-matcher@0.2.1(@types/node@26.0.1)':
     optionalDependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@rushstack/rig-package@0.7.3':
     dependencies:
       jju: 1.4.0
       resolve: 1.22.12
 
-  '@rushstack/terminal@0.24.0(@types/node@26.0.0)':
+  '@rushstack/terminal@0.24.0(@types/node@26.0.1)':
     dependencies:
-      '@rushstack/node-core-library': 5.23.1(@types/node@26.0.0)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@26.0.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@26.0.1)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@26.0.1)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
-  '@rushstack/ts-command-line@5.3.10(@types/node@26.0.0)':
+  '@rushstack/ts-command-line@5.3.10(@types/node@26.0.1)':
     dependencies:
-      '@rushstack/terminal': 0.24.0(@types/node@26.0.0)
+      '@rushstack/terminal': 0.24.0(@types/node@26.0.1)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
 
-  '@savvy-web/bundler@0.11.0(36acce83ee6775ca598bc1f62f00e2b5)':
+  '@savvy-web/bundler@0.11.2(e2c984c7d84e397a75a7695d0ac22192)':
     dependencies:
-      '@savvy-web/tsdown-plugins': 0.11.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.0)(effect@3.21.4)
+      '@savvy-web/tsdown-plugins': 0.11.2(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.1)(effect@3.21.4)
       '@tsdown/exe': 0.22.3(tsdown@0.22.3)
-      '@types/node': 26.0.0
-      '@typescript/native-preview': 7.0.0-dev.20260624.1
+      '@types/node': 26.0.1
+      '@typescript/native-preview': 7.0.0-dev.20260626.1
       effect: 3.21.4
-      rolldown: 1.1.2
-      tsdown: 0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260624.1)(tsx@4.22.4)(typescript@6.0.3)
+      rolldown: 1.1.3
+      tsdown: 0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260626.1)(tsx@4.22.4)(typescript@6.0.3)
       typescript: 6.0.3
     optionalDependencies:
       '@types/react': 19.2.17
@@ -6567,7 +6569,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@savvy-web/cli@1.3.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
+  '@savvy-web/cli@1.3.4(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
     dependencies:
       '@effect/cli': 0.75.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/cluster': 0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -6575,7 +6577,7 @@ snapshots:
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
-      '@savvy-web/silk-effects': 1.5.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      '@savvy-web/silk-effects': 1.5.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
       jsonc-effect: 0.2.1(effect@3.21.4)
       workspaces-effect: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
@@ -6590,7 +6592,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/mcp@1.3.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
+  '@savvy-web/mcp@1.3.4(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
     dependencies:
       '@effect/cluster': 0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/platform': 0.96.2(effect@3.21.4)
@@ -6598,7 +6600,7 @@ snapshots:
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@savvy-web/silk-effects': 1.5.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      '@savvy-web/silk-effects': 1.5.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
       fuse.js: 7.4.2
       workspaces-effect: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
@@ -6612,7 +6614,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/silk-effects@1.5.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)':
+  '@savvy-web/silk-effects@1.5.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/config': 3.1.4
@@ -6629,7 +6631,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
       semver-effect: 0.2.1(effect@3.21.4)
-      shell-quote: 1.8.4
+      shell-quote: 1.9.0
       sort-package-json: 4.0.0
       tinyglobby: 0.2.17
       unified: 11.0.5
@@ -6643,36 +6645,36 @@ snapshots:
       - encoding
       - supports-color
 
-  '@savvy-web/silk@1.3.2(2ba4e64278962102559ddd9ad7b767cd)':
+  '@savvy-web/silk@1.3.4(eb764a782732e619ef27a7ba08f4864d)':
     dependencies:
-      '@changesets/cli': 2.31.0(@types/node@26.0.0)
-      '@commitlint/cli': 21.1.0(@types/node@26.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
+      '@changesets/cli': 2.31.0(@types/node@26.0.1)
+      '@commitlint/cli': 21.1.0(@types/node@26.0.1)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
       '@commitlint/config-conventional': 21.1.0
       '@effect/platform': 0.96.2(effect@3.21.4)
-      '@savvy-web/cli': 1.3.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
-      '@savvy-web/mcp': 1.3.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
-      '@savvy-web/silk-effects': 1.5.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
-      '@types/node': 26.0.0
-      '@typescript/native-preview': 7.0.0-dev.20260624.1
-      commitizen: 4.3.2(@types/node@26.0.0)(typescript@6.0.3)
+      '@savvy-web/cli': 1.3.4(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
+      '@savvy-web/mcp': 1.3.4(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
+      '@savvy-web/silk-effects': 1.5.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      '@types/node': 26.0.1
+      '@typescript/native-preview': 7.0.0-dev.20260626.1
+      commitizen: 4.3.2(@types/node@26.0.1)(typescript@6.0.3)
       effect: 3.21.4
       husky: 9.1.7
       lint-staged: 17.0.8
       markdownlint-cli2: 0.22.1
       markdownlint-cli2-formatter-codequality: 0.0.7(markdownlint-cli2@0.22.1)
       semver: 7.8.5
-      turbo: 2.9.18
+      turbo: 2.10.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@savvy-web/tsdown-plugins@0.11.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.0)(effect@3.21.4)':
+  '@savvy-web/tsdown-plugins@0.11.2(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.1)(effect@3.21.4)':
     dependencies:
       '@changesets/get-release-plan': 4.0.16
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@manypkg/get-packages': 1.1.3
-      '@microsoft/api-extractor': 7.58.9(@types/node@26.0.0)
+      '@microsoft/api-extractor': 7.58.9(@types/node@26.0.1)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
       deep-equal: 2.2.3
@@ -6692,58 +6694,58 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@shikijs/core@4.2.0':
+  '@shikijs/core@4.3.0':
     dependencies:
-      '@shikijs/primitive': 4.2.0
-      '@shikijs/types': 4.2.0
+      '@shikijs/primitive': 4.3.0
+      '@shikijs/types': 4.3.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@4.2.0':
+  '@shikijs/engine-javascript@4.3.0':
     dependencies:
-      '@shikijs/types': 4.2.0
+      '@shikijs/types': 4.3.0
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
-  '@shikijs/engine-oniguruma@4.2.0':
+  '@shikijs/engine-oniguruma@4.3.0':
     dependencies:
-      '@shikijs/types': 4.2.0
+      '@shikijs/types': 4.3.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@4.2.0':
+  '@shikijs/langs@4.3.0':
     dependencies:
-      '@shikijs/types': 4.2.0
+      '@shikijs/types': 4.3.0
 
-  '@shikijs/primitive@4.2.0':
+  '@shikijs/primitive@4.3.0':
     dependencies:
-      '@shikijs/types': 4.2.0
+      '@shikijs/types': 4.3.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/rehype@4.2.0':
+  '@shikijs/rehype@4.3.0':
     dependencies:
-      '@shikijs/types': 4.2.0
+      '@shikijs/types': 4.3.0
       '@types/hast': 3.0.4
       hast-util-to-string: 3.0.1
-      shiki: 4.2.0
+      shiki: 4.3.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
 
-  '@shikijs/themes@4.2.0':
+  '@shikijs/themes@4.3.0':
     dependencies:
-      '@shikijs/types': 4.2.0
+      '@shikijs/types': 4.3.0
 
-  '@shikijs/twoslash@4.2.0(typescript@6.0.3)':
+  '@shikijs/twoslash@4.3.0(typescript@6.0.3)':
     dependencies:
-      '@shikijs/core': 4.2.0
-      '@shikijs/types': 4.2.0
+      '@shikijs/core': 4.3.0
+      '@shikijs/types': 4.3.0
       twoslash: 0.3.9(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@shikijs/types@4.2.0':
+  '@shikijs/types@4.3.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -6779,24 +6781,24 @@ snapshots:
       obug: 2.1.3
       semver: 7.8.5
       tinyexec: 1.2.4
-      tsdown: 0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260624.1)(tsx@4.22.4)(typescript@6.0.3)
+      tsdown: 0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260626.1)(tsx@4.22.4)(typescript@6.0.3)
 
-  '@turbo/darwin-64@2.9.18':
+  '@turbo/darwin-64@2.10.0':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.18':
+  '@turbo/darwin-arm64@2.10.0':
     optional: true
 
-  '@turbo/linux-64@2.9.18':
+  '@turbo/linux-64@2.10.0':
     optional: true
 
-  '@turbo/linux-arm64@2.9.18':
+  '@turbo/linux-arm64@2.10.0':
     optional: true
 
-  '@turbo/windows-64@2.9.18':
+  '@turbo/windows-64@2.10.0':
     optional: true
 
-  '@turbo/windows-arm64@2.9.18':
+  '@turbo/windows-arm64@2.10.0':
     optional: true
 
   '@tybys/wasm-util@0.10.3':
@@ -6812,7 +6814,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6859,7 +6861,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@26.0.0':
+  '@types/node@26.0.1':
     dependencies:
       undici-types: 8.3.0
 
@@ -6880,36 +6882,36 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260624.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260626.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260624.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260626.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260624.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260626.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260624.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260626.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260624.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260626.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260624.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260626.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260624.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260626.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260624.1':
+  '@typescript/native-preview@7.0.0-dev.20260626.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260624.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260624.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260624.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260624.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260624.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260624.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260624.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260626.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260626.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260626.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260626.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260626.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260626.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260626.1
 
   '@typescript/vfs@1.6.4(typescript@6.0.3)':
     dependencies:
@@ -6937,7 +6939,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -6953,7 +6955,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -6964,13 +6966,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -7063,12 +7065,12 @@ snapshots:
 
   ansis@4.3.1: {}
 
-  api-extractor-llms@0.1.0(@types/node@26.0.0)(@typescript/native-preview@7.0.0-dev.20260624.1)(typescript@6.0.3):
+  api-extractor-llms@0.2.0(@types/node@26.0.1)(@typescript/native-preview@7.0.0-dev.20260626.1)(typescript@6.0.3):
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.8(@types/node@26.0.0)
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@26.0.1)
       '@microsoft/tsdoc': 0.16.0
-      '@types/node': 26.0.0
-      '@typescript/native-preview': 7.0.0-dev.20260624.1
+      '@types/node': 26.0.1
+      '@typescript/native-preview': 7.0.0-dev.20260626.1
       typescript: 6.0.3
 
   argparse@1.0.10:
@@ -7118,7 +7120,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.38: {}
+  baseline-browser-mapping@2.10.40: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -7149,7 +7151,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.15.3
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -7167,10 +7169,10 @@ snapshots:
 
   browserslist@4.28.4:
     dependencies:
-      baseline-browser-mapping: 2.10.38
+      baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
       electron-to-chromium: 1.5.378
-      node-releases: 2.0.48
+      node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   buffer@5.7.1:
@@ -7308,17 +7310,17 @@ snapshots:
 
   commander@8.3.0: {}
 
-  commitizen@4.3.2(@types/node@26.0.0)(typescript@6.0.3):
+  commitizen@4.3.2(@types/node@26.0.1)(typescript@6.0.3):
     dependencies:
       cachedir: 2.4.0
-      cz-conventional-changelog: 3.3.0(@types/node@26.0.0)(typescript@6.0.3)
+      cz-conventional-changelog: 3.3.0(@types/node@26.0.1)(typescript@6.0.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
       find-root: 1.1.0
       fs-extra: 9.1.0
       glob: 7.2.3
-      inquirer: 8.2.7(@types/node@26.0.0)
+      inquirer: 8.2.7(@types/node@26.0.1)
       is-utf8: 0.2.1
       lodash: 4.18.1
       minimist: 1.2.8
@@ -7389,9 +7391,9 @@ snapshots:
     dependencies:
       layout-base: 1.0.2
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@26.0.0)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@26.0.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
       cosmiconfig: 9.0.2(typescript@6.0.3)
       jiti: 2.6.1
       typescript: 6.0.3
@@ -7420,16 +7422,16 @@ snapshots:
 
   cytoscape@3.34.0: {}
 
-  cz-conventional-changelog@3.3.0(@types/node@26.0.0)(typescript@6.0.3):
+  cz-conventional-changelog@3.3.0(@types/node@26.0.1)(typescript@6.0.3):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.2(@types/node@26.0.0)(typescript@6.0.3)
+      commitizen: 4.3.2(@types/node@26.0.1)(typescript@6.0.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 21.1.0(@types/node@26.0.0)(typescript@6.0.3)
+      '@commitlint/load': 21.1.0(@types/node@26.0.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -7890,7 +7892,7 @@ snapshots:
     dependencies:
       homedir-polyfill: 1.0.3
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
@@ -7919,8 +7921,8 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
-      range-parser: 1.2.1
+      qs: 6.15.3
+      range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
       serve-static: 2.2.1
@@ -8402,9 +8404,9 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inquirer@8.2.7(@types/node@26.0.0):
+  inquirer@8.2.7(@types/node@26.0.1):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@26.0.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@26.0.1)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -8717,14 +8719,14 @@ snapshots:
 
   lint-staged@17.0.8:
     dependencies:
-      listr2: 10.2.1
+      listr2: 10.2.2
       picomatch: 4.0.4
       string-argv: 0.3.2
       tinyexec: 1.2.4
     optionalDependencies:
       yaml: 2.9.0
 
-  listr2@10.2.1:
+  listr2@10.2.2:
     dependencies:
       cli-truncate: 5.2.0
       eventemitter3: 5.0.4
@@ -9610,7 +9612,7 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
-  node-releases@2.0.48: {}
+  node-releases@2.0.50: {}
 
   non-layered-tidy-tree-layout@2.0.2: {}
 
@@ -9807,8 +9809,9 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.15.2:
+  qs@6.15.3:
     dependencies:
+      es-define-property: 1.0.1
       side-channel: 1.1.1
 
   quansync@0.2.11: {}
@@ -9817,7 +9820,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  range-parser@1.2.1: {}
+  range-parser@1.3.0: {}
 
   raw-body@3.0.2:
     dependencies:
@@ -10100,7 +10103,7 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rolldown-plugin-dts@0.26.0(@typescript/native-preview@7.0.0-dev.20260624.1)(rolldown@1.1.2)(typescript@6.0.3):
+  rolldown-plugin-dts@0.26.0(@typescript/native-preview@7.0.0-dev.20260626.1)(rolldown@1.1.3)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2
@@ -10110,33 +10113,33 @@ snapshots:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.3
-      rolldown: 1.1.2
+      rolldown: 1.1.3
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260624.1
+      '@typescript/native-preview': 7.0.0-dev.20260626.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.1.2:
+  rolldown@1.1.3:
     dependencies:
       '@oxc-project/types': 0.137.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.2
-      '@rolldown/binding-darwin-arm64': 1.1.2
-      '@rolldown/binding-darwin-x64': 1.1.2
-      '@rolldown/binding-freebsd-x64': 1.1.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.2
-      '@rolldown/binding-linux-arm64-gnu': 1.1.2
-      '@rolldown/binding-linux-arm64-musl': 1.1.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.2
-      '@rolldown/binding-linux-s390x-gnu': 1.1.2
-      '@rolldown/binding-linux-x64-gnu': 1.1.2
-      '@rolldown/binding-linux-x64-musl': 1.1.2
-      '@rolldown/binding-openharmony-arm64': 1.1.2
-      '@rolldown/binding-wasm32-wasi': 1.1.2
-      '@rolldown/binding-win32-arm64-msvc': 1.1.2
-      '@rolldown/binding-win32-x64-msvc': 1.1.2
+      '@rolldown/binding-android-arm64': 1.1.3
+      '@rolldown/binding-darwin-arm64': 1.1.3
+      '@rolldown/binding-darwin-x64': 1.1.3
+      '@rolldown/binding-freebsd-x64': 1.1.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.3
+      '@rolldown/binding-linux-arm64-gnu': 1.1.3
+      '@rolldown/binding-linux-arm64-musl': 1.1.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.3
+      '@rolldown/binding-linux-s390x-gnu': 1.1.3
+      '@rolldown/binding-linux-x64-gnu': 1.1.3
+      '@rolldown/binding-linux-x64-musl': 1.1.3
+      '@rolldown/binding-openharmony-arm64': 1.1.3
+      '@rolldown/binding-wasm32-wasi': 1.1.3
+      '@rolldown/binding-win32-arm64-msvc': 1.1.3
+      '@rolldown/binding-win32-x64-msvc': 1.1.3
 
   router@2.2.0:
     dependencies:
@@ -10148,16 +10151,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rspress-plugin-api-extractor@0.3.0(faaf363626e1ec069cd26041faf1e463):
+  rspress-plugin-api-extractor@0.3.2(a0bd9bb2b4f856558ba95aaae869221b):
     dependencies:
       '@effect/platform': 0.96.2(effect@3.21.4)
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
-      '@microsoft/api-extractor-model': 7.33.8(@types/node@26.0.0)
-      '@rspress/core': 2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
-      '@shikijs/twoslash': 4.2.0(typescript@6.0.3)
-      api-extractor-llms: 0.1.0(@types/node@26.0.0)(@typescript/native-preview@7.0.0-dev.20260624.1)(typescript@6.0.3)
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@26.0.1)
+      '@rspress/core': 2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@shikijs/twoslash': 4.3.0(typescript@6.0.3)
+      api-extractor-llms: 0.2.0(@types/node@26.0.1)(@typescript/native-preview@7.0.0-dev.20260626.1)(typescript@6.0.3)
       clsx: 2.1.1
       effect: 3.21.4
       gray-matter: 4.0.3
@@ -10171,7 +10174,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-markdown: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       semver-effect: 0.2.1(effect@3.21.4)
-      shiki: 4.2.0
+      shiki: 4.3.0
       type-registry-effect: 1.0.0(84c3ad6b0fce19f3e4c842b196f23b5c)
       typescript: 6.0.3
       unist-util-visit: 5.1.0
@@ -10188,13 +10191,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  rspress-plugin-devkit@1.0.0(@rspress/core@2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
+  rspress-plugin-devkit@1.0.0(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
     dependencies:
-      '@rspress/core': 2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
       clsx: 2.1.1
       lodash-es: 4.18.1
       mdast-util-from-markdown: 2.0.3
@@ -10213,11 +10216,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rspress-plugin-mermaid@1.0.1(@rspress/core@2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
+  rspress-plugin-mermaid@1.0.1(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
     dependencies:
-      '@rspress/core': 2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       mermaid: 10.9.6
-      rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.14(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
+      rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -10285,7 +10288,7 @@ snapshots:
       mime-types: 3.0.2
       ms: 2.1.3
       on-finished: 2.4.1
-      range-parser: 1.2.1
+      range-parser: 1.3.0
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
@@ -10325,16 +10328,16 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.9.0: {}
 
-  shiki@4.2.0:
+  shiki@4.3.0:
     dependencies:
-      '@shikijs/core': 4.2.0
-      '@shikijs/engine-javascript': 4.2.0
-      '@shikijs/engine-oniguruma': 4.2.0
-      '@shikijs/langs': 4.2.0
-      '@shikijs/themes': 4.2.0
-      '@shikijs/types': 4.2.0
+      '@shikijs/core': 4.3.0
+      '@shikijs/engine-javascript': 4.3.0
+      '@shikijs/engine-oniguruma': 4.3.0
+      '@shikijs/langs': 4.3.0
+      '@shikijs/themes': 4.3.0
+      '@shikijs/types': 4.3.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
@@ -10585,7 +10588,7 @@ snapshots:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
-  tsdown@0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260624.1)(tsx@4.22.4)(typescript@6.0.3):
+  tsdown@0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260626.1)(tsx@4.22.4)(typescript@6.0.3):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -10595,8 +10598,8 @@ snapshots:
       import-without-cache: 0.4.0
       obug: 2.1.3
       picomatch: 4.0.4
-      rolldown: 1.1.2
-      rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260624.1)(rolldown@1.1.2)(typescript@6.0.3)
+      rolldown: 1.1.3
+      rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260626.1)(rolldown@1.1.3)(typescript@6.0.3)
       semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -10624,14 +10627,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.9.18:
+  turbo@2.10.0:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.18
-      '@turbo/darwin-arm64': 2.9.18
-      '@turbo/linux-64': 2.9.18
-      '@turbo/linux-arm64': 2.9.18
-      '@turbo/windows-64': 2.9.18
-      '@turbo/windows-arm64': 2.9.18
+      '@turbo/darwin-64': 2.10.0
+      '@turbo/darwin-arm64': 2.10.0
+      '@turbo/linux-64': 2.10.0
+      '@turbo/linux-arm64': 2.10.0
+      '@turbo/windows-64': 2.10.0
+      '@turbo/windows-arm64': 2.10.0
 
   twoslash-protocol@0.3.9: {}
 
@@ -10815,32 +10818,32 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.1.2
+      rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@26.0.1)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
       '@vitest/spy': 4.1.9
       '@vitest/utils': 4.1.9
       es-module-lexer: 2.1.0
-      expect-type: 1.3.0
+      expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
@@ -10850,10 +10853,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
       '@vitest/coverage-istanbul': 4.1.9(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
     transitivePeerDependencies:

--- a/website/docs/en/guide/console-modes.mdx
+++ b/website/docs/en/guide/console-modes.mdx
@@ -99,3 +99,30 @@ AgentPlugin({ console: { ci: "silent" } })
 // Draw the live progressive view on a human terminal
 AgentPlugin({ console: { human: "stream" } })
 ```
+
+## Per-run CLI override — `VITEST_AGENT_CONSOLE`
+
+For a one-off CLI run where you need to see raw console output (for example,
+when investigating a file flagged by `run_tests`'s `report.consoleLeaks`
+signal), set `VITEST_AGENT_CONSOLE` before running Vitest:
+
+```bash
+VITEST_AGENT_CONSOLE=passthrough pnpm test
+```
+
+This overrides the plugin's resolved console mode to `passthrough` for the
+active executor without touching the permanent config. An invalid value for the
+current executor slot warns to stderr and is ignored.
+
+`passthrough` is the only value valid for every executor slot. Other mode
+values (`stream`, `agent`, `silent`, `ci-annotations`) are slot-specific and
+behave the same as their config counterparts but applied per-run.
+
+### Where stray console output shows up
+
+| Surface | Sees stray `console.*` | Per-test attribution |
+| --- | --- | --- |
+| `run_tests` (MCP) | yes — `consoleLeaks` signal (counts + sample) | per file, per test where resolvable |
+| Human at a TTY | yes — Vitest's own `stdout \|` / `stderr \|` lines | yes (TTY only) |
+| Piped shell (default) | no — agent-shaped summary suppresses it | n/a |
+| Piped shell + `VITEST_AGENT_CONSOLE=passthrough` | yes — raw passthrough | no (raw, unlabeled) |

--- a/website/docs/en/guide/operating-as-an-agent.mdx
+++ b/website/docs/en/guide/operating-as-an-agent.mdx
@@ -24,10 +24,12 @@ from inside a session.
    There is no per-run coverage toggle in `run_tests`; it inherits your
    `vitest.config`. For isolated inspection use
    `vitest run <file> --coverage.enabled=false`.
-4. **Stray `console.log` is invisible through `run_tests`** — it null-routes
-   Vitest's stdout. Console behavior is set by the plugin's
-   [`console` matrix](/guide/console-modes), not by environment variables. Use
-   Vitest's native `--disableConsoleIntercept` to see intercepted output.
+4. **Stray `console.*` is surfaced by `run_tests` as a signal, not raw logs.**
+   The `ok` result carries `report.consoleLeaks` — writes by file with counts,
+   optional per-test attribution, and a truncated sample. `run_tests` still
+   null-routes Vitest's stdout; the signal captures what was printed without
+   forwarding raw log lines. To see raw output for a flagged file, run Vitest
+   on the CLI: `VITEST_AGENT_CONSOLE=passthrough pnpm test`.
 5. **Session attribution is recovered for you** from the environment the
    Claude Code plugin's SessionStart hook writes; you never set `VITEST_AGENT_*`
    vars by hand.
@@ -47,9 +49,9 @@ hook and recovered automatically. The only variables you might set yourself:
 | `VITEST_REPORTER_LOG_LEVEL` | Level of the diagnostic logger (separate from the console reporter) |
 | `VITEST_REPORTER_LOG_FILE` | File the diagnostic logger writes to |
 | `NO_COLOR` | Disables ANSI color in rendered output |
+| `VITEST_AGENT_CONSOLE` | Override the resolved console mode for the active executor on a CLI run (`passthrough` is the universally valid value across all executor slots). Useful when investigating a file flagged by `report.consoleLeaks`. An invalid value for the current slot warns to stderr and is ignored. |
 
-There is no environment variable that toggles coverage or changes the console
-mode — those are configuration, not environment.
+There is no environment variable that toggles coverage — that is configuration.
 
 ## Deeper references
 

--- a/website/package.json
+++ b/website/package.json
@@ -10,15 +10,15 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@rspress/core": "^2.0.14",
-		"@rspress/plugin-sitemap": "^2.0.14",
+		"@rspress/core": "^2.0.15",
+		"@rspress/plugin-sitemap": "^2.0.15",
 		"@types/node": "catalog:silk",
 		"@types/react": "catalog:silk",
 		"@types/react-dom": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"react": "catalog:silk",
 		"react-dom": "catalog:silk",
-		"rspress-plugin-api-extractor": "^0.3.0",
+		"rspress-plugin-api-extractor": "^0.3.2",
 		"rspress-plugin-mermaid": "^1.0.1"
 	}
 }


### PR DESCRIPTION
## What & why

Stray `console.*` output during a test run is a smell, but an agent driving
`run_tests` over MCP couldn't see it — the structured `AgentReport` carried no
console, and a piped shell collapsed everything to the agent summary. This was
the single biggest time-sink in a dogfooding session (#99).

This adds a **console-leak signal** to `run_tests` plus a CLI **escape hatch**.

### `consoleLeaks` on the `run_tests` report (always-on, ephemeral)

The `ok` report now carries an optional `consoleLeaks`:

```
consoleLeaks:
  total: 7
  byFile:
    - file: packages/x/foo.test.ts
      stdout: 5
      stderr: 2
      tests: ["leaks when fetching"]
      sample: "DEBUG cache miss for k…"   # first line, truncated
  truncated?: true                          # byFile capped at 25
```

It surfaces *where* stray output happened (per file, per test where
resolvable) with a truncated sample — without dumping raw logs. A one-line
`⚠ N stray console writes across M files (see consoleLeaks)` is added to the
markdown summary. No DB, no migration — per-run only.

### `VITEST_AGENT_CONSOLE` escape hatch

When the signal isn't enough, `VITEST_AGENT_CONSOLE=passthrough pnpm test`
overrides the plugin's resolved console mode for the active executor so raw
console reaches stdout. An invalid-for-slot value warns to stderr and is
ignored.

## Key design decision: task-tree walk, not `onConsoleLog`

Capture reads each task's `.logs` from `vitest.state.getFiles()` after the run.
An initial implementation used Vitest 4's typed `onConsoleLog` config hook —
**abandoned** because that hook is gated by `BaseReporter.shouldLog`, which the
auto-selected `silent: "passed-only"` agent reporter (Vitest 4.1+) skips for
passing tests *and* which `AgentPlugin` removes by stripping built-in console
reporters in agent mode. The result would have been `consoleLeaks` silently
`undefined` on every real MCP call. `task.logs` is populated by Vitest's
console interception independent of any reporter, so the walk survives the
strip. The e2e was what caught this — it runs a real spawn against an
`AgentPlugin` (`console: silent`) fixture and asserts a *passing* test's leaks
are captured.

## Changes by package

- **`@vitest-agent/sdk`** (minor): `ConsoleLeaks`/`ConsoleLeakFile` schema +
  optional `AgentReport.consoleLeaks`; `buildConsoleLeaks` aggregator,
  `collectConsoleLeakEntries` walk, `ConsoleLeakEntry`/`ConsoleLeakTask` types.
- **`@vitest-agent/mcp`** (minor): `run_tests` folds `consoleLeaks` into its
  report + markdown signal; real-spawn e2e under the stripped-reporter topology.
- **`@vitest-agent/plugin`** (minor): `VITEST_AGENT_CONSOLE` override.
- **Docs**: MCP patterns corpus + website (visibility matrix, env var); the
  now-stale "stray console.log is invisible through run_tests" claim corrected.

## Testing

- typecheck 20/20; feature suite 23/23 including the real-spawn e2e.
- New unit coverage: schema round-trip, aggregator (sort/cap/truncate/sample),
  task-tree walk, markdown signal (singular/plural/truncated `N+`), env override.

## Notes

- Two pre-existing commits rode along from the branch point: `chore: update
  deps` and `fix: export forgotten types flagged by API Extractor`.
- Reporter-path capture for the non-MCP `AgentReport` is deliberately deferred
  (low consumption; multi-project filtering). Spec/plan live in
  `docs/superpowers/`.
- Follow-ups (out of scope): `packages/mcp/CLAUDE.md` still says `run_tests`
  uses `spawnSync` (it's in-process `createVitest`); docs-site api-extractor
  snapshot may need regen for the new sdk exports.

Closes #99.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>
