### PR TITLE
chore: switch to independent per-package versioning

### DIFF
--- a/.changeset/brave-cranes-wander.md
+++ b/.changeset/brave-cranes-wander.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/cli": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/brave-dogs-leap.md
+++ b/.changeset/brave-dogs-leap.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/plugin": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/brave-foxes-dream.md
+++ b/.changeset/brave-foxes-dream.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/reporter": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/brave-owls-soar.md
+++ b/.changeset/brave-owls-soar.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/mcp": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From         | To      |
+| ------------------ | ------------- | ------- | ------------ | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.1      | ^1.0.1  |

--- a/.changeset/bright-jets-rise.md
+++ b/.changeset/bright-jets-rise.md
@@ -20,3 +20,7 @@ The tool's markdown output includes a one-line warning when leaks are present:
 ```
 
 No configuration is required. The signal is omitted entirely on runs with no stray output.
+
+## Maintenance
+
+- Removed the cross-package version drift check from the MCP server startup path. `vitest-agent-mcp` no longer compares its version against `@vitest-agent/sdk` at init and no longer writes a version drift warning to stderr. The `CURRENT_MCP_VERSION` constant remains exported for version introspection.

--- a/.changeset/bright-owls-leap.md
+++ b/.changeset/bright-owls-leap.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/cli": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From         | To      |
+| ------------------ | ------------- | ------- | ------------ | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.1      | ^1.0.1  |

--- a/.changeset/bright-ships-soar.md
+++ b/.changeset/bright-ships-soar.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sidecar-win32-x64": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From         | To      |
+| ------------------ | ------------- | ------- | ------------ | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.1      | ^1.0.1  |

--- a/.changeset/calm-trees-leap.md
+++ b/.changeset/calm-trees-leap.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/sidecar-darwin-arm64": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/clever-owls-laugh.md
+++ b/.changeset/clever-owls-laugh.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/ui": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From         | To      |
+| ------------------ | ------------- | ------- | ------------ | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.1      | ^1.0.1  |

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -20,21 +20,9 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"fixed": [
-		[
-			"@vitest-agent/cli",
-			"@vitest-agent/mcp",
-			"@vitest-agent/plugin",
-			"@vitest-agent/reporter",
-			"@vitest-agent/sdk",
-			"@vitest-agent/sidecar",
-			"@vitest-agent/sidecar-darwin-arm64",
-			"@vitest-agent/sidecar-linux-arm64",
-			"@vitest-agent/sidecar-linux-x64",
-			"@vitest-agent/sidecar-win32-x64",
-			"@vitest-agent/ui"
-		]
-	],
+	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+		"onlyUpdatePeerDependentsWhenOutOfRange": true
+	},
 	"ignore": ["playground", "docs"],
 	"privatePackages": {
 		"tag": true,

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,20 +22,20 @@
 	"updateInternalDependencies": "patch",
 	"fixed": [
 		[
+			"@vitest-agent/cli",
+			"@vitest-agent/mcp",
 			"@vitest-agent/plugin",
 			"@vitest-agent/reporter",
 			"@vitest-agent/sdk",
-			"@vitest-agent/ui",
-			"@vitest-agent/cli",
-			"@vitest-agent/mcp",
 			"@vitest-agent/sidecar",
 			"@vitest-agent/sidecar-darwin-arm64",
 			"@vitest-agent/sidecar-linux-arm64",
 			"@vitest-agent/sidecar-linux-x64",
-			"@vitest-agent/sidecar-win32-x64"
+			"@vitest-agent/sidecar-win32-x64",
+			"@vitest-agent/ui"
 		]
 	],
-	"ignore": ["playground"],
+	"ignore": ["playground", "docs"],
 	"privatePackages": {
 		"tag": true,
 		"version": true

--- a/.changeset/happy-cups-dream.md
+++ b/.changeset/happy-cups-dream.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sidecar-linux-x64": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From         | To      |
+| ------------------ | ------------- | ------- | ------------ | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.1      | ^1.0.1  |

--- a/.changeset/happy-foxes-ponder.md
+++ b/.changeset/happy-foxes-ponder.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/mcp": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/happy-wolves-fly.md
+++ b/.changeset/happy-wolves-fly.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sidecar": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From         | To      |
+| ------------------ | ------------- | ------- | ------------ | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.1      | ^1.0.1  |

--- a/.changeset/lucky-foxes-laugh.md
+++ b/.changeset/lucky-foxes-laugh.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/sidecar-win32-x64": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/mild-cups-wake.md
+++ b/.changeset/mild-cups-wake.md
@@ -17,3 +17,7 @@ An invalid value for the detected executor is silently ignored and a diagnostic 
 ## Bug Fixes
 
 `CoverageOptions` is now exported from the `@vitest-agent/plugin` entry point. The interface appears in `CoverageAnalyzer`'s public method signatures and was reachable through type inference but not directly importable. The package now reports zero API Extractor errors with no new suppressions.
+
+## Maintenance
+
+- Removed the cross-package version drift check from `AgentPlugin`. The plugin no longer compares its version against `@vitest-agent/sdk` and `@vitest-agent/reporter` at construction time and no longer writes a version drift warning to stderr. The `CURRENT_PLUGIN_VERSION` constant remains exported for version introspection.

--- a/.changeset/quiet-foxes-leap.md
+++ b/.changeset/quiet-foxes-leap.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/plugin": patch
+---
+
+## Dependencies
+
+| Dependency         | Type           | Action  | From         | To          |
+| ------------------ | -------------- | ------- | ------------ | ----------- |
+| @savvy-web/bundler | devDependency  | updated | ^0.11.1      | ^1.0.1      |

--- a/.changeset/quiet-llamas-listen.md
+++ b/.changeset/quiet-llamas-listen.md
@@ -1,0 +1,7 @@
+---
+"@vitest-agent/cli": patch
+---
+
+## Maintenance
+
+- Removed the cross-package version drift check from the CLI bin entrypoint. The `vitest-agent` CLI no longer compares its version against `@vitest-agent/sdk` at startup and no longer writes a version drift warning to stderr. The `CURRENT_CLI_VERSION` constant remains exported for version introspection.

--- a/.changeset/quiet-owls-dream.md
+++ b/.changeset/quiet-owls-dream.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sidecar-darwin-arm64": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From         | To      |
+| ------------------ | ------------- | ------- | ------------ | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.1      | ^1.0.1  |

--- a/.changeset/silver-cats-dance.md
+++ b/.changeset/silver-cats-dance.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/sidecar": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/silver-cups-rest.md
+++ b/.changeset/silver-cups-rest.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/sdk": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/silver-trees-laugh.md
+++ b/.changeset/silver-trees-laugh.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/sidecar-linux-arm64": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/swift-dogs-soar.md
+++ b/.changeset/swift-dogs-soar.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sidecar-linux-arm64": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From         | To      |
+| ------------------ | ------------- | ------- | ------------ | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.1      | ^1.0.1  |

--- a/.changeset/swift-trees-leap.md
+++ b/.changeset/swift-trees-leap.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/ui": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/wild-cups-fly.md
+++ b/.changeset/wild-cups-fly.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/sidecar-linux-x64": patch
----
-
-## Dependencies
-
-| Dependency         | Type          | Action  | From    | To      |
-| ------------------ | ------------- | ------- | ------- | ------- |
-| @savvy-web/bundler | devDependency | updated | ^0.11.0 | ^0.11.1 |

--- a/.changeset/wild-ships-fly.md
+++ b/.changeset/wild-ships-fly.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/reporter": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From         | To      |
+| ------------------ | ------------- | ------- | ------------ | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.1      | ^1.0.1  |

--- a/.changeset/wild-wolves-laugh.md
+++ b/.changeset/wild-wolves-laugh.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sdk": patch
+---
+
+## Dependencies
+
+| Dependency         | Type          | Action  | From         | To      |
+| ------------------ | ------------- | ------- | ------------ | ------- |
+| @savvy-web/bundler | devDependency | updated | ^0.11.1      | ^1.0.1  |

--- a/.claude/design/vitest-agent/architecture.md
+++ b/.claude/design/vitest-agent/architecture.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-03-20
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 90
 related:
   - ./components.md
@@ -61,7 +61,7 @@ workspace) and the `docs` documentation-site workspace at `website/`.
 | `plugin/` (file-based) | `plugin/` | Claude Code plugin distributed via the marketplace as `vitest-agent@spencerbeggs`. Hooks, the TDD orchestrator subagent, slash commands, sub-skill primitives, the MCP loader. |
 | `docs` | `website/` | RSPress 2.0 documentation site deployed to `vitest-agent.dev` via Cloudflare Pages. Generates per-package API reference from each package's API Extractor model. Private, versions independently, imports nothing from the runtime packages. See [./components/docs-site.md](./components/docs-site.md). |
 
-The seven npm workspaces release in lockstep. `@vitest-agent/plugin` declares `@vitest-agent/cli` and `@vitest-agent/mcp` as required workspace `peerDependencies` (alongside the host-supplied Vitest peers `vitest`, `@vitest/runner`, `@vitest/coverage-v8`, `@vitest/coverage-istanbul`); its regular workspace `dependencies` are `@vitest-agent/reporter` and `@vitest-agent/sdk` only. The cli / mcp peers are required, not optional — there is no `peerDependenciesMeta`. Declaring `@vitest-agent/plugin` still pulls in the whole `@vitest-agent/*` family for a published consumer: npm 7+ and pnpm (with this repo's `autoInstallPeers: true`) auto-install required peers, and a peer-installed package lands at the consumer's top level, so its bin resolves — a transitively-nested regular dependency's bin would not. `@vitest-agent/sidecar` reaches a consumer transitively through `@vitest-agent/cli`, along with its four per-platform binaries. All six non-SDK packages pin `@vitest-agent/sdk` at `workspace:*`. The four per-platform sidecar sub-packages are not counted among the seven primary workspaces — they carry only a prebuilt binary and an `os` / `cpu` declaration, and are published as `optionalDependencies` of `@vitest-agent/sidecar`.
+The seven npm workspaces version independently per package — there is no shared release train. `@vitest-agent/plugin` declares `@vitest-agent/cli` and `@vitest-agent/mcp` as required workspace `peerDependencies` at a `workspace:^` range (a caret range so a compatible minor bump to either peer does not force a major bump of the plugin), alongside the host-supplied Vitest peers `vitest`, `@vitest/runner`, `@vitest/coverage-v8`, `@vitest/coverage-istanbul`; its regular workspace `dependencies` are `@vitest-agent/reporter` and `@vitest-agent/sdk` only. The cli / mcp peers are required, not optional — there is no `peerDependenciesMeta`. Declaring `@vitest-agent/plugin` still pulls in the whole `@vitest-agent/*` family for a published consumer: npm 7+ and pnpm (with this repo's `autoInstallPeers: true`) auto-install required peers, and a peer-installed package lands at the consumer's top level, so its bin resolves — a transitively-nested regular dependency's bin would not. `@vitest-agent/sidecar` reaches a consumer transitively through `@vitest-agent/cli`, along with its four per-platform binaries. All six non-SDK packages pin `@vitest-agent/sdk` at `workspace:*`. The four per-platform sidecar sub-packages are not counted among the seven primary workspaces — they carry only a prebuilt binary and an `os` / `cpu` declaration, and are published as `optionalDependencies` of `@vitest-agent/sidecar`.
 
 The dependency direction between CLI and sidecar is noteworthy: `@vitest-agent/cli` depends on `@vitest-agent/sidecar` (to call `resolveSidecarBinaryPath`), not the reverse. The parent `@vitest-agent/sidecar` package has no workspace runtime dependencies — its only source file (`src/resolve-sidecar-binary-path.ts`) uses `createRequire` from `node:module` to resolve the per-platform package's bin path. The per-platform children declare `@vitest-agent/sdk` as their only workspace `devDependency`, bundled into the SEA at build time — each child's `src/bin.ts` imports `dispatch` from the dedicated `@vitest-agent/sdk/dispatch` entry point. The closing edge of the dependency graph is `@vitest-agent/sidecar-<platform> → @vitest-agent/sdk` (a true leaf), so there is no workspace dependency cycle: `pnpm install` issues no cyclic-dependency warning and `turbo boundaries` passes. `packages/sidecar/turbo.json` uses the normal topological task ordering (`^build:dev` / `^build:prod`) — the prior `dependsOn: []` cycle workaround is gone now that the cli→sidecar→cli edge no longer exists.
 
@@ -137,25 +137,7 @@ live in [./components/plugin-claude.md](./components/plugin-claude.md).
   test layer pairs. Domain shapes are Effect Schemas, re-exported from
   `@vitest-agent/sdk`. Zod is reserved for tRPC tool input validation in
   the MCP package.
-- **Lockstep release.** The seven npm packages share one version — a bump
-  to any one bumps all seven. The plugin declares `@vitest-agent/reporter`
-  and `@vitest-agent/sdk` as regular `dependencies` and `@vitest-agent/cli`
-  and `@vitest-agent/mcp` as required `peerDependencies`, so consumers
-  install only `@vitest-agent/plugin` and the rest arrives at the matching
-  version — the regular deps transitively, the required peers via npm 7+ /
-  pnpm auto-install. `@vitest-agent/sidecar` arrives through `@vitest-agent/cli`
-  along with its four per-platform binaries. The CLI and MCP packages are
-  peers rather than regular deps because the auto-installed peer lands at
-  the consumer's top level, so the `vitest-agent` and `vitest-agent-mcp`
-  bins resolve for the Claude Code plugin's hook scripts — a nested regular
-  dependency's bin would not. The
-  Claude Code plugin can
-  lag the npm packages. Runtime version sync is verifiable through
-  `process.env.__PACKAGE_VERSION__`, which `rslib-builder` inlines into
-  each package's bundle as a string at build time; an inlined-at-build
-  constant avoids a runtime `package.json` read and surfaces a mismatch
-  loudly when the invariant is broken (a hand-mixed install, a forgotten
-  lockstep release).
+- **Independent per-package release.** Each npm package versions on its own — changesets no longer pins the family to a single shared version. The plugin declares `@vitest-agent/reporter` and `@vitest-agent/sdk` as regular `dependencies` and `@vitest-agent/cli` and `@vitest-agent/mcp` as required `peerDependencies` (at `workspace:^`), so consumers install only `@vitest-agent/plugin` and the rest arrives — the regular deps transitively, the required peers via npm 7+ / pnpm auto-install. `@vitest-agent/sidecar` arrives through `@vitest-agent/cli` along with its four per-platform binaries. The CLI and MCP packages are peers rather than regular deps because the auto-installed peer lands at the consumer's top level, so the `vitest-agent` and `vitest-agent-mcp` bins resolve for the Claude Code plugin's hook scripts — a nested regular dependency's bin would not. The Claude Code plugin and `@vitest-agent/sidecar` likewise version independently. A release emits a per-package git tag `@vitest-agent/<pkg>@<version>` and one GitHub Release per package, not a single shared-version tag; the docs/deploy trigger keys on the plugin Release name containing `@vitest-agent/plugin`. Each package still inlines its own release version as `process.env.__PACKAGE_VERSION__` (via `rslib-builder` at build time) and re-exports it as a public `CURRENT_<PKG>_VERSION` constant, but nothing consumes those constants for a runtime cross-package check any more — see D36 in [./decisions.md](./decisions.md).
 - **One shared database, deterministic path.** `data.db` lives at
   `$XDG_DATA_HOME/vitest-agent/<workspaceKey>/data.db` (with the usual
   XDG fallback). The path is a function of workspace identity, not

--- a/.claude/design/vitest-agent/components/cli.md
+++ b/.claude/design/vitest-agent/components/cli.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-05-06
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 92
 related:
   - ../architecture.md
@@ -41,7 +41,7 @@ The bin is a utility-only surface: **MCP is the data path for test-landscape que
 
 `packages/cli/src/bin.ts`. The bin resolves `dbPath` via `resolveDataPath(process.cwd())` under `PathResolutionLive(projectDir) + NodeContext.layer`, then provides `CliLive(dbPath, logLevel, logFile)` to the `@effect/cli` `Command.run` effect. Defects print `formatFatalError(cause)` to stderr.
 
-Immediately before `Command.run`, the bin compares `CURRENT_CLI_VERSION` against `CURRENT_SDK_VERSION` and writes one stderr line on mismatch (`[@vitest-agent/cli] version drift: … Reinstall @vitest-agent/* packages so versions match.`). The check is observation-only — invocation continues, and the `"0.0.0"` dev-build sentinel skips it. `packages/cli/src/index.ts` exports `CURRENT_CLI_VERSION` (inlined from `process.env.__PACKAGE_VERSION__` via the package's `rslib.config.ts` `define`). The `doctor` subcommand is unrelated to this check — it covers database health, not cross-package version invariants. Integration coverage: `packages/cli/__test__/bin-version-drift.test.ts` mocks `CURRENT_SDK_VERSION` to assert the warning shape; see D36 in [../decisions.md](../decisions.md).
+`packages/cli/src/index.ts` exports `CURRENT_CLI_VERSION` (inlined from `process.env.__PACKAGE_VERSION__` via the package's `rslib.config.ts` `define`), part of the public API. Under the earlier lockstep design the bin compared it against `CURRENT_SDK_VERSION` before `Command.run` and warned on mismatch; that drift check (and its `bin-version-drift.test.ts` coverage) was removed with the move to independent per-package versioning, so the bin now runs straight into `Command.run`. The `doctor` subcommand covers database health, not cross-package version invariants. See D36 in [../decisions.md](../decisions.md).
 
 The top-level command tree is exactly three children, wired in `bin.ts`'s `withSubcommands`:
 

--- a/.claude/design/vitest-agent/components/docs-site.md
+++ b/.claude/design/vitest-agent/components/docs-site.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: documentation
 created: 2026-05-27
-updated: 2026-06-26
-last-synced: 2026-06-26
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 85
 related:
   - ../architecture.md
@@ -23,7 +23,7 @@ The user-facing documentation site for the whole `vitest-agent` family. An RSPre
 **Build entry:** `website/rspress.config.ts`
 **Internal dependencies:** none at runtime — it consumes the published packages' API Extractor models as build inputs, not as imports.
 
-The site is not one of the seven publishable packages and does not version in lockstep with them. Its own `package.json#version` is independent. It exists purely to render documentation; nothing in the runtime packages imports from it.
+The site is not one of the seven publishable packages; like every package in the family it versions independently, keyed off its own `package.json#version`. It exists purely to render documentation; nothing in the runtime packages imports from it.
 
 ## Information architecture
 
@@ -49,7 +49,7 @@ Two classes of generated artifact are deliberately gitignored (see the consolida
 
 The deploy pipeline is `.github/workflows/deploy-docs.yml`. It triggers on `release: published` and on manual `workflow_dispatch`.
 
-All `vitest-agent` packages release in lockstep from one commit sharing a single semver tag, but each package gets its own GitHub Release. To deploy exactly once per release rather than once per package, the workflow's `if` guard keys on the plugin package's Release — it checks that `github.event.release.name` contains `@vitest-agent/plugin`, a substring no other package name carries. The job checks out `main`, rebuilds the site from the committed snapshot db, and publishes `website/dist` to the Cloudflare Pages project named `vitest-agent` via `cloudflare/wrangler-action`.
+A changesets release from one version PR can publish several `@vitest-agent/*` packages at once, and each package gets its own GitHub Release at its own version. To deploy exactly once per release event rather than once per published package, the workflow's `if` guard keys on the plugin package's Release — it checks that `github.event.release.name` contains `@vitest-agent/plugin`, a substring no other package name carries. The job checks out `main`, rebuilds the site from the committed snapshot db, and publishes `website/dist` to the Cloudflare Pages project named `vitest-agent` via `cloudflare/wrangler-action`.
 
 There is a bootstrap caveat documented in the workflow header: until `rspress-plugin-api-extractor` is on npm and `website/package.json` swaps its local dependency for the published version, a CI runner cannot resolve the plugin, so the first dispatch or release deploy requires that swap to have landed on main first.
 

--- a/.claude/design/vitest-agent/components/mcp.md
+++ b/.claude/design/vitest-agent/components/mcp.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-05-06
-updated: 2026-06-26
-last-synced: 2026-06-26
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 92
 related:
   - ../architecture.md
@@ -58,18 +58,7 @@ precedence: `VITEST_AGENT_REPORTER_PROJECT_DIR` (set by the plugin loader)
 NodeContext.layer`, creates `ManagedRuntime.make(McpLive(dbPath, ...))`,
 and calls `startMcpServer({ runtime, cwd: projectDir })`.
 
-Inside `main()`, before `ManagedRuntime.make`, the bin compares
-`CURRENT_MCP_VERSION` against `CURRENT_SDK_VERSION` and writes one
-stderr line on mismatch
-(`[@vitest-agent/mcp] version drift: @vitest-agent/mcp@<a> with
-@vitest-agent/sdk@<b>. Reinstall @vitest-agent/* packages so versions
-match.`). The check is observation-only — the server boot continues.
-`packages/mcp/src/index.ts` exports `CURRENT_MCP_VERSION` (inlined
-from `process.env.__PACKAGE_VERSION__` via the package's
-`rslib.config.ts` `define`). Integration coverage:
-`packages/mcp/__test__/bin-version-drift.test.ts` mocks
-`CURRENT_SDK_VERSION` to assert the warning shape; see D36 in
-[../decisions.md](../decisions.md).
+`packages/mcp/src/index.ts` exports `CURRENT_MCP_VERSION` (inlined from `process.env.__PACKAGE_VERSION__` via the package's `rslib.config.ts` `define`), part of the public API. Under the earlier lockstep design the bin compared it against `CURRENT_SDK_VERSION` inside `main()` and warned on mismatch; that drift check (and its `bin-version-drift.test.ts` coverage) was removed with the move to independent per-package versioning, so the bin now boots straight into `ManagedRuntime.make`. See D36 in [../decisions.md](../decisions.md).
 
 The `VITEST_AGENT_REPORTER_PROJECT_DIR` precedence is load-bearing: Claude
 Code does not reliably propagate `CLAUDE_PROJECT_DIR` to MCP server

--- a/.claude/design/vitest-agent/components/plugin-claude.md
+++ b/.claude/design/vitest-agent/components/plugin-claude.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-05-06
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 90
 related:
   - ../architecture.md
@@ -107,14 +107,7 @@ spawn time. Bundling was rejected because the SDK depends on `better-sqlite3`,
 a native module that must match the user's platform and Node version. See
 D29 (retired) for the dynamic-import approach this replaced.
 
-The PM-walk is also load-bearing for the lockstep release invariant
-(Decision 36). The MCP server must run from the consumer's installation
-context so the version-pinned peer dep on `@vitest-agent/mcp` resolves to
-the same release as the `@vitest-agent/plugin` that wired up the reporter.
-A global `npx vitest-agent-mcp` invocation (or any spawn rooted outside
-the user's package manager) would resolve against an arbitrary version
-and silently drift from the plugin's expected SDK contract. The CLI is
-directory-bound for the same reason.
+The PM-walk is also load-bearing for dependency resolution (Decision 36). The MCP server must run from the consumer's installation context so the peer dep on `@vitest-agent/mcp` resolves to whatever the consumer's lockfile holds — a version compatible with the `@vitest-agent/plugin` that wired up the reporter. A global `npx vitest-agent-mcp` invocation (or any spawn rooted outside the user's package manager) would resolve against an arbitrary version and could drift from the plugin's expected SDK contract. The CLI is directory-bound for the same reason.
 
 ### Hook architecture
 

--- a/.claude/design/vitest-agent/components/plugin.md
+++ b/.claude/design/vitest-agent/components/plugin.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-05-06
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 93
 related:
   - ../architecture.md
@@ -137,23 +137,7 @@ stack; `logLevel` and `logFile` resolve from the
 `VITEST_REPORTER_LOG_LEVEL` and `VITEST_REPORTER_LOG_FILE` env vars via
 `resolveLogLevel` / `resolveLogFile` in the SDK.
 
-**Cross-package version drift check.** The very first statement in
-`AgentPlugin()` is a call to the internal `checkVersionDrift` helper,
-which compares `CURRENT_PLUGIN_VERSION` against `CURRENT_SDK_VERSION`
-and `CURRENT_REPORTER_VERSION` and writes one stderr line per
-mismatch. A module-level `_hasWarnedDrift` boolean suppresses repeated
-warnings so multi-project Vitest configs do not duplicate the line.
-The plugin re-exports the public version constant
-`CURRENT_PLUGIN_VERSION` (sourced from
-`process.env.__PACKAGE_VERSION__` via rslib-builder's `define`
-substitution) and a test-only `_resetVersionDriftGuardForTests` hook
-that re-arms the once-per-process gate between integration test cases
-(`packages/plugin/__test__/version-drift.test.ts`). The plugin
-intentionally does not compare against `CURRENT_UI_VERSION` —
-`@vitest-agent/ui` is not a direct plugin dependency at all after the
-reporter-package restructure; it arrives transitively through
-`@vitest-agent/reporter`. See the root CLAUDE.md "Cross-package version
-drift" section and D36 in [../decisions.md](../decisions.md).
+**Version constant (no runtime drift check).** The plugin re-exports the public version constant `CURRENT_PLUGIN_VERSION` (sourced from `process.env.__PACKAGE_VERSION__` via rslib-builder's `define` substitution). Under the earlier lockstep design the `AgentPlugin()` factory compared this against `CURRENT_SDK_VERSION` and `CURRENT_REPORTER_VERSION` and warned on drift; that check (and its `_hasWarnedDrift` guard, `_resetVersionDriftGuardForTests` hook, and `version-drift.test.ts` suite) was removed when the packages moved to independent versioning, so the constant is now public API with no internal consumer. See D36 in [../decisions.md](../decisions.md).
 
 ## AgentReporter (internal Vitest-API class)
 

--- a/.claude/design/vitest-agent/components/reporter.md
+++ b/.claude/design/vitest-agent/components/reporter.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-05-06
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 90
 related:
   - ../architecture.md
@@ -85,13 +85,4 @@ A custom factory that wants live painting subscribes to `kit.runEvents` at facto
 
 ## CURRENT_REPORTER_VERSION
 
-`packages/reporter/src/index.ts` exports `CURRENT_REPORTER_VERSION`
-(inlined from `process.env.__PACKAGE_VERSION__` via the package's
-`rslib.config.ts` `define`). The plugin imports it and compares
-against `CURRENT_PLUGIN_VERSION` at the top of the `AgentPlugin()`
-factory to surface cross-package drift on stderr — see
-[./plugin.md](./plugin.md) and D36 in [../decisions.md](../decisions.md).
-The package-local
-`packages/reporter/__test__/version-constant.test.ts` imports the
-constant through dist/dev (so it sees the substituted literal) and
-asserts it equals the package's `package.json#version`.
+`packages/reporter/src/index.ts` exports `CURRENT_REPORTER_VERSION` (inlined from `process.env.__PACKAGE_VERSION__` via the package's `rslib.config.ts` `define`), part of the public API. Under the earlier lockstep design the plugin imported it and compared against `CURRENT_PLUGIN_VERSION` at the top of the `AgentPlugin()` factory to surface cross-package drift; that check (and the package-local `version-constant.test.ts`) was removed with the move to independent per-package versioning, so the constant now has no internal consumer. See [./plugin.md](./plugin.md) and D36 in [../decisions.md](../decisions.md).

--- a/.claude/design/vitest-agent/components/sdk.md
+++ b/.claude/design/vitest-agent/components/sdk.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-05-06
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 96
 related:
   - ../architecture.md
@@ -603,22 +603,7 @@ moved symbols are deliberately **not** re-exported from the main barrel.
 
 ## CURRENT_SDK_VERSION
 
-`packages/sdk/src/index.ts` exports `CURRENT_SDK_VERSION: string`,
-inlined from `process.env.__PACKAGE_VERSION__` by the SDK's
-`rslib.config.ts` `define` block at build time. The constant is the
-authoritative version reference for the cross-package drift checks
-wired in the plugin factory, the MCP bin, and the CLI bin — each peer
-compares its own `CURRENT_<PKG>_VERSION` against this one at init and
-emits a stderr warning on mismatch (see D36).
-
-A shared shape test at
-`packages/sdk/__test__/version-constants-shape.test.ts` imports all six
-`CURRENT_*_VERSION` constants through dist/dev and asserts they are
-non-empty strings and lockstep-equal. Each runtime package also has a
-local `__test__/version-constant.test.ts` that imports its own
-constant through dist/dev (so it sees the substituted literal, not
-the source-time `process.env.__PACKAGE_VERSION__!` expression) and
-asserts it matches that package's `package.json#version`.
+`packages/sdk/src/index.ts` exports `CURRENT_SDK_VERSION: string`, inlined from `process.env.__PACKAGE_VERSION__` by the SDK's `rslib.config.ts` `define` block at build time. Every runtime package exports the analogous `CURRENT_<PKG>_VERSION` constant the same way. These are public API — a consumer can read a package's own release version — but nothing compares them across packages at runtime. The earlier lockstep design wired init-time drift checks (plugin factory, MCP bin, CLI bin) against this constant; those checks, and the version-constant test suites that backed them, were removed with the move to independent per-package versioning. See D36 in [../decisions.md](../decisions.md).
 
 ## Output pipeline
 

--- a/.claude/design/vitest-agent/components/sidecar.md
+++ b/.claude/design/vitest-agent/components/sidecar.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: performance
 created: 2026-05-15
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 92
 related:
   - ../architecture.md
@@ -68,7 +68,7 @@ The two variants mirror the rslib packages' layout: `dist/dev` is the workspace 
 
 The `dist/dev` variant must always be present — not only the publish target — because the parent `@vitest-agent/sidecar` package is rslib-built and its own `build:prod` resolves the workspace-protocol `optionalDependencies` on these children by reading each child's `dist/dev/package.json` (the `linkDirectory` base). Without `dist/dev` the parent build fails with `Workspace resolution failed`.
 
-Each child `package.json` declares a `publishConfig` pointing at `dist/npm` so the release flow publishes the sidecar children to npm, identically to the lockstep packages.
+Each child `package.json` declares a `publishConfig` pointing at `dist/npm` so the release flow publishes the sidecar children to npm, identically to the primary packages.
 
 ## Hook integration
 

--- a/.claude/design/vitest-agent/components/ui.md
+++ b/.claude/design/vitest-agent/components/ui.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-05-12
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 90
 related:
   - ../architecture.md
@@ -211,4 +211,4 @@ See `../decisions.md` for the recorded design choices:
 
 ## CURRENT_UI_VERSION
 
-`packages/ui/src/index.ts` exports `CURRENT_UI_VERSION` (inlined from `process.env.__PACKAGE_VERSION__` via the package's `rslib.config.ts` `define`). The constant participates in the shared shape test at `packages/sdk/__test__/version-constants-shape.test.ts` (asserts all six runtime `CURRENT_*_VERSION` strings are non-empty and lockstep-equal) and in `packages/ui/__test__/version-constant.test.ts` (asserts it matches `packages/ui/package.json#version`). No init-time drift check compares against `CURRENT_UI_VERSION` because `@vitest-agent/ui` is consumed transitively through the plugin and is not a hard peer dependency. See D36 in [../decisions.md](../decisions.md).
+`packages/ui/src/index.ts` exports `CURRENT_UI_VERSION` (inlined from `process.env.__PACKAGE_VERSION__` via the package's `rslib.config.ts` `define`), part of the public API. It was never wired into a runtime drift check even under the earlier lockstep design — `@vitest-agent/ui` is consumed transitively through the plugin and is not a hard peer dependency — and the cross-package version checks were removed entirely with the move to independent per-package versioning. See D36 in [../decisions.md](../decisions.md).

--- a/.claude/design/vitest-agent/decisions-retired.md
+++ b/.claude/design/vitest-agent/decisions-retired.md
@@ -3,8 +3,8 @@ status: archived
 module: vitest-agent
 category: architecture
 created: 2026-05-06
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 100
 related:
   - ./decisions.md
@@ -150,3 +150,13 @@ SQLite columns. CLI commands (`history`, `status`, `trends`, `coverage`,
 `doctor`) and MCP tools accepted a `subProject` filter parameter.
 `HistoryTracker.classify` keyed on `(project, subProject)`. A null
 `subProject` was distinct from an empty string at the row level.
+
+---
+
+## Decision 36 (Lockstep form): Lockstep Release with Build-Inlined Drift Check (Retired)
+
+**Superseded by:** [Decision 36 — Independent Per-Package Release](./decisions.md#decision-36-independent-per-package-release)
+
+**Why retired:** the six npm packages shared one version (a bump to any one bumped all six) and three init-time checks asserted that every `@vitest-agent/*` package in the same process carried the same build-inlined version, warning on stderr otherwise. Exact version equality only made sense under a lockstep release train. When the family moved to independent per-package versioning the equality assertion became a false positive on every ordinary consumer install — a plugin on one minor legitimately running an mcp on a later compatible minor is not drift — so the lockstep grouping and the drift check were removed together. The `CURRENT_<PKG>_VERSION` constants survive as public API; nothing consumes them across packages now.
+
+**What it was:** changesets pinned the family to one version via a `fixed`/`linked` grouping. Each runtime package exported `CURRENT_<PKG>_VERSION`, inlined from `process.env.__PACKAGE_VERSION__` at build time. Three observation-only checks ran at init: the `AgentPlugin()` factory compared `CURRENT_PLUGIN_VERSION` against `CURRENT_SDK_VERSION` and `CURRENT_REPORTER_VERSION` (gated by a module-level `_hasWarnedDrift` flag, with a test-only `_resetVersionDriftGuardForTests` hook to re-arm it); the `vitest-agent-mcp` bin compared `CURRENT_MCP_VERSION` against `CURRENT_SDK_VERSION` in `main()`; the `vitest-agent` CLI bin compared `CURRENT_CLI_VERSION` against `CURRENT_SDK_VERSION` before `Command.run`. Each mismatch emitted one stderr line of the form `[@vitest-agent/<pkg>] version drift: <pkg>@<a> with <peer>@<b>. Reinstall @vitest-agent/* packages so versions match.` and continued. The plugin never compared against `CURRENT_UI_VERSION` because `@vitest-agent/ui` is not a hard peer. Build-inlining (vs a runtime `package.json` read) was chosen so the check had no I/O cost, no path-resolution ambiguity, and worked in packaged-binary environments where `package.json` is not on disk. The release artifacts matched the lockstep grouping: one unified semver git tag (e.g. `1.0.1`) and a single combined GitHub Release whose body concatenated every package's section and to which all packages' assets were attached — replaced under the independent scheme by per-package `@vitest-agent/<pkg>@<version>` tags and Releases.

--- a/.claude/design/vitest-agent/decisions.md
+++ b/.claude/design/vitest-agent/decisions.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-03-20
-updated: 2026-06-17
-last-synced: 2026-06-17
+updated: 2026-06-30
+last-synced: 2026-06-30
 completeness: 100
 related:
   - ./architecture.md
@@ -512,8 +512,9 @@ The seven workspaces under `packages/`:
 | `@vitest-agent/mcp` | `vitest-agent-mcp` bin |
 | `@vitest-agent/sidecar` | per-Bash `inject-env` fast-path native binary; a regular `dependency` of `@vitest-agent/cli` |
 
-The six non-sidecar packages release in lockstep via changesets `linked`
-config; `@vitest-agent/sidecar` versions independently. The plugin
+Every `@vitest-agent/*` package versions independently — changesets
+carries no `fixed`/`linked` grouping, so a bump to one package does not
+force the rest (see D36). The plugin
 declares the CLI and MCP packages as **required** `peerDependencies` so
 installing the plugin still pulls the agent tooling with it;
 `@vitest-agent/reporter`, `@vitest-agent/sdk` and `@vitest-agent/ui` are
@@ -542,10 +543,17 @@ and a peer-installed package lands at the consumer's top level — so the
 `vitest-agent` and `vitest-agent-mcp` bins resolve for the Claude Code
 plugin's hook scripts. A transitively-nested regular dependency's bin
 would not. The published `@vitest-agent/plugin` carries real registry
-version ranges for these peers (rslib-builder rewrites the `workspace:*`
-protocol to concrete versions at publish time), so the auto-install
-resolves against the registry. In the monorepo dev workspace the peers
-are `workspace:*` ranges that `autoInstallPeers` cannot satisfy from the
+version ranges for these peers (rslib-builder rewrites the `workspace:^`
+protocol to a concrete caret range at publish time), so the auto-install
+resolves against the registry. The cli and mcp peers use `workspace:^`
+rather than `workspace:*` deliberately: changesets reads a `workspace:*`
+peer as an exact pin, so a minor bump to either peer would treat the
+plugin's peer range as changed and force the plugin to a major bump (a
+changed peer range is a breaking change); `workspace:^` paired with the
+`onlyUpdatePeerDependentsWhenOutOfRange` changeset option keeps the
+plugin on a minor when its peers take a compatible in-range minor (see
+D36). In the monorepo dev workspace the peers
+are `workspace:^` ranges that `autoInstallPeers` cannot satisfy from the
 registry, so the root `package.json` declares `@vitest-agent/cli` and
 `@vitest-agent/mcp` directly as devDependencies and `pnpm-workspace.yaml`
 adds a `publicHoistPattern` for both so their bins land in the root
@@ -799,76 +807,21 @@ support. The maintenance scripts depend on workspace `node_modules`
 (`tsx`, Effect Schema); the gain is sharing the `UpstreamManifest`
 schema with the runtime.
 
-### Decision 36: Lockstep Release with Build-Inlined Version
+### Decision 36: Independent Per-Package Release
 
-The six npm packages release in lockstep — a version bump to any one
-bumps all six — and every bundle carries its release version as a
-build-time string constant `process.env.__PACKAGE_VERSION__`, inlined
-by `rslib-builder` from the source `package.json` at build time. The
-Claude Code plugin versions independently; it can lag the npm packages
-by one or more releases, and is the only piece of the system permitted
-to do so.
+Every `@vitest-agent/*` package versions independently. Changesets carries no `fixed` or `linked` grouping — a bump to one package never forces the others — and the runtime cross-package drift check that the earlier lockstep form relied on has been removed.
 
-The runtime invariant is that the packages running in the same process
-must share the same `__PACKAGE_VERSION__` value. Each runtime package
-exports a `CURRENT_<PKG>_VERSION` constant (sourced from
-`process.env.__PACKAGE_VERSION__`), and three init-time checks compare
-these constants without ever blocking the run: the `AgentPlugin()`
-factory in `packages/plugin/src/plugin.ts` compares
-`CURRENT_PLUGIN_VERSION` against `CURRENT_SDK_VERSION` and
-`CURRENT_REPORTER_VERSION` (gated by a module-level `_hasWarnedDrift`
-flag so multi-project Vitest configs only warn once per process; a
-test-only `_resetVersionDriftGuardForTests` hook re-arms it); the
-The `vitest-agent-mcp` bin compares `CURRENT_MCP_VERSION` against
-`CURRENT_SDK_VERSION` inside `main()`; the `vitest-agent` CLI bin
-compares `CURRENT_CLI_VERSION` against `CURRENT_SDK_VERSION` before
-`Command.run`. Each mismatch emits one stderr line of the form
-`[@vitest-agent/<pkg>] version drift: <pkg>@<myVersion> with
-<peer>@<peerVersion>. Reinstall @vitest-agent/* packages so versions
-match.` and continues — the check is observation-only. The plugin
-intentionally does not compare against `CURRENT_UI_VERSION` because
-`@vitest-agent/ui` is not a hard peer dependency.
+Each runtime package still exports a `CURRENT_<PKG>_VERSION` constant, inlined from `process.env.__PACKAGE_VERSION__` by `rslib-builder` at build time. These remain part of the public API (a consumer or a package's own test can read its release version) but nothing compares them across packages at init any more.
 
-**Why build-inlined (vs runtime `package.json` read):** the inlined
-constant has no I/O cost, no path-resolution failure mode, and no
-ambiguity about *which* `package.json` is read (the package's own,
-the consumer's hoisted copy, a pnpm symlink target). It also makes
-mismatch detectable in environments where `package.json` files are
-not on disk at runtime (bundled, packaged binaries). The trade-off is
-that the build is the source of truth for the version string — but
-that is already the case for everything else `rslib-builder`
-produces.
+**Why independent (vs lockstep):** the lockstep form bumped all six runtime packages on the smallest change to any one and asserted exact version equality across the family at runtime. Once the packages are allowed to move independently that equality assertion is a false positive on every ordinary consumer install — a plugin on one minor legitimately running an mcp on a later compatible minor is not drift — so the shared release train and the drift check were removed together. The package-boundary contracts at the SDK layer (D33, D34) are enforced by the dependency ranges and TypeScript, not by a runtime string compare.
 
-**Why lockstep (vs independent semver per package):** the npm
-packages share types and runtime contracts at the SDK boundary
-(`DataStore`, `DataReader`, the reporter contract types, the schemas).
-A consumer hitting any cross-package type mismatch sees an opaque
-TypeScript or runtime error rather than a "you upgraded the plugin
-but not the reporter" diagnostic. The plugin's regular `dependencies`
-on reporter and sdk plus its required `peerDependencies` on cli and
-mcp (D33) make installation lockstep on the consumer's side;
-build-inlined version comparison makes drift detectable at runtime if
-the lockfile ever lies (npm's looser peer-dep enforcement, manual
-`npm install` patterns, monorepo hoist surprises).
+**The peer-range mechanism.** The plugin's required peers `@vitest-agent/cli` and `@vitest-agent/mcp` are declared `workspace:^`, not `workspace:*`. Changesets reads a `workspace:*` peer as an exact pin, so a minor bump to either peer treats the plugin's peer range as changed and forces the plugin to a major bump (a changed peer range is breaking). `workspace:^` paired with the changeset option `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange: true` keeps the plugin on a minor when its peers take a compatible in-range minor; `updateInternalDependencies: "patch"` still bumps internal dependents on patch. See `.changeset/config.json` for the live settings.
 
-**Why the Claude Code plugin can lag:** the plugin is a file-based
-distribution through the Claude marketplace (D20). Its release cadence
-is decoupled from npm's. The plugin's loader (D30) shells out to the
-user's package manager to spawn the MCP server — whichever version
-of `@vitest-agent/mcp` the consumer's lockfile resolves is what the
-plugin gets. The MCP server's startup version check is the gate that
-catches plugin-vs-MCP drift if it happens.
+**Release artifacts.** A release now produces, per package, a git tag `@vitest-agent/<pkg>@<version>` (changesets' scoped-package tag format, e.g. `@vitest-agent/sdk@1.1.0`) and one GitHub Release titled with that same tag, each carrying that package's own changelog body, its own provenance assets (npm tarball, SBOM, API report, meta) and a per-package Publish Summary. This replaces the retired lockstep scheme's single unified semver tag (e.g. `1.0.1`) plus one combined Release whose body concatenated every package's section and to which all packages' assets were attached. The docs/deploy trigger still keys on the plugin Release name containing `@vitest-agent/plugin` — unchanged. The two prior unified releases were backfilled to match: the unified `1.0.0` and `1.0.1` git tags and Releases were deleted and re-created per package (`@vitest-agent/<pkg>@1.0.0` / `@1.0.1`, assets re-homed) so history matches the new scheme and the tooling finds a per-package previous-tag reference for changelog generation. The Release marked "Latest" is `@vitest-agent/plugin@1.0.1`.
 
-**Trade-off:** every package release is the size of the smallest
-useful change times six. A docs-only fix in the SDK still bumps the
-plugin, reporter, ui, CLI, and MCP. Acceptable in exchange for the
-runtime sync guarantee.
+**Why the Claude Code plugin and sidecar were already independent:** both versioned on their own before this change — the marketplace plugin is a file-based distribution with its own cadence (D20), and `@vitest-agent/sidecar` ships per-platform binaries that rev separately. Independent versioning generalizes that posture to the whole family.
 
-**Cross-references:** D33 (Five-Package Split — establishes the
-required-peer-deps shape this decision protects) and D30 (Plugin MCP
-Loader — describes why the MCP runs from the consumer's installation
-context, which is what makes the build-inlined version a meaningful
-sync check).
+**Cross-references:** D33 (Five-Package Split — establishes the required-peer-deps shape these ranges live on) and D30 (Plugin MCP Loader — the consumer-rooted spawn that makes the resolved peer version whatever the consumer's lockfile holds). The retired lockstep form, including the removed build-inlined drift check, lives in [./decisions-retired.md](./decisions-retired.md).
 
 ### Decision 37: Per-Executor Console Matrix + Streaming Reporter Tap
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,10 +1,11 @@
 # Deploys the RSPress docs site (website/, package "docs") to Cloudflare
 # Pages.
 #
-# Trigger model: all vitest-agent packages release in lockstep from one
-# commit on main, sharing a single semver tag (e.g. 2.0.0) but publishing
-# one GitHub Release per package. We deploy once per release by keying on
-# the plugin package's Release — its name contains "@vitest-agent/plugin",
+# Trigger model: each vitest-agent package versions independently and a
+# release publishes one GitHub Release per package, each tagged
+# "@vitest-agent/<pkg>@<version>". A single commit on main can publish
+# several packages at once, so we deploy once per release cycle by keying
+# on the plugin package's Release — its name contains "@vitest-agent/plugin",
 # which no other package name does. A manual workflow_dispatch also deploys
 # (used for the first test deployment once the Cloudflare secrets are set).
 #
@@ -29,7 +30,7 @@ permissions:
 
 jobs:
   deploy:
-    # Run on a manual dispatch, or once per lockstep release when the
+    # Run on a manual dispatch, or once per release cycle when the
     # plugin package's GitHub Release is the one being published.
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.release.name, '@vitest-agent/plugin') }}
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ This is a pnpm monorepo. Workspaces are defined in `pnpm-workspace.yaml`:
 The seven publishable packages live under `packages/`. The `docs` site (`website/`) is a private workspace — it renders documentation and is never published. Four
 per-platform sub-packages (`@vitest-agent/sidecar-{darwin-arm64,linux-arm64,linux-x64,win32-x64}` under `packages/sidecar-*/`) carry the prebuilt sidecar binaries and are pulled in as `optionalDependencies` of `@vitest-agent/sidecar`. The `plugin/` directory at the repo root is a file-based Claude Code plugin (NOT a pnpm workspace). Root-level configs (`turbo.json`, `biome.jsonc`, etc.) apply to all workspaces. To scope commands to a specific package, use `--filter='./packages/<name>'`.
 
-The six original packages release in lockstep; `@vitest-agent/sidecar` is a new package that versions independently of that group. `@vitest-agent/plugin` declares `@vitest-agent/cli` and `@vitest-agent/mcp` as required `peerDependencies` (alongside the Vitest-side peers `vitest`, `@vitest/runner`, `@vitest/coverage-v8`, `@vitest/coverage-istanbul`), plus regular workspace `dependencies` on `@vitest-agent/reporter` and `@vitest-agent/sdk`. Required peers are still pulled for a published consumer — npm 7+ and pnpm (`autoInstallPeers: true`) auto-install required peers, and the published plugin carries concrete registry version ranges — so declaring `@vitest-agent/plugin` transitively brings `@vitest-agent/cli` and `@vitest-agent/mcp`, with their bins landing at the consumer's top level. The dependency flow is `plugin → reporter → ui → sdk`: the plugin no longer depends on `@vitest-agent/ui` (or `react` / `ink`) directly — `@vitest-agent/reporter` supplies the default reporter and the Ink live mount, and pulls `ui` / `react` / `ink` transitively. `@vitest-agent/sidecar` reaches a consumer transitively: it is a regular `dependency` of `@vitest-agent/cli`, which is itself a required peer of the plugin, so installing the plugin pulls `@vitest-agent/sidecar` and its four per-platform `optionalDependencies` automatically. In the dev workspace, the plugin's peers are `workspace:*` ranges that `autoInstallPeers` cannot satisfy from the registry, so the workspace root `package.json` declares `@vitest-agent/cli` and `@vitest-agent/mcp` directly as devDependencies, and `pnpm-workspace.yaml` adds a `publicHoistPattern` for both so their bins land in the root `node_modules/.bin` for the dogfood Claude Code plugin hooks; the root no longer lists `@vitest-agent/reporter`, `@vitest-agent/sidecar`, or `@vitest-agent/ui` directly.
+Every `@vitest-agent/*` package versions independently — a change to one package bumps only that package, plus a patch ripple to its workspace dependents via changesets' `updateInternalDependencies: "patch"`. `@vitest-agent/plugin` declares `@vitest-agent/cli` and `@vitest-agent/mcp` as required `peerDependencies` (alongside the Vitest-side peers `vitest`, `@vitest/runner`, `@vitest/coverage-v8`, `@vitest/coverage-istanbul`), plus regular workspace `dependencies` on `@vitest-agent/reporter` and `@vitest-agent/sdk`. Required peers are still pulled for a published consumer — npm 7+ and pnpm (`autoInstallPeers: true`) auto-install required peers, and the published plugin carries concrete registry version ranges — so declaring `@vitest-agent/plugin` transitively brings `@vitest-agent/cli` and `@vitest-agent/mcp`, with their bins landing at the consumer's top level. The dependency flow is `plugin → reporter → ui → sdk`: the plugin no longer depends on `@vitest-agent/ui` (or `react` / `ink`) directly — `@vitest-agent/reporter` supplies the default reporter and the Ink live mount, and pulls `ui` / `react` / `ink` transitively. `@vitest-agent/sidecar` reaches a consumer transitively: it is a regular `dependency` of `@vitest-agent/cli`, which is itself a required peer of the plugin, so installing the plugin pulls `@vitest-agent/sidecar` and its four per-platform `optionalDependencies` automatically. In the dev workspace, the plugin's internal peers (`@vitest-agent/cli`, `@vitest-agent/mcp`) are `workspace:^` ranges that `autoInstallPeers` cannot satisfy from the registry, so the workspace root `package.json` declares `@vitest-agent/cli` and `@vitest-agent/mcp` directly as devDependencies, and `pnpm-workspace.yaml` adds a `publicHoistPattern` for both so their bins land in the root `node_modules/.bin` for the dogfood Claude Code plugin hooks; the root no longer lists `@vitest-agent/reporter`, `@vitest-agent/sidecar`, or `@vitest-agent/ui` directly.
 Users typically configure the plugin with just
 `AgentPlugin({ console, coverageTargets, transport? })` — the plugin
 injects `DefaultVitestAgentReporter` from `@vitest-agent/reporter`, which
@@ -160,25 +160,9 @@ Resolution precedence (highest first):
 Fails loudly with `WorkspaceRootNotFoundError` if no identity is resolvable.
 No silent fallback to a path hash.
 
-## Cross-package version drift
+## Cross-package versioning
 
-The six original runtime packages release in lockstep; `@vitest-agent/sidecar` and the Claude Code marketplace plugin (`vitest-agent@spencerbeggs`) each version independently.
-If you see a `[@vitest-agent/<pkg>] version drift: …` line on stderr
-during a Vitest run, MCP startup, or CLI invocation, the imported
-`@vitest-agent/*` versions do not match. The warning is informational —
-the run continues — but it usually means a partially-upgraded install.
-Reinstall the `@vitest-agent/*` packages so the versions match.
-
-The check is wired at three points: the top of the `AgentPlugin()`
-factory (compares against `CURRENT_SDK_VERSION` and
-`CURRENT_REPORTER_VERSION`; one warning per mismatched peer, suppressed
-after the first call in the same process), inside the `vitest-agent-mcp`
-bin's `main()` (compares against `CURRENT_SDK_VERSION`), and at the top of
-the `vitest-agent` CLI bin before `Command.run` (compares against
-`CURRENT_SDK_VERSION`). Each runtime package exposes a
-`CURRENT_<PKG>_VERSION` constant inlined by rslib-builder's
-`process.env.__PACKAGE_VERSION__` substitution at build time, sourced
-from the package's own `package.json#version`.
+Every `@vitest-agent/*` package versions independently — there is no lockstep `fixed` group. Consumers only ever install `@vitest-agent/plugin`; its required peers (`cli`, `mcp`) auto-install and the rest arrive transitively, so version skew across the family is invisible to a published consumer. The runtime drift check (the `checkVersionDrift` helper formerly wired into `AgentPlugin()`, the `vitest-agent-mcp` bin, and the `vitest-agent` CLI bin) was removed. Each package still exports a `CURRENT_<PKG>_VERSION` constant (inlined at build time from its own `package.json#version`) as a public API for version introspection by downstream tooling, but nothing imports it internally anymore.
 
 ## Build Pipeline
 
@@ -301,7 +285,7 @@ All commits require:
 
 All seven packages publish to npm with
 provenance via the [@savvy-web/changesets](https://github.com/savvy-web/changesets)
-release workflow. The six original packages release in lockstep; `@vitest-agent/sidecar` versions independently.
+release workflow. Every package versions independently — there is no lockstep `fixed` group. Each release publishes a git tag per package of the form `@vitest-agent/<pkg>@<version>` (e.g. `@vitest-agent/plugin@1.1.0`) plus one GitHub Release per package, replacing the retired unified single-semver-tag (`1.0.0`) + one-combined-release scheme. The prior `1.0.0`/`1.0.1` unified tags/releases were retroactively split into per-package tags/releases so history matches; the bare `1.0.0`/`1.0.1` tags no longer exist.
 
 ## Testing
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"extends": ["@savvy-web/silk/biome"],
+	"root": true,
 	"overrides": [
 		{
 			// `!` non-null assertions are idiomatic in test fixtures the

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"runtime": [
 			{
 				"name": "node",
-				"version": "26.3.1",
+				"version": "26.4.0",
 				"onFail": "ignore"
 			}
 		]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/silk": "^1.3.4",
+		"@savvy-web/silk": "^1.3.5",
 		"@vitest-agent/cli": "workspace:*",
 		"@vitest-agent/mcp": "workspace:*",
 		"@vitest-agent/plugin": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,8 +46,8 @@
 		"effect": "catalog:silk"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
-		"@types/node": "catalog:silk",
+		"@savvy-web/bundler": "^1.0.1",
+		"@types/node": "^26.0.0",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",
 		"typescript": "catalog:silk",

--- a/packages/cli/savvy.build.ts
+++ b/packages/cli/savvy.build.ts
@@ -1,13 +1,7 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
-const config = defineBuild({
+await build({
 	meta: {
 		localPaths: ["../../website/lib/models/cli"],
 	},
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -8,7 +8,6 @@
 import { Command } from "@effect/cli";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
 import {
-	CURRENT_SDK_VERSION,
 	PathResolutionLive,
 	formatFatalError,
 	resolveDataPath,
@@ -19,7 +18,6 @@ import { Cause, Console, Effect } from "effect";
 import { agentCommand } from "./commands/agent.js";
 import { dbCommand } from "./commands/db.js";
 import { doctorCommand } from "./commands/doctor.js";
-import { CURRENT_CLI_VERSION } from "./index.js";
 import { CliLive } from "./layers/CliLive.js";
 
 const rootCommand = Command.make("vitest-agent").pipe(
@@ -33,20 +31,6 @@ const cli = Command.run(rootCommand, {
 
 const logLevel = resolveLogLevel();
 const logFile = resolveLogFile();
-
-// Cross-package version drift check. Compares this CLI's version against
-// @vitest-agent/sdk and writes a single stderr line on mismatch.
-// Observation-only — never throws. The `"0.0.0"` fallback marks a dev
-// build where rslib-builder did not substitute the literal; skip the
-// check to avoid spurious warnings during local source-loaded runs.
-// See the root CLAUDE.md "Cross-package version drift" section.
-if (CURRENT_CLI_VERSION !== "0.0.0" && CURRENT_SDK_VERSION !== CURRENT_CLI_VERSION) {
-	process.stderr.write(
-		`[@vitest-agent/cli] version drift: @vitest-agent/cli@${CURRENT_CLI_VERSION} ` +
-			`with @vitest-agent/sdk@${CURRENT_SDK_VERSION}. ` +
-			`Reinstall @vitest-agent/* packages so versions match.\n`,
-	);
-}
 
 // Resolve the project root used for `data.db` resolution. Honor an explicit
 // `VITEST_AGENT_PROJECT_DIR` override before `process.cwd()` so hook-driven

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,8 +30,7 @@ export {
 /**
  * The version of this package, inlined at build time from
  * `package.json#version` via rslib-builder's `__PACKAGE_VERSION__` substitution.
- * Compared against `CURRENT_SDK_VERSION` at CLI bin init to surface
- * partially-upgraded installs as a single stderr warning.
+ * Exported for version introspection by downstream tooling.
  *
  * @public
  */

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,8 +47,8 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
-		"@types/node": "catalog:silk",
+		"@savvy-web/bundler": "^1.0.1",
+		"@types/node": "^26.0.0",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",
 		"typescript": "catalog:silk",

--- a/packages/mcp/savvy.build.ts
+++ b/packages/mcp/savvy.build.ts
@@ -1,13 +1,7 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
-const config = defineBuild({
+await build({
 	meta: {
 		localPaths: ["../../website/lib/models/mcp"],
 	},
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { NodeContext } from "@effect/platform-node";
 import {
-	CURRENT_SDK_VERSION,
 	PathResolutionLive,
 	formatFatalError,
 	resolveDataPath,
@@ -11,30 +10,8 @@ import {
 import { Effect, ManagedRuntime } from "effect";
 import type { McpContext } from "./context.js";
 import { createCurrentSessionIdRef, createSessionContextRef, sessionContextFromEnv } from "./context.js";
-import { CURRENT_MCP_VERSION } from "./index.js";
 import { McpLive } from "./layers/McpLive.js";
 import { startMcpServer } from "./server.js";
-
-/**
- * Cross-package version drift check. Compares this MCP package's version
- * against @vitest-agent/sdk and writes a single stderr line on mismatch.
- * Observation-only — never throws. The `"0.0.0"` fallback marks a dev
- * build (rslib-builder did not substitute the literal); skip the check
- * to avoid spurious warnings during local source-loaded runs. See the
- * root CLAUDE.md "Cross-package version drift" section.
- *
- * @internal
- */
-function checkVersionDrift(): void {
-	if (CURRENT_MCP_VERSION === "0.0.0") return;
-	if (CURRENT_SDK_VERSION !== CURRENT_MCP_VERSION) {
-		process.stderr.write(
-			`[@vitest-agent/mcp] version drift: @vitest-agent/mcp@${CURRENT_MCP_VERSION} ` +
-				`with @vitest-agent/sdk@${CURRENT_SDK_VERSION}. ` +
-				`Reinstall @vitest-agent/* packages so versions match.\n`,
-		);
-	}
-}
 
 /**
  * Resolve the user's project directory.
@@ -82,7 +59,6 @@ function resolveInitialSessionId(): string | null {
 
 async function main() {
 	const projectDir = resolveProjectDir();
-	checkVersionDrift();
 	const initialSessionId = resolveInitialSessionId();
 
 	const dbPath = await Effect.runPromise(

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -20,13 +20,11 @@ export { appRouter } from "./router.js";
 export { startMcpServer } from "./server.js";
 export type { Remediation, TddErrorEnvelope } from "./tools/_tdd-error-envelope.js";
 
-// --- Cross-package version constant (T12 drift check) ---
+// --- Package version constant ---
 /**
  * The version of this package, inlined at build time from
  * package.json#version via rslib-builder's __PACKAGE_VERSION__ substitution.
- * Compared against CURRENT_SDK_VERSION at MCP bin init to surface
- * partially-upgraded installs as a single stderr warning. See the root
- * CLAUDE.md "Cross-package version drift" section.
+ * Exported for version introspection by downstream tooling.
  *
  * @public
  */

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/packages/plugin/CLAUDE.md
+++ b/packages/plugin/CLAUDE.md
@@ -7,10 +7,12 @@ baseline/trend computation, and delegates rendering entirely to a
 `@vitest-agent/reporter` when the user does not pass a custom `reporter`
 option, and never touches rendering itself. The reporter owns mode
 branching and the Ink live-mount lifecycle. Declares `@vitest-agent/cli`
-and `@vitest-agent/mcp` as required `peerDependencies` (alongside the
-Vitest-side peers `vitest`, `@vitest/runner`, `@vitest/coverage-v8`,
-`@vitest/coverage-istanbul`), plus regular workspace `dependencies` on
-`@vitest-agent/reporter` and `@vitest-agent/sdk`. The plugin no longer
+and `@vitest-agent/mcp` as required `peerDependencies` at `workspace:^`
+(these two version independently, so the caret tracks compatible majors
+rather than pinning exact; alongside the Vitest-side peers `vitest`,
+`@vitest/runner`, `@vitest/coverage-v8`, `@vitest/coverage-istanbul`),
+plus regular workspace `dependencies` on `@vitest-agent/reporter` and
+`@vitest-agent/sdk`. The plugin no longer
 depends on `@vitest-agent/ui`, `react`, or `ink` — `reporter` pulls those
 transitively. `@vitest-agent/sidecar` is not a direct dependency — it
 arrives transitively through the required `@vitest-agent/cli` peer.

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -46,9 +46,9 @@
 		"workspaces-effect": "^1.2.0"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
+		"@savvy-web/bundler": "^1.0.1",
 		"@types/better-sqlite3": "^7.6.13",
-		"@types/node": "catalog:silk",
+		"@types/node": "^26.0.0",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-istanbul": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -59,8 +59,8 @@
 		"vitest": "catalog:silk"
 	},
 	"peerDependencies": {
-		"@vitest-agent/cli": "workspace:*",
-		"@vitest-agent/mcp": "workspace:*",
+		"@vitest-agent/cli": "workspace:^",
+		"@vitest-agent/mcp": "workspace:^",
 		"@vitest/coverage-istanbul": "catalog:silkPeers",
 		"@vitest/coverage-v8": "catalog:silkPeers",
 		"vitest": "catalog:silkPeers"

--- a/packages/plugin/savvy.build.ts
+++ b/packages/plugin/savvy.build.ts
@@ -1,6 +1,6 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
-const config = defineBuild({
+await build({
 	dtsExternals: ["@vitest/runner"],
 	meta: {
 		localPaths: ["../../website/lib/models/plugin"],
@@ -12,9 +12,3 @@ const config = defineBuild({
 		},
 	},
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -1,6 +1,5 @@
 import { execSync } from "node:child_process";
 import type { TestTagDefinition } from "@vitest/runner";
-import { CURRENT_REPORTER_VERSION } from "@vitest-agent/reporter";
 import type {
 	AgentPluginOptions,
 	ConsoleMode,
@@ -14,7 +13,6 @@ import type {
 } from "@vitest-agent/sdk";
 import {
 	AgentConsoleMode,
-	CURRENT_SDK_VERSION,
 	CiConsoleMode,
 	CoverageLevel,
 	EnvironmentDetector,
@@ -183,59 +181,11 @@ const aggregatedReporterByVitest = new WeakSet<object>();
  * The version of this package, inlined at build time from
  * `package.json#version` via rslib-builder's `__PACKAGE_VERSION__` substitution.
  * Re-exported from the package barrel as the public symbol; defined here so
- * the drift-check code path can read it without a circular import.
+ * consumers can introspect the running plugin version without a circular import.
  *
  * @public
  */
 export const CURRENT_PLUGIN_VERSION: string = process.env.__PACKAGE_VERSION__ ?? "0.0.0";
-
-/**
- * Cross-package version drift warning state. Module-scoped so multi-project
- * Vitest configs construct one plugin per project but only emit the
- * warning once per Node process. See the root CLAUDE.md
- * "Cross-package version drift" section.
- *
- * @internal
- */
-let _hasWarnedDrift = false;
-
-/**
- * Compare CURRENT_PLUGIN_VERSION against each runtime peer the plugin
- * orchestrates and write one stderr line per mismatch. The check is
- * observation-only — never throws, never exits. Suppressed after the
- * first call in the same process so multi-project Vitest configs do
- * not duplicate the warning.
- *
- * The `"0.0.0"` fallback (from process.env.__PACKAGE_VERSION__ ??
- * "0.0.0" in the constant source) marks a dev build where rslib-builder
- * has not substituted the literal — typically when this module is
- * loaded directly from source rather than from dist. Skip the check
- * in that case; the asymmetry between source-loaded plugin and
- * dist-loaded peers would fire a spurious warning on every dev test
- * run otherwise.
- *
- * @internal
- */
-function checkVersionDrift(pluginVersion: string): void {
-	if (_hasWarnedDrift) return;
-	if (pluginVersion === "0.0.0") return;
-	const peers: ReadonlyArray<readonly [string, string]> = [
-		["@vitest-agent/sdk", CURRENT_SDK_VERSION],
-		["@vitest-agent/reporter", CURRENT_REPORTER_VERSION],
-	];
-	let warned = false;
-	for (const [peerName, peerVersion] of peers) {
-		if (peerVersion !== pluginVersion) {
-			process.stderr.write(
-				`[@vitest-agent/plugin] version drift: @vitest-agent/plugin@${pluginVersion} ` +
-					`with ${peerName}@${peerVersion}. ` +
-					`Reinstall @vitest-agent/* packages so versions match.\n`,
-			);
-			warned = true;
-		}
-	}
-	if (warned) _hasWarnedDrift = true;
-}
 
 const TEST_FILE_SUFFIX_RE = /\.(?:test|spec)\.(?:ts|tsx|js|jsx)$/;
 const TEST_FILE_DIR_RE = /\/(?:src|__test__)\//;
@@ -265,11 +215,6 @@ function envToExecutor(env: Environment): Executor {
  * @public
  */
 export function AgentPlugin(options: AgentPluginConstructorOptions = {}, _layer?: Layer.Layer<EnvironmentDetector>) {
-	// Surface cross-package version drift once per process so partially-upgraded
-	// installs (sdk and plugin at different versions, etc.) name themselves
-	// early rather than tripping later as a confusing schema error.
-	checkVersionDrift(CURRENT_PLUGIN_VERSION);
-
 	const layer = _layer ?? EnvironmentDetectorLive;
 
 	// Plugin's own debug-log helper reads VITEST_REPORTER_LOG_LEVEL via

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/packages/reporter/CLAUDE.md
+++ b/packages/reporter/CLAUDE.md
@@ -19,7 +19,7 @@ __test__/
 
 | File | Purpose |
 | ---- | ------- |
-| `src/index.ts` | Public surface. Exports `DefaultVitestAgentReporter`, the dispatch helpers (`buildDispatchInputs`, `resolveCellOptions`, `renderAgentStringForReport`, `renderHumanStringForReport`), the live renderer (`_createLiveInk` + `LiveInkRenderer` type). Re-exports the contract types (`ResolvedReporterConfig`, `ReporterKit`, `ReporterRenderInput`, `RenderedOutput`, `VitestAgentReporter`, `VitestAgentReporterFactory`) from `@vitest-agent/sdk`. Exports `CURRENT_REPORTER_VERSION` for the cross-package drift check |
+| `src/index.ts` | Public surface. Exports `DefaultVitestAgentReporter`, the dispatch helpers (`buildDispatchInputs`, `resolveCellOptions`, `renderAgentStringForReport`, `renderHumanStringForReport`), the live renderer (`_createLiveInk` + `LiveInkRenderer` type). Re-exports the contract types (`ResolvedReporterConfig`, `ReporterKit`, `ReporterRenderInput`, `RenderedOutput`, `VitestAgentReporter`, `VitestAgentReporterFactory`) from `@vitest-agent/sdk`. Exports `CURRENT_REPORTER_VERSION` as public API for version introspection by downstream tooling |
 | `src/defaultReporter.ts` | `DefaultVitestAgentReporter` `VitestAgentReporterFactory`. Subscribes to the run-event stream at run start (`onInit`), folds published events into `RenderState`, classifies, dispatches through the 12-cell matrix, and owns mode orchestration: branches on `kit.config.consoleMode` and owns the Ink live-mount lifecycle (mount / rerender / unmount) for `stream` mode. `render(input, kit)` is called once at run end. Also exposes the dispatch helpers re-exported by `index.ts` |
 | `src/LiveInkRenderer.tsx` | `_createLiveInk` imperative orchestration. Mounts `StreamApp` for `stream` mode and drives an animation clock that ticks the spinner between run events. `event(e)` advances state and rerenders, `unmount()` is idempotent, `snapshot()` exposes the latest reduced state. Mount failures degrade silently with a stderr warning. Driven by `DefaultVitestAgentReporter`, not by the plugin |
 
@@ -37,7 +37,7 @@ __test__/
 - Editing `DefaultVitestAgentReporter`: rendering orchestration (mode branching, Ink mount lifecycle, dispatch wiring) belongs here. Reducer or dispatcher-cell changes belong in `@vitest-agent/ui`; contract changes belong in `@vitest-agent/sdk`; plugin lifecycle wiring belongs in `@vitest-agent/plugin`.
 - `render(input, kit)` takes two arguments — the second is a health-aware `ReporterKit` resolved at run end. Keep the two-argument signature in sync with the contract in `packages/sdk/src/contracts/reporter.ts`.
 - Adding a re-export: confirm the symbol genuinely belongs in the public custom-reporter surface before adding it. Surface bloat propagates to every downstream consumer.
-- Keep `CURRENT_REPORTER_VERSION` wired — the plugin's drift check compares against it, and this package is now its correct home.
+- Keep `CURRENT_REPORTER_VERSION` exported — it is public API for version introspection by downstream tooling. The cross-package runtime drift check was removed, so nothing imports it internally anymore, but it stays part of this package's surface.
 
 ## Design references
 

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -44,9 +44,9 @@
 		"react": "catalog:silk"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
+		"@savvy-web/bundler": "^1.0.1",
 		"@types/better-sqlite3": "^7.6.13",
-		"@types/node": "catalog:silk",
+		"@types/node": "^26.0.0",
 		"@types/react": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-istanbul": "^4.1.8",

--- a/packages/reporter/savvy.build.ts
+++ b/packages/reporter/savvy.build.ts
@@ -1,14 +1,8 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
-const config = defineBuild({
+await build({
 	bundledPackages: ["@vitest-agent/sdk", "@vitest-agent/ui"],
 	meta: {
 		localPaths: ["../../website/lib/models/reporter"],
 	},
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/reporter/src/index.ts
+++ b/packages/reporter/src/index.ts
@@ -64,14 +64,11 @@ export {
 	createLiveInk as _createLiveInk,
 } from "./LiveInkRenderer.js";
 
-// --- Cross-package version constant (T12 drift check) ---
+// --- Package version constant ---
 /**
  * The version of this package, inlined at build time from
  * package.json#version via rslib-builder's __PACKAGE_VERSION__ substitution.
- * The reporter is consumed through the plugin so it does not run its own
- * init-time drift check, but the constant is exported so the plugin can
- * compare against it. See the root CLAUDE.md "Cross-package version drift"
- * section.
+ * Exported for version introspection by downstream tooling.
  *
  * @public
  */

--- a/packages/reporter/tsconfig.json
+++ b/packages/reporter/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -50,8 +50,8 @@
 		"xdg-effect": "^2.0.1"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
-		"@types/node": "catalog:silk",
+		"@savvy-web/bundler": "^1.0.1",
+		"@types/node": "^26.0.0",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",
 		"typescript": "catalog:silk",

--- a/packages/sdk/savvy.build.ts
+++ b/packages/sdk/savvy.build.ts
@@ -1,6 +1,6 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
-const config = defineBuild({
+await build({
 	meta: {
 		localPaths: ["../../website/lib/models/sdk"],
 		tsdoc: {
@@ -11,9 +11,3 @@ const config = defineBuild({
 		},
 	},
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -127,14 +127,13 @@ export * from "./utils/safe-filename.js";
 export * from "./utils/validate-coverage-targets-shape.js";
 export * from "./utils/validate-phase-transition.js";
 
-// --- Cross-package version constant (T12 drift check) ---
+// --- Package version constant ---
 /**
  * The version of this package. Inlined at build time from
  * package.json#version via rslib-builder's __PACKAGE_VERSION__ substitution.
  * Source-level reads (workspace `exports: "./src/index.ts"` during dev)
  * see the `"0.0.0"` fallback — a clear signal the build pipeline has not
- * substituted yet. Read by the plugin / MCP / CLI init-time drift check.
- * See the root CLAUDE.md "Cross-package version drift" section.
+ * substituted yet. Exported for version introspection by downstream tooling.
  * @public
  */
 export const CURRENT_SDK_VERSION: string = process.env.__PACKAGE_VERSION__ ?? "0.0.0";

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/packages/sidecar-darwin-arm64/package.json
+++ b/packages/sidecar-darwin-arm64/package.json
@@ -26,8 +26,8 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
-		"@types/node": "catalog:silk",
+		"@savvy-web/bundler": "^1.0.1",
+		"@types/node": "^26.0.0",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",
 		"typescript": "catalog:silk"

--- a/packages/sidecar-darwin-arm64/savvy.build.ts
+++ b/packages/sidecar-darwin-arm64/savvy.build.ts
@@ -1,12 +1,6 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
-const config = defineBuild({
+await build({
 	meta: false,
 	exe: { fileName: "vitest-agent-sidecar" },
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/sidecar-darwin-arm64/tsconfig.json
+++ b/packages/sidecar-darwin-arm64/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/packages/sidecar-linux-arm64/package.json
+++ b/packages/sidecar-linux-arm64/package.json
@@ -26,8 +26,8 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
-		"@types/node": "catalog:silk",
+		"@savvy-web/bundler": "^1.0.1",
+		"@types/node": "^26.0.0",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",
 		"typescript": "catalog:silk"

--- a/packages/sidecar-linux-arm64/savvy.build.ts
+++ b/packages/sidecar-linux-arm64/savvy.build.ts
@@ -1,12 +1,6 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
-const config = defineBuild({
+await build({
 	meta: false,
 	exe: { fileName: "vitest-agent-sidecar" },
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/sidecar-linux-arm64/tsconfig.json
+++ b/packages/sidecar-linux-arm64/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/packages/sidecar-linux-x64/package.json
+++ b/packages/sidecar-linux-x64/package.json
@@ -26,8 +26,8 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
-		"@types/node": "catalog:silk",
+		"@savvy-web/bundler": "^1.0.1",
+		"@types/node": "^26.0.0",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",
 		"typescript": "catalog:silk"

--- a/packages/sidecar-linux-x64/savvy.build.ts
+++ b/packages/sidecar-linux-x64/savvy.build.ts
@@ -1,12 +1,6 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
-const config = defineBuild({
+await build({
 	meta: false,
 	exe: { fileName: "vitest-agent-sidecar" },
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/sidecar-linux-x64/tsconfig.json
+++ b/packages/sidecar-linux-x64/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/packages/sidecar-win32-x64/package.json
+++ b/packages/sidecar-win32-x64/package.json
@@ -26,8 +26,8 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
-		"@types/node": "catalog:silk",
+		"@savvy-web/bundler": "^1.0.1",
+		"@types/node": "^26.0.0",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",
 		"typescript": "catalog:silk"

--- a/packages/sidecar-win32-x64/savvy.build.ts
+++ b/packages/sidecar-win32-x64/savvy.build.ts
@@ -1,12 +1,6 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
-const config = defineBuild({
+await build({
 	meta: false,
 	exe: { fileName: "vitest-agent-sidecar" },
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/sidecar-win32-x64/tsconfig.json
+++ b/packages/sidecar-win32-x64/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -31,8 +31,8 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
-		"@types/node": "catalog:silk",
+		"@savvy-web/bundler": "^1.0.1",
+		"@types/node": "^26.0.0",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",
 		"typescript": "catalog:silk",

--- a/packages/sidecar/savvy.build.ts
+++ b/packages/sidecar/savvy.build.ts
@@ -1,4 +1,4 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
 // The `vitest-agent-sidecar` parent package does NOT cross-build the four SEA
 // binaries — that work lives in the per-platform `vitest-agent-sidecar-<platform>`
@@ -8,14 +8,8 @@ import { defineBuild, runBuild } from "@savvy-web/bundler";
 // and exposes a programmatic `.` export (`src/index.ts`) re-exporting the pure
 // `resolveSidecarBinaryPath` helper. The matching child puts the SEA directly on
 // PATH, so the hook runs the native binary with no intermediate Node process.
-const config = defineBuild({
+await build({
 	meta: {
 		localPaths: ["../../website/lib/models/sidecar"],
 	},
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/sidecar/tsconfig.json
+++ b/packages/sidecar/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,8 +35,8 @@
 		"effect": "catalog:silk"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
-		"@types/node": "catalog:silk",
+		"@savvy-web/bundler": "^1.0.1",
+		"@types/node": "^26.0.0",
 		"@types/react": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"ink": "^7.1.0",

--- a/packages/ui/savvy.build.ts
+++ b/packages/ui/savvy.build.ts
@@ -1,6 +1,6 @@
-import { defineBuild, runBuild } from "@savvy-web/bundler";
+import { build } from "@savvy-web/bundler";
 
-const config = defineBuild({
+await build({
 	bundledPackages: ["@vitest-agent/sdk"],
 	meta: {
 		localPaths: ["../../website/lib/models/ui"],
@@ -12,9 +12,3 @@ const config = defineBuild({
 		},
 	},
 });
-
-export default config;
-
-if (import.meta.main) {
-	await runBuild(config, { cwd: import.meta.dirname, argv: process.argv.slice(2) });
-}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -73,13 +73,11 @@ export {
 	synthesizeRunEvents,
 } from "./synthesize.js";
 
-// --- Cross-package version constant (T12 drift check) ---
+// --- Package version constant ---
 /**
  * The version of this package, inlined at build time from
  * `package.json#version` via rslib-builder's `__PACKAGE_VERSION__`
- * substitution. The UI package is consumed through the plugin so it does not
- * run its own init-time drift check, but the constant is exported so the
- * plugin can compare against it.
+ * substitution. Exported for version introspection by downstream tooling.
  *
  * @public
  */

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,5 +3,5 @@
 	"compilerOptions": {
 		"jsx": "react-jsx"
 	},
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -4,8 +4,8 @@
 	"private": true,
 	"type": "module",
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.11.1",
-		"@types/node": "catalog:silk",
+		"@savvy-web/bundler": "^1.0.1",
+		"@types/node": "^26.0.0",
 		"@typescript/native-preview": "catalog:silk",
 		"typescript": "catalog:silk",
 		"vitest": "catalog:silk"

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": ["@savvy-web/bundler/tsconfig/ecma.json"]
+	"extends": "@savvy-web/bundler/tsconfig/ecma.json"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,17 +6,17 @@ importers:
   .:
     configDependencies:
       '@savvy-web/pnpm-plugin-silk':
-        specifier: 0.16.1
-        version: 0.16.1
+        specifier: 0.18.0
+        version: 0.18.0
 
 packages:
 
-  '@savvy-web/pnpm-plugin-silk@0.16.1':
-    resolution: {integrity: sha512-ezIsMs06mTSjPqip8fcXJCx0KXVzRd3vSyjHr2YvTiqksY3Q+l9yd+YZg7Yo4CMwnyndZAolaqXX2WrN0XEWAw==}
+  '@savvy-web/pnpm-plugin-silk@0.18.0':
+    resolution: {integrity: sha512-jCfqTFQpeocI+kKo3uNkpIEuAthh2zFqNEMQvRNXMmXzyHq/mZ7ou4hGdbLRjcLo4wGPlpRHtufkrCPH2AraNg==}
 
 snapshots:
 
-  '@savvy-web/pnpm-plugin-silk@0.16.1': {}
+  '@savvy-web/pnpm-plugin-silk@0.18.0': {}
 
 ---
 lockfileVersion: '9.0'
@@ -55,8 +55,8 @@ catalogs:
       specifier: ^19.2.3
       version: 19.2.3
     '@typescript/native-preview':
-      specifier: ^7.0.0-dev.20260621.1
-      version: 7.0.0-dev.20260626.1
+      specifier: ^7.0.0-dev.20260630.1
+      version: 7.0.0-dev.20260630.1
     '@vitest/coverage-istanbul':
       specifier: ^4.1.9
       version: 4.1.9
@@ -91,15 +91,15 @@ overrides:
   smol-toml: '>=1.6.1'
   tmp: ^0.2.7
 
-pnpmfileChecksum: sha256-0Hz0PgO2FsM2liVwjPH5Y2q4AecirKTu3Q+A4ISCQ3s=
+pnpmfileChecksum: sha256-6jZVth4VKFfr9fLL0GnfLvk9HN1b6Wv8emae+KtJDHs=
 
 importers:
 
   .:
     devDependencies:
       '@savvy-web/silk':
-        specifier: ^1.3.4
-        version: 1.3.4(eb764a782732e619ef27a7ba08f4864d)
+        specifier: ^1.3.5
+        version: 1.3.5(4d3405cd032433dffc9c7d79c01804f4)
       '@vitest-agent/cli':
         specifier: workspace:*
         version: link:packages/cli/dist/dev/pkg
@@ -150,14 +150,14 @@ importers:
         version: 3.21.4
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       '@vitest/coverage-v8':
         specifier: catalog:silk
         version: 4.1.9(vitest@4.1.9)
@@ -206,14 +206,14 @@ importers:
         version: 4.4.3
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       '@vitest/coverage-v8':
         specifier: catalog:silk
         version: 4.1.9(vitest@4.1.9)
@@ -274,8 +274,8 @@ importers:
         version: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -284,7 +284,7 @@ importers:
         version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       '@vitest/coverage-istanbul':
         specifier: catalog:silk
         version: 4.1.9(vitest@4.1.9)
@@ -345,8 +345,8 @@ importers:
         version: 19.2.7
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -358,7 +358,7 @@ importers:
         version: 19.2.17
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       '@vitest/coverage-istanbul':
         specifier: ^4.1.8
         version: 4.1.9(vitest@4.1.9)
@@ -428,14 +428,14 @@ importers:
         version: 2.0.1(4b99e7aa355a094dc1986218f72d3bb6)
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       '@vitest/coverage-v8':
         specifier: catalog:silk
         version: 4.1.9(vitest@4.1.9)
@@ -450,14 +450,14 @@ importers:
   packages/sidecar:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       '@vitest/coverage-v8':
         specifier: catalog:silk
         version: 4.1.9(vitest@4.1.9)
@@ -485,14 +485,14 @@ importers:
   packages/sidecar-darwin-arm64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       '@vitest-agent/sdk':
         specifier: workspace:*
         version: link:../sdk/dist/dev/pkg
@@ -504,14 +504,14 @@ importers:
   packages/sidecar-linux-arm64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       '@vitest-agent/sdk':
         specifier: workspace:*
         version: link:../sdk/dist/dev/pkg
@@ -523,14 +523,14 @@ importers:
   packages/sidecar-linux-x64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       '@vitest-agent/sdk':
         specifier: workspace:*
         version: link:../sdk/dist/dev/pkg
@@ -542,14 +542,14 @@ importers:
   packages/sidecar-win32-x64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       '@vitest-agent/sdk':
         specifier: workspace:*
         version: link:../sdk/dist/dev/pkg
@@ -568,8 +568,8 @@ importers:
         version: 3.21.4
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
@@ -578,7 +578,7 @@ importers:
         version: 19.2.17
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       ink:
         specifier: ^7.1.0
         version: 7.1.0(@types/react@19.2.17)(react@19.2.7)
@@ -599,14 +599,14 @@ importers:
   playground:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.11.1
-        version: 0.11.2(e2c984c7d84e397a75a7695d0ac22192)
+        specifier: ^1.0.1
+        version: 1.0.1(0f606660af4b84755e92246f802c217d)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       typescript:
         specifier: catalog:silk
         version: 6.0.3
@@ -618,10 +618,10 @@ importers:
     devDependencies:
       '@rspress/core':
         specifier: ^2.0.15
-        version: 2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-sitemap':
         specifier: ^2.0.15
-        version: 2.0.15(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 2.0.15(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.1
@@ -633,7 +633,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260626.1
+        version: 7.0.0-dev.20260630.1
       react:
         specifier: catalog:silk
         version: 19.2.7
@@ -641,11 +641,11 @@ importers:
         specifier: catalog:silk
         version: 19.2.7(react@19.2.7)
       rspress-plugin-api-extractor:
-        specifier: ^0.3.2
-        version: 0.3.2(a0bd9bb2b4f856558ba95aaae869221b)
+        specifier: ^0.3.3
+        version: 0.3.3(85aeaa9ec16aa54b86d447d09e39765b)
       rspress-plugin-mermaid:
         specifier: ^1.0.1
-        version: 1.0.1(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 1.0.1(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
 
 packages:
 
@@ -990,20 +990,11 @@ packages:
       '@effect/rpc': ^0.75.1
       effect: ^3.21.2
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
-
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -1267,8 +1258,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1507,8 +1498,8 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rsbuild/core@2.0.15':
-    resolution: {integrity: sha512-O8vmMhZu1YImO6jOqt/K/vlJSvkq7UtSq5YM1DIlcEd9LW8Gf6/dkQ1B2KPI6F+hSMFBnTTTumdcIowSLCw97g==}
+  '@rsbuild/core@2.1.1':
+    resolution: {integrity: sha512-s6Cc+pHCJK9RP6Yk4LwsQWHxxxasrk5kmo9nkZK7j1iObp4w2PLivsUdP6HtkeoXuxcnK3QKH8/r49plNBjaQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1525,64 +1516,76 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.8':
-    resolution: {integrity: sha512-vCgbgH7B7qom+uID+RCZsTCOYFb9wC4/4+1U6rMfytrXGVJ72eNQs2tbdjOl0lb18CT3N/n+VkWynUiLk84GwA==}
+  '@rspack/binding-darwin-arm64@2.1.1':
+    resolution: {integrity: sha512-6K8jA3pZphBwLt5DU78wl0IzY1myHrqNSvFVCd9CHa+szlOwv2iMQpZdYdpupIBxwiZ39rrDyQKtoZw7lsAG8w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.8':
-    resolution: {integrity: sha512-satPm2PD4B7jDTVlVAdvMVdUszwLvWUEnUDzLb77mvVkezKNDZmuhb+e8s+FfKs8hJpNbZ9VAejuA2rr8o985w==}
+  '@rspack/binding-darwin-x64@2.1.1':
+    resolution: {integrity: sha512-RdqtEfIbSe5ucLNVvMac1k88UwmL4Gil8uXqlEFcSZ3VC2jTOkecadd+B0RYqJ+PirSInrRmKm1cr0740zppOA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.8':
-    resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
+  '@rspack/binding-linux-arm64-gnu@2.1.1':
+    resolution: {integrity: sha512-ROKtqXoLpbZO1vYEcNxQg6COvRhdlJcoib1Z4pzG1nIyctEAUuFmnD7pIvJiVe6M7YuJNXW+1p0BhpptT2XEUQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.0.8':
-    resolution: {integrity: sha512-igjJ43yxWQ72GZqjDDZSSHax9/Vg+6rLMmOvFglTJUkQpB4Tyvu/YjW+WRjYj2xRw6blOjLxUSJWASvuSqqlvg==}
+  '@rspack/binding-linux-arm64-musl@2.1.1':
+    resolution: {integrity: sha512-QdQpG9dK0GfPASjBd/8rUwDNW0ShfFfYJfcoGLNTM6A8EqmgvWwklXDiCVF5dXALbZIksAuRznIKnLDsUoXi9Q==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.0.8':
-    resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
+  '@rspack/binding-linux-riscv64-gnu@2.1.1':
+    resolution: {integrity: sha512-LGdYCAvblZp2qtHk9UseYftIRyaBzSWqEzd1toaS08sYESXERm+YBbrYKKiyq1yXiU1L7BkhMUxiWc3GCYmKcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-musl@2.1.1':
+    resolution: {integrity: sha512-87phiiPGFT1p4gy3Oz6YdNijCPXdjJy43LFdE8AFiZsV4ChFXQPqnVCF2aMRLybYa51A+9wGYlTvxt09yUQUww==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-x64-gnu@2.1.1':
+    resolution: {integrity: sha512-om0/PvZzxISsnyz3hdmI3xBi3Qsn6faRGrfp6WJpGHa5JYYaRVWz1MJ9fe+/cQE9ON9r32HpMOeuataCLv+Owg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.0.8':
-    resolution: {integrity: sha512-6CtDaGZjNDvJd9TBp7a9zABbrPORO21W96+3ZcGBn0YNUPUk4ARxIxrTTpeJ/1F41QDM8AYIkGDdqEYMqTYBsA==}
+  '@rspack/binding-linux-x64-musl@2.1.1':
+    resolution: {integrity: sha512-YgAyTOM5ZWvWT0Exwcg7QkGUv9PsHT4yIsEyJbH+a99uAKliGMwkHIOP/aJgrCF8G+lTfigY2wyl9cWo4TA4aw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.0.8':
-    resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
+  '@rspack/binding-wasm32-wasi@2.1.1':
+    resolution: {integrity: sha512-OicgaB3Dcd+KXsH/I3DkJG7XQyREJScg/jLkCtycFn9BhT0IVJvgi37F8QNJKl8Bp9YZIGehsqK9HpQWav6SLw==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.8':
-    resolution: {integrity: sha512-8NCuiQsAhXrwRBy57QZoypqrws/zLBkaQVGiB8hksr6v++8hNigNjqpQARLbd0iyMuHsQQ++8+auGk6xlDXmzw==}
+  '@rspack/binding-win32-arm64-msvc@2.1.1':
+    resolution: {integrity: sha512-fwL4P3SsC0r/vVGgnmexnc4vkvf+9vWMcGw5fdlPBJNR/zWlZRSXR5V6eXcHrpYVLhBsLYvZYE3NZa9paIUGxw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.8':
-    resolution: {integrity: sha512-bxiekytbX7V9KFAra+HkwtNWC6pYfHEBBZFpiT0xUs3mCFOmAAFVBsBSQsoCP9AdCEXoMAvNdnrHNw3iov4OZw==}
+  '@rspack/binding-win32-ia32-msvc@2.1.1':
+    resolution: {integrity: sha512-j3BISXbjPyI57HeHxW9Jx+UP7RebNQ4t62uCbRP29caf9aghYJP+ZA5nJ2X7pol7N5Je2/V6WNahuNd0zQFDOA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.8':
-    resolution: {integrity: sha512-7zPs8YCe/ZVJTwd+5lpB0CP0tkn2pONf/T1ycmVY76u21Nrwt8mXQGc/2yH2eWP4B7fikYBr3hGr7mpR2fajqQ==}
+  '@rspack/binding-win32-x64-msvc@2.1.1':
+    resolution: {integrity: sha512-aPNNFuZT5iBM8+S9J4P5ywJbf3tUvZN3Ppe6mXJ8/jTVDUDhe0YVj3AgD/AuxnUvl+yHrLfQkN1nNwUfIcomfA==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.0.8':
-    resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
+  '@rspack/binding@2.1.1':
+    resolution: {integrity: sha512-6062hZP33fn1w51ClpQnum19GGXl/3eS754xrRYbQ7wwBNZk94HVwfSyiqcNCtY/pB1lsFjnaTKiW/Q+jv0axQ==}
 
-  '@rspack/core@2.0.8':
-    resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
+  '@rspack/core@2.1.1':
+    resolution: {integrity: sha512-Rgz6xZcD0rm7ejZhYNi13qvW2dSnIQQt/7D3xbYoT5hOU838JbkF0P3SAMFGKE+FyLZswnyRpxGfnYHZQqDmJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -1646,8 +1649,8 @@ packages:
   '@rushstack/ts-command-line@5.3.10':
     resolution: {integrity: sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==}
 
-  '@savvy-web/bundler@0.11.2':
-    resolution: {integrity: sha512-2at7loxxkIP63mFCWD1aBQje0g9EUzrvYrMoPyCSbn+z4rCZ+5HiCCD2mi4BWbGopcy6JtK5IOLrQblHbvUGJw==}
+  '@savvy-web/bundler@1.0.1':
+    resolution: {integrity: sha512-4XPRmFVzTEk+d6u1asiGpEtTbT7EZDLVQGrT8peuBtP4z0B7Zfq7/5K73NoiL7X2A/dpzbazyJs1kLrmrm7cqw==}
     peerDependencies:
       '@types/node': ^26.0.0
       '@types/react': ^19.2.0
@@ -1666,29 +1669,29 @@ packages:
       react-dom:
         optional: true
 
-  '@savvy-web/cli@1.3.4':
-    resolution: {integrity: sha512-+ZiHXjCiS5QHZtDAaxRlz7w/eiuwu7Q710adWcUUT6hdhQP3mWx3C3+neZvk2C9CgLYkSLX0HOBUjB3EJedjAw==}
+  '@savvy-web/cli@1.3.5':
+    resolution: {integrity: sha512-3npVx0yJblD6OU8HwOQfEvQUV3hfShLOcrRwjm2geS8NEn1+teHKDXvHfuhDqklH1PVfBr1y+Go8p8VSKx5Xaw==}
     hasBin: true
 
-  '@savvy-web/mcp@1.3.4':
-    resolution: {integrity: sha512-Oemf5C5Oydeof6jBPtrz3EqWn6OofEMp3aUN2Z511lSUKaFpFo379jusd2KPUYSWRJNIpsqDnUi9Mbs8I277zQ==}
+  '@savvy-web/mcp@1.3.5':
+    resolution: {integrity: sha512-TtOGB1XOK4hdlYkLtJ5BKBAELSTVE/kGokbR2qboeJQ6C84ZbL1/Mdm3eKFyUMG8b71PmB+jZdkeam7y6SF2aA==}
     hasBin: true
 
-  '@savvy-web/silk-effects@1.5.1':
-    resolution: {integrity: sha512-dPSzT8nd2YbG39Ow+OaWwv6dAl5b7aBeORjVRh64wcUiWPnacmShpkUmduWEUXpbU8CrzBo9IjtJ8a9DrGQoVA==}
+  '@savvy-web/silk-effects@1.5.2':
+    resolution: {integrity: sha512-0PSBEfdfI84YlK+H2urVnw/4AjAU0dodBZ056EzMSiF3DE0vMRlemHifakKSip5Wm6/r1FB4mSBTsv/0b0kTAw==}
     peerDependencies:
-      '@effect/platform': '>=0.96.0'
-      effect: '>=3.21.0'
+      '@effect/platform': ^0.96.0
+      effect: ^3.21.0
 
-  '@savvy-web/silk@1.3.4':
-    resolution: {integrity: sha512-mjNO3WCUFGK9nP9eEtgv7h1hD4oYC6cRbVe/g0/4CNaEm7LeyEodrs/p15qGZuoqkOsCWkOzdVu81tpGxTgi5w==}
+  '@savvy-web/silk@1.3.5':
+    resolution: {integrity: sha512-oXz8Th2WSDEuiSF5Vlm+S0qJVWLMwly/N4bkSomM6sAJxrizlH20enpmJ+z/PEeM1sVq7M590PDJ6Xgu6LHdkA==}
     peerDependencies:
       '@biomejs/biome': ~2.5.0
       '@changesets/cli': ^2.31.0
-      '@commitlint/cli': ^21.0.1
-      '@commitlint/config-conventional': ^21.0.2
-      '@savvy-web/cli': 1.3.4
-      '@savvy-web/mcp': 1.3.4
+      '@commitlint/cli': ^21.1.0
+      '@commitlint/config-conventional': ^21.1.0
+      '@savvy-web/cli': 1.3.5
+      '@savvy-web/mcp': 1.3.5
       '@types/node': ^26.0.0
       '@typescript/native-preview': ^7.0.0-dev.20260612.1
       commitizen: ^4.3.0
@@ -1696,16 +1699,16 @@ packages:
       lint-staged: ^17.0.7
       markdownlint-cli2: ^0.22.1
       markdownlint-cli2-formatter-codequality: ^0.0.7
-      turbo: ^2.9.18
+      turbo: ^2.10.0
       typescript: ^6.0.0
     peerDependenciesMeta:
       '@biomejs/biome':
         optional: true
 
-  '@savvy-web/tsdown-plugins@0.11.2':
-    resolution: {integrity: sha512-N1JJefs2uPvAhJzxshavZUVVQunhaU72nIpUJlKOK8ddY+Mkad8p+LCUxuhOfCV8aGvVUTgvc24+aFky+babxg==}
+  '@savvy-web/tsdown-plugins@1.0.1':
+    resolution: {integrity: sha512-py/yTsT8BX5/ZBv2E0Q++b072W1bkuzfPGiunbBF8bc4izwyw6gnfI4NW3k9c+1gTTRDOTsiDzS30SjWGt/iwQ==}
     peerDependencies:
-      effect: '>=3.21.0'
+      effect: ^3.21.0
 
   '@shikijs/core@4.3.0':
     resolution: {integrity: sha512-EooU3i9F6IAE8kEu+AnGf9DFZWkQBZ+hJn3tLVbsH+61mtQiva5biai66fAA6nvFPXkLgvrh7BrR7YcJU83xQQ==}
@@ -1781,33 +1784,33 @@ packages:
     peerDependencies:
       tsdown: 0.22.3
 
-  '@turbo/darwin-64@2.10.0':
-    resolution: {integrity: sha512-EwvHThXzpY0KGd1/NAmuewI5D+aVa3Rl/OlxE36yfjUKb/+ySrfJrSlEFt8aD1OXwnnaHnQnPKHFndor0Zxlsg==}
+  '@turbo/darwin-64@2.10.1':
+    resolution: {integrity: sha512-EjfrTXVmT0r4Spv+nu1KRcvjqavCq35F5GRCvoxQi83uoX3wxQ2QTgDkSxO8O4HVXyi28dW0of/y2RFBOD4emA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.10.0':
-    resolution: {integrity: sha512-9d2fTyyG0lf5Wq1bwJA9qUaeecViMkLcdctWaMMmCkxZ/JqypmqOwK3W6vmejeKVgkr06gSoiX8bD+xN5Jpxcg==}
+  '@turbo/darwin-arm64@2.10.1':
+    resolution: {integrity: sha512-nVNvaJ7aHxF5zBw8Nc9Er2Iw8A/SPAw25sqlu/63/qGfDMGdarRYrxjdM0O0XK8X8bGg3Yr93Ro7I5tJksrfgA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.10.0':
-    resolution: {integrity: sha512-sZBtjMuufitanjzi6UssoUpJMnnPlLMcdcJj3m3ptNsSq31Xh7MnjhwA5nWvLDTfEFg8GPcbYFXMo8vSdKRfqQ==}
+  '@turbo/linux-64@2.10.1':
+    resolution: {integrity: sha512-jaYr5GQGfW2jMkoux7/Yh+pUhKgqBM0pyAZnNTUybnVPy4qB2jP0C4B32Nmg00BYaAU3FaWr/bQ3CKKIYjdI2Q==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.10.0':
-    resolution: {integrity: sha512-vkq/Z8R+1DQ+kifWFa810IjRy2NNBVvha3cg9sWA3nFh6nnGrHSMnnJKrzH7c/No9kq4Jb55Ru44YKsCSBgrKg==}
+  '@turbo/linux-arm64@2.10.1':
+    resolution: {integrity: sha512-2Wg5TBGYQjaPMJhQzYf0EEM9N5mSE3AKmWBWKz6fsjZ8dlLL4uV7X3PnwtNO1+kRYjwg34ilJwweaT8MvxZOcA==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.10.0':
-    resolution: {integrity: sha512-CRUEguLWxFQHptYZS7HjPhNhAFawfea07iR+xAQ5e4klgLrPCMdexBkXwSCwOxqTFknJ7RZFN3gOaADsw+Gttg==}
+  '@turbo/windows-64@2.10.1':
+    resolution: {integrity: sha512-fRCK6wZiWQgE5fb+WpaBgDsHNo/fKcCoMEOms9E5Il/Bp/ec9uhsVNn0V/2gmN2hSCyFm7oKf0BZY6Lb6CDMOQ==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.10.0':
-    resolution: {integrity: sha512-dVHGaf9F8twzgibcBqKoADT/LLqf9++jDb+hq/LPWWaOmRpp4M+/pVOm7vy4z9D++xg8eaxWLT0+wQxFwhYu9A==}
+  '@turbo/windows-arm64@2.10.1':
+    resolution: {integrity: sha512-6REIwRpmmnJdHYL+fIv2BGBC9PYd+8Ta+J53nmcHjqi46v/z+hS1sirYU5fg7Cg1r9/99dpRtSXHKTgvcLYSpg==}
     cpu: [arm64]
     os: [win32]
 
@@ -1892,50 +1895,50 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260626.1':
-    resolution: {integrity: sha512-VDPHf8RZRzsBH6cgArK1u9sH8MODMNkvkNczEt1EXpOLfZeplIhcpKld5Zc9Da8/S9YB4768rjfBkdFokxBu+Q==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260630.1':
+    resolution: {integrity: sha512-zo1TYD32r+MKOTnzhB1YGr2Jrw14tzGR/rpfr6hRMDz0kV9k2CWVvtOYOmOtRdmuO4KWZcWtVX13QyaPGhA8Hw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260626.1':
-    resolution: {integrity: sha512-bi7iQZe2A90cFJ3EQnigezEI7F0e5vX6E/QUGluQ1mKZmcbbQCdAwDMDQFV8Z6w3xNrk9AYyNQbvq0DtzJX46w==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260630.1':
+    resolution: {integrity: sha512-57RYyZQQ6+drfu+CagVdqUvQwNesvuu/rJb/au66jv+figfpDOugD0S6ruQl1SxpFFfr0lCny3KEplsBdqFDEg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260626.1':
-    resolution: {integrity: sha512-/iptuCYiucdY0HK0nE5ydRjIx0KOf3AY7fieRaQHA4X9/s4ey37rc/58aBX3dtx0x2EhlzpXT5f0ikYY65Zynw==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260630.1':
+    resolution: {integrity: sha512-QQxNyZ9rVbE6lUqctrrRiTtA5Z0w2FFBy8SkiP/eDkuRy2WXrVpMQYntNn6d4nO1nWTmWJR1z/CS+H2rsrl8gg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260626.1':
-    resolution: {integrity: sha512-ilB0Ew5GWLrqMklNVrMdCEyNePypoEMnd4l5aUopnDRebgtXmtu0RE2GDl9LOTZ1BwlbXsuYAkEHt18Ta25hxg==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260630.1':
+    resolution: {integrity: sha512-FLJSSt3bUmRpzWlr5cDE+td40FoDy/MT+VDYk4JGouisJo7g7GPjuF+fYOfsKI/RbD9f6gDFTyFPAoTLVVR/9g==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260626.1':
-    resolution: {integrity: sha512-4o80l1+RoJLkR1G4KOZjTYN1yOAGbq0K2CAP0zF35MPnD8O559Tw8OMuYA+XPpEFE0fkb7mmcxL8J9cxM/kAbw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260630.1':
+    resolution: {integrity: sha512-WqNPvUBngGfnkunqn3IuIkkF6PA/HPSSbVucolO7stc9DxWZqfRals6/C8RTvuQaif9qt+bcY9U6lLXuDFyClA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260626.1':
-    resolution: {integrity: sha512-xHxewRWY74zJnwt4bj+Kdf6Owfs6L0Fbggb37psSa6CvofqcvSI3AyuwiBNjC0T8Eb/d/BMMXttbPJ4XXqMpXQ==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260630.1':
+    resolution: {integrity: sha512-awATkrGGm2L1IraQgaw21VXWtAqv79DJ57No/J65Y+bL8InOVR2zu+zCH+5E44m8bh9IXwnShI7cAdvp02WNEw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260626.1':
-    resolution: {integrity: sha512-Iuf5nqTY4m5kxEvraDpieEf0XS6gDdjBBkw3g74pseznhpMeDFzgRvVCbSaf2pdjBNGugZbiBDVTEOclmD9cjA==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260630.1':
+    resolution: {integrity: sha512-M/+P66Gsss/CANV+MkKVFeNi9jljYYR3N2COf/WrVYcDwrHyiYHZYExfTw2cEbbkH8LcawXAekp9d23bevBR4Q==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260626.1':
-    resolution: {integrity: sha512-2RC5omeJPqWKebi5zM3nkMSrTpKpq2zLB3SfceqmFZY3vMCXtIJSE6IpA/AszlKQmNcbT/kWscmgE/PXEvnguQ==}
+  '@typescript/native-preview@7.0.0-dev.20260630.1':
+    resolution: {integrity: sha512-5OTvy2YpoDsOwAPqj4LkI4mrlAtc3mRzNdHAPp/1JWUvsKSRTzqAB2JPVD4qHUkAd9qY89yb758kc7fGyn3gbw==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -2166,8 +2169,8 @@ packages:
   body-scroll-lock@4.0.0-beta.0:
     resolution: {integrity: sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2278,8 +2281,8 @@ packages:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
-  cli-truncate@6.0.1:
-    resolution: {integrity: sha512-2FPVnc3JxdRLONB/9edO1RwuUFFPJ3U2c6XvyccEhjqV5xw6mS22aH27OFdD1u4IYQOEUzXsT6ZU06d1VCSu+Q==}
+  cli-truncate@6.1.0:
+    resolution: {integrity: sha512-ofWtXdvPO1WepoE9Gn4dPdZw+ADud1Yz9K+xm9FjK5vvrs/D60vrlKIQeSw1wJX4cphW2bnWi8GZSKvf9T6shw==}
     engines: {node: '>=22'}
 
   cli-width@3.0.0:
@@ -2730,8 +2733,8 @@ packages:
   effect@3.21.4:
     resolution: {integrity: sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==}
 
-  electron-to-chromium@1.5.378:
-    resolution: {integrity: sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==}
+  electron-to-chromium@1.5.381:
+    resolution: {integrity: sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==}
 
   elkjs@0.9.3:
     resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
@@ -2787,15 +2790,15 @@ packages:
   es-get-iterator@1.1.3:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+  es-module-lexer@2.2.0:
+    resolution: {integrity: sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.48.1:
-    resolution: {integrity: sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==}
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -2911,8 +2914,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2981,8 +2984,8 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
-  fs-extra@11.3.5:
-    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+  fs-extra@11.3.6:
+    resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -3494,16 +3497,16 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -4309,8 +4312,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -4328,8 +4331,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.3:
+    resolution: {integrity: sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -4404,15 +4407,15 @@ packages:
     peerDependencies:
       react: '>=19'
 
-  react-router-dom@7.18.0:
-    resolution: {integrity: sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==}
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.18.0:
-    resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -4585,8 +4588,8 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  rspress-plugin-api-extractor@0.3.2:
-    resolution: {integrity: sha512-7wtXVZ5j7KSPctn1EtdtfTZor7Qfr+ulQzYc0md4L27ZM1hqFYkw0THp3Mka86lffdFe/DzVAkGMNRvul79+aA==}
+  rspress-plugin-api-extractor@0.3.3:
+    resolution: {integrity: sha512-ZjtZ811Lhevovpi1FsI2xSwW0w9ALNq7gGnlV6MlvimM72+Avhf9YtP9YtnVH9D2N20bOQnEgy3HCeT7T8vgfA==}
     engines: {node: '>=24.11.0'}
     peerDependencies:
       '@rspress/core': ^2.0.0
@@ -4901,8 +4904,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -5013,8 +5016,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.10.0:
-    resolution: {integrity: sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw==}
+  turbo@2.10.1:
+    resolution: {integrity: sha512-z9WGX2bAfElLOri8JY6pcwr+GfS18B5iGefLcvv3nwM9MoE/fPQQhpgZKTRlBciqGSDuLnfNyfP+eji8mEapQA==}
     hasBin: true
 
   twoslash-protocol@0.3.9:
@@ -5672,7 +5675,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -5736,7 +5739,7 @@ snapshots:
   '@commitlint/ensure@21.1.0':
     dependencies:
       '@commitlint/types': 21.1.0
-      es-toolkit: 1.48.1
+      es-toolkit: 1.49.0
 
   '@commitlint/execute-rule@21.0.1': {}
 
@@ -5765,7 +5768,7 @@ snapshots:
       '@commitlint/types': 21.1.0
       cosmiconfig: 9.0.2(typescript@6.0.3)
       cosmiconfig-typescript-loader: 6.3.0(@types/node@26.0.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
-      es-toolkit: 1.48.1
+      es-toolkit: 1.49.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
     transitivePeerDependencies:
@@ -5794,7 +5797,7 @@ snapshots:
     dependencies:
       '@commitlint/config-validator': 21.1.0
       '@commitlint/types': 21.1.0
-      es-toolkit: 1.48.1
+      es-toolkit: 1.49.0
       global-directory: 5.0.0
       resolve-from: 5.0.0
 
@@ -5928,29 +5931,13 @@ snapshots:
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
 
-  '@emnapi/core@1.10.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6197,10 +6184,10 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -6359,87 +6346,95 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rsbuild/core@2.0.15':
+  '@rsbuild/core@2.1.1':
     dependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.8(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.15
+      '@rsbuild/core': 2.1.1
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rspack/binding-darwin-arm64@2.0.8':
+  '@rspack/binding-darwin-arm64@2.1.1':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.8':
+  '@rspack/binding-darwin-x64@2.1.1':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.8':
+  '@rspack/binding-linux-arm64-gnu@2.1.1':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.8':
+  '@rspack/binding-linux-arm64-musl@2.1.1':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.8':
+  '@rspack/binding-linux-riscv64-gnu@2.1.1':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.8':
+  '@rspack/binding-linux-riscv64-musl@2.1.1':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.0.8':
+  '@rspack/binding-linux-x64-gnu@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.1':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.1.1':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.8':
+  '@rspack/binding-win32-arm64-msvc@2.1.1':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.8':
+  '@rspack/binding-win32-ia32-msvc@2.1.1':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.8':
+  '@rspack/binding-win32-x64-msvc@2.1.1':
     optional: true
 
-  '@rspack/binding@2.0.8':
+  '@rspack/binding@2.1.1':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.8
-      '@rspack/binding-darwin-x64': 2.0.8
-      '@rspack/binding-linux-arm64-gnu': 2.0.8
-      '@rspack/binding-linux-arm64-musl': 2.0.8
-      '@rspack/binding-linux-x64-gnu': 2.0.8
-      '@rspack/binding-linux-x64-musl': 2.0.8
-      '@rspack/binding-wasm32-wasi': 2.0.8
-      '@rspack/binding-win32-arm64-msvc': 2.0.8
-      '@rspack/binding-win32-ia32-msvc': 2.0.8
-      '@rspack/binding-win32-x64-msvc': 2.0.8
+      '@rspack/binding-darwin-arm64': 2.1.1
+      '@rspack/binding-darwin-x64': 2.1.1
+      '@rspack/binding-linux-arm64-gnu': 2.1.1
+      '@rspack/binding-linux-arm64-musl': 2.1.1
+      '@rspack/binding-linux-riscv64-gnu': 2.1.1
+      '@rspack/binding-linux-riscv64-musl': 2.1.1
+      '@rspack/binding-linux-x64-gnu': 2.1.1
+      '@rspack/binding-linux-x64-musl': 2.1.1
+      '@rspack/binding-wasm32-wasi': 2.1.1
+      '@rspack/binding-win32-arm64-msvc': 2.1.1
+      '@rspack/binding-win32-ia32-msvc': 2.1.1
+      '@rspack/binding-win32-x64-msvc': 2.1.1
 
-  '@rspack/core@2.0.8(@swc/helpers@0.5.23)':
+  '@rspack/core@2.1.1(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': 2.0.8
+      '@rspack/binding': 2.1.1
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.8(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@rsbuild/core': 2.0.15
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8(@swc/helpers@0.5.23))
+      '@rsbuild/core': 2.1.1
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.15
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -6459,7 +6454,7 @@ snapshots:
       react-lazy-with-preload: 2.2.1
       react-reconciler: 0.33.0(react@19.2.7)
       react-render-to-markdown: 19.1.0(react@19.2.7)
-      react-router-dom: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router-dom: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rehype-external-links: 3.0.0
       rehype-raw: 7.0.0
       remark-cjk-friendly: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
@@ -6484,13 +6479,13 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@rspress/plugin-sitemap@2.0.15(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rspress/plugin-sitemap@2.0.15(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))':
     dependencies:
-      '@rspress/core': 2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rspress/shared@2.0.15':
     dependencies:
-      '@rsbuild/core': 2.0.15
+      '@rsbuild/core': 2.1.1
       '@shikijs/rehype': 4.3.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -6502,7 +6497,7 @@ snapshots:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fs-extra: 11.3.5
+      fs-extra: 11.3.6
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.12
@@ -6536,15 +6531,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@savvy-web/bundler@0.11.2(e2c984c7d84e397a75a7695d0ac22192)':
+  '@savvy-web/bundler@1.0.1(0f606660af4b84755e92246f802c217d)':
     dependencies:
-      '@savvy-web/tsdown-plugins': 0.11.2(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.1)(effect@3.21.4)
+      '@savvy-web/tsdown-plugins': 1.0.1(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.1)(effect@3.21.4)
       '@tsdown/exe': 0.22.3(tsdown@0.22.3)
       '@types/node': 26.0.1
-      '@typescript/native-preview': 7.0.0-dev.20260626.1
+      '@typescript/native-preview': 7.0.0-dev.20260630.1
       effect: 3.21.4
       rolldown: 1.1.3
-      tsdown: 0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260626.1)(tsx@4.22.4)(typescript@6.0.3)
+      tsdown: 0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260630.1)(tsx@4.22.4)(typescript@6.0.3)
       typescript: 6.0.3
     optionalDependencies:
       '@types/react': 19.2.17
@@ -6569,7 +6564,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@savvy-web/cli@1.3.4(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
+  '@savvy-web/cli@1.3.5(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
     dependencies:
       '@effect/cli': 0.75.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/cluster': 0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -6577,7 +6572,7 @@ snapshots:
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
-      '@savvy-web/silk-effects': 1.5.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      '@savvy-web/silk-effects': 1.5.2(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
       jsonc-effect: 0.2.1(effect@3.21.4)
       workspaces-effect: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
@@ -6592,7 +6587,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/mcp@1.3.4(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
+  '@savvy-web/mcp@1.3.5(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
     dependencies:
       '@effect/cluster': 0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/platform': 0.96.2(effect@3.21.4)
@@ -6600,7 +6595,7 @@ snapshots:
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@savvy-web/silk-effects': 1.5.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      '@savvy-web/silk-effects': 1.5.2(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
       fuse.js: 7.4.2
       workspaces-effect: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
@@ -6614,7 +6609,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/silk-effects@1.5.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)':
+  '@savvy-web/silk-effects@1.5.2(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/config': 3.1.4
@@ -6626,7 +6621,7 @@ snapshots:
       jsonc-effect: 0.2.1(effect@3.21.4)
       mdast-util-heading-range: 4.0.0
       mdast-util-to-string: 4.0.0
-      prettier: 3.8.4
+      prettier: 3.9.3
       remark-gfm: 4.0.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -6645,17 +6640,17 @@ snapshots:
       - encoding
       - supports-color
 
-  '@savvy-web/silk@1.3.4(eb764a782732e619ef27a7ba08f4864d)':
+  '@savvy-web/silk@1.3.5(4d3405cd032433dffc9c7d79c01804f4)':
     dependencies:
       '@changesets/cli': 2.31.0(@types/node@26.0.1)
       '@commitlint/cli': 21.1.0(@types/node@26.0.1)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
       '@commitlint/config-conventional': 21.1.0
       '@effect/platform': 0.96.2(effect@3.21.4)
-      '@savvy-web/cli': 1.3.4(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
-      '@savvy-web/mcp': 1.3.4(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
-      '@savvy-web/silk-effects': 1.5.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      '@savvy-web/cli': 1.3.5(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
+      '@savvy-web/mcp': 1.3.5(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
+      '@savvy-web/silk-effects': 1.5.2(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@types/node': 26.0.1
-      '@typescript/native-preview': 7.0.0-dev.20260626.1
+      '@typescript/native-preview': 7.0.0-dev.20260630.1
       commitizen: 4.3.2(@types/node@26.0.1)(typescript@6.0.3)
       effect: 3.21.4
       husky: 9.1.7
@@ -6663,13 +6658,13 @@ snapshots:
       markdownlint-cli2: 0.22.1
       markdownlint-cli2-formatter-codequality: 0.0.7(markdownlint-cli2@0.22.1)
       semver: 7.8.5
-      turbo: 2.10.0
+      turbo: 2.10.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@savvy-web/tsdown-plugins@0.11.2(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.1)(effect@3.21.4)':
+  '@savvy-web/tsdown-plugins@1.0.1(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.1)(effect@3.21.4)':
     dependencies:
       '@changesets/get-release-plan': 4.0.16
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -6781,24 +6776,24 @@ snapshots:
       obug: 2.1.3
       semver: 7.8.5
       tinyexec: 1.2.4
-      tsdown: 0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260626.1)(tsx@4.22.4)(typescript@6.0.3)
+      tsdown: 0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260630.1)(tsx@4.22.4)(typescript@6.0.3)
 
-  '@turbo/darwin-64@2.10.0':
+  '@turbo/darwin-64@2.10.1':
     optional: true
 
-  '@turbo/darwin-arm64@2.10.0':
+  '@turbo/darwin-arm64@2.10.1':
     optional: true
 
-  '@turbo/linux-64@2.10.0':
+  '@turbo/linux-64@2.10.1':
     optional: true
 
-  '@turbo/linux-arm64@2.10.0':
+  '@turbo/linux-arm64@2.10.1':
     optional: true
 
-  '@turbo/windows-64@2.10.0':
+  '@turbo/windows-64@2.10.1':
     optional: true
 
-  '@turbo/windows-arm64@2.10.0':
+  '@turbo/windows-arm64@2.10.1':
     optional: true
 
   '@tybys/wasm-util@0.10.3':
@@ -6882,36 +6877,36 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260626.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260630.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260626.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260630.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260626.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260630.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260626.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260630.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260626.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260630.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260626.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260630.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260626.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260630.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260626.1':
+  '@typescript/native-preview@7.0.0-dev.20260630.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260626.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260626.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260626.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260626.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260626.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260626.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260626.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260630.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260630.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260630.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260630.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260630.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260630.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260630.1
 
   '@typescript/vfs@1.6.4(typescript@6.0.3)':
     dependencies:
@@ -7028,14 +7023,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7065,12 +7060,12 @@ snapshots:
 
   ansis@4.3.1: {}
 
-  api-extractor-llms@0.2.0(@types/node@26.0.1)(@typescript/native-preview@7.0.0-dev.20260626.1)(typescript@6.0.3):
+  api-extractor-llms@0.2.0(@types/node@26.0.1)(@typescript/native-preview@7.0.0-dev.20260630.1)(typescript@6.0.3):
     dependencies:
       '@microsoft/api-extractor-model': 7.33.8(@types/node@26.0.1)
       '@microsoft/tsdoc': 0.16.0
       '@types/node': 26.0.1
-      '@typescript/native-preview': 7.0.0-dev.20260626.1
+      '@typescript/native-preview': 7.0.0-dev.20260630.1
       typescript: 6.0.3
 
   argparse@1.0.10:
@@ -7159,7 +7154,7 @@ snapshots:
 
   body-scroll-lock@4.0.0-beta.0: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7171,7 +7166,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.378
+      electron-to-chromium: 1.5.381
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
@@ -7261,7 +7256,7 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.1
 
-  cli-truncate@6.0.1:
+  cli-truncate@6.1.0:
     dependencies:
       slice-ansi: 9.0.0
       string-width: 8.2.1
@@ -7402,7 +7397,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -7731,7 +7726,7 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  electron-to-chromium@1.5.378: {}
+  electron-to-chromium@1.5.381: {}
 
   elkjs@0.9.3: {}
 
@@ -7780,13 +7775,13 @@ snapshots:
       isarray: 2.0.5
       stop-iteration-iterator: 1.1.0
 
-  es-module-lexer@2.1.0: {}
+  es-module-lexer@2.2.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
-  es-toolkit@1.48.1: {}
+  es-toolkit@1.49.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -7954,7 +7949,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.3: {}
 
   fastq@1.20.1:
     dependencies:
@@ -8020,7 +8015,7 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
-  fs-extra@11.3.5:
+  fs-extra@11.3.6:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
@@ -8151,7 +8146,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -8377,9 +8372,9 @@ snapshots:
       chalk: 5.6.2
       cli-boxes: 4.0.1
       cli-cursor: 4.0.0
-      cli-truncate: 6.0.1
+      cli-truncate: 6.1.0
       code-excerpt: 4.0.0
-      es-toolkit: 1.48.1
+      es-toolkit: 1.49.0
       indent-string: 5.0.0
       is-in-ci: 2.0.0
       patch-console: 2.0.0
@@ -8599,7 +8594,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -8608,7 +8603,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -9554,7 +9549,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 
@@ -9766,7 +9761,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.16:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -9786,12 +9781,12 @@ snapshots:
       pump: 3.0.4
       rc: 1.2.8
       simple-get: 4.0.1
-      tar-fs: 2.1.4
+      tar-fs: 2.1.5
       tunnel-agent: 0.6.0
 
   prettier@2.8.8: {}
 
-  prettier@3.8.4: {}
+  prettier@3.9.3: {}
 
   property-information@7.2.0: {}
 
@@ -9873,13 +9868,13 @@ snapshots:
       react: 19.2.7
       react-reconciler: 0.33.0(react@19.2.7)
 
-  react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie: 1.1.1
       react: 19.2.7
@@ -9892,7 +9887,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -10103,7 +10098,7 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rolldown-plugin-dts@0.26.0(@typescript/native-preview@7.0.0-dev.20260626.1)(rolldown@1.1.3)(typescript@6.0.3):
+  rolldown-plugin-dts@0.26.0(@typescript/native-preview@7.0.0-dev.20260630.1)(rolldown@1.1.3)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2
@@ -10115,7 +10110,7 @@ snapshots:
       obug: 2.1.3
       rolldown: 1.1.3
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260626.1
+      '@typescript/native-preview': 7.0.0-dev.20260630.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -10151,16 +10146,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rspress-plugin-api-extractor@0.3.2(a0bd9bb2b4f856558ba95aaae869221b):
+  rspress-plugin-api-extractor@0.3.3(85aeaa9ec16aa54b86d447d09e39765b):
     dependencies:
       '@effect/platform': 0.96.2(effect@3.21.4)
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@microsoft/api-extractor-model': 7.33.8(@types/node@26.0.1)
-      '@rspress/core': 2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@shikijs/twoslash': 4.3.0(typescript@6.0.3)
-      api-extractor-llms: 0.2.0(@types/node@26.0.1)(@typescript/native-preview@7.0.0-dev.20260626.1)(typescript@6.0.3)
+      api-extractor-llms: 0.2.0(@types/node@26.0.1)(@typescript/native-preview@7.0.0-dev.20260630.1)(typescript@6.0.3)
       clsx: 2.1.1
       effect: 3.21.4
       gray-matter: 4.0.3
@@ -10169,7 +10164,7 @@ snapshots:
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-hast: 13.2.1
       open: 11.0.0
-      prettier: 3.8.4
+      prettier: 3.9.3
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-markdown: 10.1.0(@types/react@19.2.17)(react@19.2.7)
@@ -10191,9 +10186,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  rspress-plugin-devkit@1.0.0(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
+  rspress-plugin-devkit@1.0.0(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
     dependencies:
-      '@rspress/core': 2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -10216,11 +10211,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rspress-plugin-mermaid@1.0.1(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
+  rspress-plugin-mermaid@1.0.1(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)):
     dependencies:
-      '@rspress/core': 2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       mermaid: 10.9.6
-      rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.15(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
+      rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.15(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -10531,7 +10526,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tar-fs@2.1.4:
+  tar-fs@2.1.5:
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
@@ -10588,7 +10583,7 @@ snapshots:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
-  tsdown@0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260626.1)(tsx@4.22.4)(typescript@6.0.3):
+  tsdown@0.22.3(@tsdown/exe@0.22.3)(@typescript/native-preview@7.0.0-dev.20260630.1)(tsx@4.22.4)(typescript@6.0.3):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -10599,7 +10594,7 @@ snapshots:
       obug: 2.1.3
       picomatch: 4.0.4
       rolldown: 1.1.3
-      rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260626.1)(rolldown@1.1.3)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260630.1)(rolldown@1.1.3)(typescript@6.0.3)
       semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -10627,14 +10622,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.10.0:
+  turbo@2.10.1:
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.0
-      '@turbo/darwin-arm64': 2.10.0
-      '@turbo/linux-64': 2.10.0
-      '@turbo/linux-arm64': 2.10.0
-      '@turbo/windows-64': 2.10.0
-      '@turbo/windows-arm64': 2.10.0
+      '@turbo/darwin-64': 2.10.1
+      '@turbo/darwin-arm64': 2.10.1
+      '@turbo/linux-64': 2.10.1
+      '@turbo/linux-arm64': 2.10.1
+      '@turbo/windows-64': 2.10.1
+      '@turbo/windows-arm64': 2.10.1
 
   twoslash-protocol@0.3.9: {}
 
@@ -10822,7 +10817,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.16
       rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -10842,7 +10837,7 @@ snapshots:
       '@vitest/snapshot': 4.1.9
       '@vitest/spy': 4.1.9
       '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
+      es-module-lexer: 2.2.0
       expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.3
@@ -11003,7 +10998,7 @@ snapshots:
     dependencies:
       consola: 2.15.3
       globby: 11.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       nconf: 0.12.1
 
   yaml@2.9.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,10 +246,10 @@ importers:
         specifier: catalog:silk
         version: 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@vitest-agent/cli':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../cli/dist/dev/pkg
       '@vitest-agent/mcp':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../mcp/dist/dev/pkg
       '@vitest-agent/reporter':
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
   - website
 autoInstallPeers: true
 configDependencies:
-  "@savvy-web/pnpm-plugin-silk": 0.16.1+sha512-ezIsMs06mTSjPqip8fcXJCx0KXVzRd3vSyjHr2YvTiqksY3Q+l9yd+YZg7Yo4CMwnyndZAolaqXX2WrN0XEWAw==
+  "@savvy-web/pnpm-plugin-silk": 0.18.0+sha512-jCfqTFQpeocI+kKo3uNkpIEuAthh2zFqNEMQvRNXMmXzyHq/mZ7ou4hGdbLRjcLo4wGPlpRHtufkrCPH2AraNg==
 linkWorkspacePackages: deep
 loglevel: warn
 verifyDepsBeforeRun: false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
-	"extends": ["@savvy-web/silk/tsconfig/node/root.json"]
+	"extends": "@savvy-web/silk/tsconfig/node/root.json"
 }

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,8 @@
 				"$TURBO_ROOT$/pnpm-workspace.yaml",
 				"$TURBO_ROOT$/pnpm-lock.yaml",
 				"$TURBO_ROOT$/tsconfig.json",
+				"!$TURBO_ROOT$/__test__/**",
+				"!$TURBO_ROOT$/docs/**",
 				"README.md",
 				"LICENSE",
 				"package.json",
@@ -20,7 +22,11 @@
 				"*.cts",
 				"public/**/*",
 				"lib/**/*",
-				"src/**/*"
+				"src/**/*",
+				"!__test__/**/*",
+				"!CHANGELOG.md",
+				"!CLAUDE.md",
+				"!CLAUDE.local.md"
 			],
 			"outputLogs": "errors-only",
 			"outputs": ["dist/dev/**"]
@@ -35,6 +41,8 @@
 				"$TURBO_ROOT$/pnpm-lock.yaml",
 				"$TURBO_ROOT$/tsconfig.json",
 				"$TURBO_ROOT$/.changeset/**",
+				"!$TURBO_ROOT$/__test__/**",
+				"!$TURBO_ROOT$/docs/**",
 				"README.md",
 				"LICENSE",
 				"package.json",
@@ -44,7 +52,11 @@
 				"*.cts",
 				"public/**/*",
 				"lib/**/*",
-				"src/**/*"
+				"src/**/*",
+				"!__test__/**/*",
+				"!CHANGELOG.md",
+				"!CLAUDE.md",
+				"!CLAUDE.local.md"
 			],
 			"outputLogs": "full",
 			"outputs": ["dist/prod/**"]

--- a/website/package.json
+++ b/website/package.json
@@ -12,13 +12,13 @@
 	"devDependencies": {
 		"@rspress/core": "^2.0.15",
 		"@rspress/plugin-sitemap": "^2.0.15",
-		"@types/node": "catalog:silk",
+		"@types/node": "^26.0.0",
 		"@types/react": "catalog:silk",
 		"@types/react-dom": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"react": "catalog:silk",
 		"react-dom": "catalog:silk",
-		"rspress-plugin-api-extractor": "^0.3.2",
+		"rspress-plugin-api-extractor": "^0.3.3",
 		"rspress-plugin-mermaid": "^1.0.1"
 	}
 }


### PR DESCRIPTION
## Summary

Switches the `@vitest-agent/*` family from lockstep releases to independent
per-package versioning, and removes the now-obsolete cross-package version
drift check.

### Why

A pending release computed `2.0.0` for every package even though only mcp
and plugin had minor changes. Root cause: the plugin's `workspace:*`
peerDependency on mcp — changesets treats `workspace:*` as an exact pin, so
mcp's minor bump read as out-of-range and force-majored the plugin, which
the `fixed` lockstep group then spread to all 11 packages. Post-1.0 there is
no real reason to release in lockstep: consumers only install
`@vitest-agent/plugin`, its required peers auto-install, and the rest arrive
transitively, so version skew across the family is invisible.

### Changes

- **`.changeset/config.json`** — removed the `fixed` group; added
  `onlyUpdatePeerDependentsWhenOutOfRange: true`. `updateInternalDependencies:
  "patch"` retained.
- **`packages/plugin/package.json`** — internal peers (`cli`, `mcp`) changed
  from `workspace:*` to `workspace:^` so a compatible peer minor no longer
  forces a plugin major.
- **Drift check removed** from `plugin.ts`, `cli/bin.ts`, `mcp/bin.ts`. It
  asserted exact version equality, which only made sense under lockstep and
  became a false positive under independent versioning. The
  `CURRENT_<PKG>_VERSION` constants stay exported as public API.
- **Changesets reconciled** — folded a drift-removal note into the plugin,
  mcp, and cli entries; refreshed the stale `@savvy-web/bundler` dependency
  changesets.
- **Docs** — CLAUDE.md (root + plugin + reporter) and the design docs
  (Decision 36 rewritten to "Independent Per-Package Release"; lockstep form
  retired) updated. Stale `deploy-docs.yml` trigger comment corrected.

### Release outcome

`savvy changeset version --dry-run` now yields `sdk`/`mcp`/`plugin` -> `1.1.0`
and the rest -> `1.0.2`, with no major bump.

### Out-of-band: historical tag/release backfill (already live on GitHub)

The two prior unified releases (`1.0.0`, `1.0.1`) were retroactively split
into per-package `@vitest-agent/<pkg>@<version>` tags and GitHub Releases so
history matches the new scheme and the release tooling finds a per-package
previous-tag reference. Provenance assets were re-homed per package; the
unified `1.0.0`/`1.0.1` tags and Releases were deleted. "Latest" is
`@vitest-agent/plugin@1.0.1`. This was done directly against the remote, not
in this branch.

### Verification

- `pnpm run typecheck` — all packages pass.
- Tests for the changed packages (cli, mcp, plugin) — 602/602 pass.
- `savvy changeset check` — all changesets valid.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>
