### PR TITLE
feat(phase-transition): support triangulated behaviors and one-step behavior crossings

### DIFF
--- a/.changeset/six-donkeys-resolve.md
+++ b/.changeset/six-donkeys-resolve.md
@@ -1,0 +1,10 @@
+---
+"@vitest-agent/mcp": patch
+---
+
+## Bug Fixes
+
+Fixes `tdd_phase_transition_request` artifact auto-resolution picking the newest matching artifact for the whole task, ignoring which behavior it belonged to (#115).
+
+* The lookup is now scoped by `behaviorId` only on transitions where behavior-match binding actually applies (`red→green` and `green→refactor`), using the sdk's `transitionEnforcesBehaviorMatch` predicate.
+* `red.triangulate→green` and `refactor→red` remain unscoped, since their evidence legitimately belongs to a different behavior than the one being requested.

--- a/.changeset/tidy-otters-triangulate.md
+++ b/.changeset/tidy-otters-triangulate.md
@@ -1,0 +1,18 @@
+---
+"@vitest-agent/sdk": minor
+---
+
+## Features
+
+Adds phase-transition support for triangulation batches, where a single implementation satisfies several behaviors and only the first produces its own failing run (#115).
+
+* `requiredArtifactForTransition` now requires a `test_failed_run` for `red.triangulate→green` (previously accepted with no evidence at all) — a triangulation batch must still point at a real failing run, just not necessarily the requested behavior's own.
+* `validatePhaseTransition` relaxes the phase-window and behavior-match binding rules specifically for `red.triangulate→green`, so a batch's shared failing run can serve as evidence for a later behavior in the same batch.
+* New export `transitionEnforcesBehaviorMatch(from, to)` reports whether D2 binding rule 2 (behavior-match) applies to a transition. It is `true` only for `red→green` and `green→refactor`, and `false` for `red.triangulate→green` and `refactor→red` — letting `refactor→red` cross a behavior boundary in one step without a rebind dance.
+
+```ts
+import { transitionEnforcesBehaviorMatch } from "@vitest-agent/sdk";
+
+transitionEnforcesBehaviorMatch("red", "green"); // true
+transitionEnforcesBehaviorMatch("red.triangulate", "green"); // false
+```

--- a/.claude/design/vitest-agent/components/mcp.md
+++ b/.claude/design/vitest-agent/components/mcp.md
@@ -286,10 +286,16 @@ When omitted, the tool auto-resolves the most recent matching artifact
 for the required-evidence rule of the target phase via
 `DataReader.listTddArtifactsForTask({ walkParents: true })` (which
 follows the `sessions.parent_session_id` chain so the resolver finds
-artifacts written under a rotated `chat_id`). The
-auto-resolved artifact id is returned in the response so the
-orchestrator can record what evidence was bound. Explicit citation
-still wins when the agent supplies it.
+artifacts written under a rotated `chat_id`). That lookup is
+behavior-scoped — it passes `behaviorId` — only for `red→green` and
+`green→refactor`, the transitions where the validator enforces
+behavior-match (rule 2), gated by the shared
+`transitionEnforcesBehaviorMatch` predicate from the SDK; it stays
+unscoped for `red.triangulate→green` and `refactor→red` so the batch or
+prior-behavior evidence those transitions rely on is still found
+(issue #115). The auto-resolved artifact id is returned in the response
+so the orchestrator can record what evidence was bound. Explicit
+citation still wins when the agent supplies it.
 
 The `tdd_artifact_list` tool exposes the same reader directly so the
 orchestrator can list candidate artifacts before committing to a

--- a/.claude/design/vitest-agent/decisions.md
+++ b/.claude/design/vitest-agent/decisions.md
@@ -1262,26 +1262,40 @@ reason and a remediation hint.
 
 **The three D2 binding rules:**
 
-1. **Evidence in phase window AND session.** The cited test must have
-   been authored in the current phase window
-   (`test_case_created_turn_at >= phase_started_at`) AND in the
-   current session (`test_case_authored_in_session === true`).
-   Prevents citing a test written before the phase started or in
-   another session.
-2. **Behavior match.** When the orchestrator requests a transition for
-   a specific behavior, the cited artifact's `behavior_id` must equal
-   the `requested_behavior_id`. Prevents citing the right kind of
-   evidence but for the wrong behavior.
-3. **Test wasn't already failing.** For `red → green` transitions
-   where the cited evidence is a `test_failed_run`, the test's
-   `test_first_failure_run_id` must equal the cited `test_run_id`.
-   Prevents citing a test that was *already* failing on main as proof
-   of "I just put it in red".
+1. **Evidence in phase window AND session.** The cited test must carry
+   a specific `test_case_id`, have been authored in the current phase
+   window (`test_case_created_turn_at >= phase_started_at`) AND in the
+   current session (`test_case_authored_in_session === true`). Prevents
+   citing a test written before the phase started or in another
+   session. The phase-window portion is skipped for
+   `red.triangulate → green` (see below); the specific-test and session
+   portions always apply.
+2. **Behavior match.** Scoped to the transitions whose cited evidence
+   must belong to the behavior being transitioned — `red → green` (this
+   behavior's failing test) and `green → refactor` (its passing test).
+   When the orchestrator requests a transition for a specific behavior,
+   the cited artifact's `behavior_id` must equal the
+   `requested_behavior_id`. It is NOT applied to `refactor → red` (the
+   required `test_passed_run` necessarily belongs to the just-finished
+   behavior, never the new target) or `red.triangulate → green` (the
+   cited failing run belongs to an earlier batch member). Scoping it
+   this way lets a behavior-boundary crossing happen in one
+   `refactor → red` step — with the new `behaviorId` set, citing the
+   prior behavior's passing run — replacing the previous two-step
+   `refactor → red` (no `behaviorId`) then `red → red` rebind. Before
+   this, rule 2 fired for every evidence-bearing transition whenever a
+   `behaviorId` was supplied, which made a one-step crossing impossible.
+3. **Test wasn't already failing.** For `red → green` and
+   `red.triangulate → green` transitions where the cited evidence is a
+   `test_failed_run`, the test's `test_first_failure_run_id` must equal
+   the cited `test_run_id`. Prevents citing a test that was *already*
+   failing on main as proof of "I just put it in red".
 
-**Artifact-kind precondition:** `red → green` requires
-`test_failed_run`, `green → refactor` requires `test_passed_run`,
-`refactor → red` requires `test_passed_run` (refactor must end with
-all tests still passing).
+**Artifact-kind precondition:** `red → green` and
+`red.triangulate → green` require `test_failed_run`,
+`green → refactor` requires `test_passed_run`, `refactor → red`
+requires `test_passed_run` (refactor must end with all tests still
+passing).
 
 **Source-phase guard for `green`:** `validatePhaseTransition` enforces
 that `green` may only be entered from `red`, `red.triangulate`, or
@@ -1291,10 +1305,40 @@ remediation pointing at the missing `→ red` step. Skipping the named
 red phase entirely would leave the `tdd_phases` table without a
 `phase="red"` row, breaking the phase-evidence integrity metric.
 
+**Triangulation-aware `red.triangulate → green` (issue #115):**
+`requiredArtifactForTransition` now returns `test_failed_run` for
+`red.triangulate → green` — previously it returned `null` (it only
+matched `from === "red"`), so the transition was accepted with zero
+evidence, a hole now closed. For this transition the validator keeps
+the artifact-kind check, the specific-test check (`test_case_id`
+non-null), the authored-in-session check and rule 3, but skips the
+phase-window portion of rule 1 and rule 2 entirely. Rationale: in a
+triangulation batch one shared implementation satisfies several
+behaviors, so later behaviors' tests never fail on their own; the
+batch's real failing run (belonging to an earlier behavior) is accepted
+as evidence for each member. A specific real in-session failing test
+must still exist. No new `DenialReason` literals were needed — these
+changes only remove denials and close the zero-evidence hole. The
+three-rule framing still holds; rules 1 (phase-window portion) and 2
+are conditionally skipped as described.
+
+**One predicate keeps validator and auto-resolution in lockstep:** the
+exported pure helper `transitionEnforcesBehaviorMatch(from, to)` (same
+file, returns true only for `red → green` and `green → refactor`) gates
+rule 2 in the validator AND scopes the MCP tool's artifact
+auto-resolution. `tdd_phase_transition_request` passes `behaviorId` to
+`listTddArtifactsForTask` only when the helper is true, so
+auto-resolution narrows the lookup to the requested behavior on exactly
+the transitions where the validator will require it, and stays unscoped
+(batch / prior-behavior) otherwise. This fixed a latent bug where
+auto-resolution picked the newest matching artifact task-wide
+regardless of behavior.
+
 All remaining transitions are evidence-free and accepted
 unconditionally — including `spike → red` (the entry point for every
-TDD cycle), `red.triangulate → red`, `green.fake-it → refactor`, and
-`refactor → red`.
+TDD cycle), `red.triangulate → red`, and `green.fake-it → refactor`.
+(`refactor → red` is evidence-bearing per the artifact-kind
+precondition above, not evidence-free.)
 
 **Why a pure function (vs Effect service):** the function takes a
 context object and returns a result. No I/O, no async. Effect service

--- a/.claude/design/vitest-agent/schemas.md
+++ b/.claude/design/vitest-agent/schemas.md
@@ -363,6 +363,12 @@ denial branch carries `remediation` with a concrete `suggestedTool` and
 `humanHint` so the orchestrator can recover without a round-trip to the
 human.
 
+The file also exports the pure functions `validatePhaseTransition`,
+`requiredArtifactForTransition` and `transitionEnforcesBehaviorMatch(from, to): boolean`.
+The last is the shared predicate that gates D2 binding rule 2 (behavior-match)
+and scopes the MCP tool's artifact auto-resolution to the same transitions —
+see [./decisions.md](./decisions.md) D11.
+
 **Authoring-window scope (D2 rule 1):** the check applies to
 `test_failed_run` artifacts only. It does not apply to `test_passed_run` or
 other kinds, so `green→refactor` transitions citing a `test_passed_run`

--- a/packages/mcp/__test__/router.test.ts
+++ b/packages/mcp/__test__/router.test.ts
@@ -1152,6 +1152,193 @@ describe("MCP Router", () => {
 			expect(r.remediation?.humanHint).toMatch(/test_failed_run/);
 		});
 
+		it("auto-resolves the failing run for the REQUESTED behavior on red→green, not the newest across behaviors (issue #115)", async () => {
+			// Given: two behaviors, each with a test_failed_run. Behavior 2's run is the NEWEST by
+			// recorded_at, but behavior 1's is the one we're greening. Before issue #115, auto-resolution
+			// ignored behaviorId and grabbed the newest matching artifact task-wide — behavior 2's — which
+			// the validator then rejected at rule 2 (evidence_not_for_behavior), even though behavior 1's
+			// valid failing run existed. Auto-resolution must scope the lookup to the requested behavior.
+			const { tddId, goalId, sessionId } = await seedTddSessionForTransition("cc-tdd-trans-autoresolve-beh", "g");
+			const caller = createTestCaller();
+			const b1 = (await caller.tdd_behavior({ action: "create", goalId, behavior: "beh-1" })) as {
+				ok: true;
+				behavior: { id: number };
+			};
+			const b2 = (await caller.tdd_behavior({ action: "create", goalId, behavior: "beh-2" })) as {
+				ok: true;
+				behavior: { id: number };
+			};
+
+			const b1PhaseStart = "2026-05-01T01:00:00.000Z";
+			const { b1Artifact } = await testRuntime.runPromise(
+				Effect.gen(function* () {
+					const store = yield* DataStore;
+
+					// Behavior 2's phase + NEWEST failing run (older phase start, newest recorded_at).
+					const b2Phase = yield* store.writeTddPhase({
+						tddTaskId: tddId,
+						behaviorId: b2.behavior.id,
+						phase: "red",
+						startedAt: "2026-05-01T00:00:00.000Z",
+					});
+					yield* store.writeTddArtifact({
+						phaseId: b2Phase.id,
+						artifactKind: "test_failed_run",
+						recordedAt: "2026-05-01T02:00:00.000Z",
+					});
+
+					// Behavior 1's phase (opened last → current open phase) + a fully valid failing run,
+					// recorded BEFORE behavior 2's so it is not the newest.
+					const turnOccurredAt = "2026-05-01T01:00:00.100Z";
+					const turnId = yield* store.writeTurn({
+						sessionId,
+						type: "file_edit",
+						payload: JSON.stringify({ type: "file_edit", file_path: "src/b1.test.ts", edit_kind: "write" }),
+						occurredAt: turnOccurredAt,
+					});
+					yield* store.writeSettings("hash-b1", { vitestVersion: "4.1.0" }, {});
+					const runId = yield* store.writeRun({
+						invocationId: "inv-b1-001",
+						project: "default",
+						settingsHash: "hash-b1",
+						timestamp: turnOccurredAt,
+						commitSha: null,
+						branch: null,
+						reason: "failed",
+						duration: 500,
+						total: 1,
+						passed: 0,
+						failed: 1,
+						skipped: 0,
+						scoped: false,
+					});
+					const fileId = yield* store.ensureFile("src/b1.test.ts");
+					const [moduleId] = yield* store.writeModules(runId, [
+						{ fileId, relativeModuleId: "src/b1.test.ts", state: "failed", duration: 200 },
+					]);
+					const [testCaseId] = yield* store.writeTestCases(moduleId, [
+						{ name: "b1 behavior", fullName: "b1 > behavior", state: "failed", duration: 10, createdTurnId: turnId },
+					]);
+					const b1Phase = yield* store.writeTddPhase({
+						tddTaskId: tddId,
+						behaviorId: b1.behavior.id,
+						phase: "red",
+						startedAt: b1PhaseStart,
+					});
+					const b1Artifact = yield* store.writeTddArtifact({
+						phaseId: b1Phase.id,
+						artifactKind: "test_failed_run",
+						testCaseId,
+						testRunId: runId,
+						testFirstFailureRunId: runId,
+						recordedAt: "2026-05-01T01:00:01.000Z",
+					});
+					return { b1Artifact };
+				}),
+			);
+
+			const r = (await caller.tdd_phase_transition_request({
+				tddTaskId: tddId,
+				goalId,
+				behaviorId: b1.behavior.id,
+				requestedPhase: "green",
+			})) as { accepted: boolean; citedArtifactId?: number; denialReason?: string };
+
+			// Then: accepted, and the auto-resolved artifact is behavior 1's — not behavior 2's newer run.
+			expect(r.accepted).toBe(true);
+			expect(r.citedArtifactId).toBe(b1Artifact);
+		});
+
+		it("auto-resolves the batch failing run (cross-behavior) on red.triangulate→green without behavior-scoping (issue #115)", async () => {
+			// Given: a triangulation batch. Behavior 1 produced the batch's real failing run; behavior 2
+			// is a later member whose own test passed the moment the shared implementation landed, so it
+			// has NO failing run of its own. Requesting red.triangulate→green for behavior 2 must auto-resolve
+			// behavior 1's failing run — the lookup must NOT be scoped to behavior 2 (which owns nothing),
+			// mirroring the validator's decision to skip behavior-match for triangulation.
+			const { tddId, goalId, sessionId } = await seedTddSessionForTransition("cc-tdd-trans-triangulate", "g");
+			const caller = createTestCaller();
+			const b1 = (await caller.tdd_behavior({ action: "create", goalId, behavior: "tri-1" })) as {
+				ok: true;
+				behavior: { id: number };
+			};
+			const b2 = (await caller.tdd_behavior({ action: "create", goalId, behavior: "tri-2" })) as {
+				ok: true;
+				behavior: { id: number };
+			};
+
+			const { b1Artifact } = await testRuntime.runPromise(
+				Effect.gen(function* () {
+					const store = yield* DataStore;
+
+					// Behavior 1's red.triangulate phase + the batch's real failing run.
+					const turnOccurredAt = "2026-05-02T00:00:00.100Z";
+					const turnId = yield* store.writeTurn({
+						sessionId,
+						type: "file_edit",
+						payload: JSON.stringify({ type: "file_edit", file_path: "src/tri.test.ts", edit_kind: "write" }),
+						occurredAt: turnOccurredAt,
+					});
+					yield* store.writeSettings("hash-tri", { vitestVersion: "4.1.0" }, {});
+					const runId = yield* store.writeRun({
+						invocationId: "inv-tri-001",
+						project: "default",
+						settingsHash: "hash-tri",
+						timestamp: turnOccurredAt,
+						commitSha: null,
+						branch: null,
+						reason: "failed",
+						duration: 500,
+						total: 1,
+						passed: 0,
+						failed: 1,
+						skipped: 0,
+						scoped: false,
+					});
+					const fileId = yield* store.ensureFile("src/tri.test.ts");
+					const [moduleId] = yield* store.writeModules(runId, [
+						{ fileId, relativeModuleId: "src/tri.test.ts", state: "failed", duration: 200 },
+					]);
+					const [testCaseId] = yield* store.writeTestCases(moduleId, [
+						{ name: "tri-1 behavior", fullName: "tri > 1", state: "failed", duration: 10, createdTurnId: turnId },
+					]);
+					const b1Phase = yield* store.writeTddPhase({
+						tddTaskId: tddId,
+						behaviorId: b1.behavior.id,
+						phase: "red.triangulate",
+						startedAt: "2026-05-02T00:00:00.000Z",
+					});
+					const b1Artifact = yield* store.writeTddArtifact({
+						phaseId: b1Phase.id,
+						artifactKind: "test_failed_run",
+						testCaseId,
+						testRunId: runId,
+						testFirstFailureRunId: runId,
+						recordedAt: "2026-05-02T00:00:01.000Z",
+					});
+
+					// Behavior 2's red.triangulate phase (opened last → current) with NO failing run of its own.
+					yield* store.writeTddPhase({
+						tddTaskId: tddId,
+						behaviorId: b2.behavior.id,
+						phase: "red.triangulate",
+						startedAt: "2026-05-02T01:00:00.000Z",
+					});
+					return { b1Artifact };
+				}),
+			);
+
+			const r = (await caller.tdd_phase_transition_request({
+				tddTaskId: tddId,
+				goalId,
+				behaviorId: b2.behavior.id,
+				requestedPhase: "green",
+			})) as { accepted: boolean; citedArtifactId?: number; denialReason?: string };
+
+			// Then: accepted, citing behavior 1's batch failing run — resolution was not scoped to behavior 2.
+			expect(r.accepted).toBe(true);
+			expect(r.citedArtifactId).toBe(b1Artifact);
+		});
+
 		it("echoes citedArtifactSource='explicit-id' when citedArtifactId was supplied", async () => {
 			const { tddId, goalId } = await seedTddSessionForTransition("cc-tdd-trans-explicit-id", "g");
 			const { artifactId } = await testRuntime.runPromise(

--- a/packages/mcp/src/tools/tdd-phase-transition-request.ts
+++ b/packages/mcp/src/tools/tdd-phase-transition-request.ts
@@ -1,5 +1,11 @@
 import type { ArtifactKind, CitedArtifactRow, Phase } from "@vitest-agent/sdk";
-import { DataReader, DataStore, requiredArtifactForTransition, validatePhaseTransition } from "@vitest-agent/sdk";
+import {
+	DataReader,
+	DataStore,
+	requiredArtifactForTransition,
+	transitionEnforcesBehaviorMatch,
+	validatePhaseTransition,
+} from "@vitest-agent/sdk";
 
 import { Effect, Option, Schema } from "effect";
 import { publicProcedure } from "../context.js";
@@ -229,10 +235,21 @@ export const tddPhaseTransitionRequest = publicProcedure
 					resolvedKindSource = "transition-derived";
 				}
 
+				// Scope the artifact lookup to the requested behavior only for the transitions where
+				// the validator enforces behavior-match (rule 2): red→green and green→refactor. For
+				// those, the newest matching artifact task-wide may belong to a different behavior and
+				// get rejected even though the correct one exists (issue #115). We must NOT scope for
+				// red.triangulate→green (the batch's failing run belongs to an earlier behavior) or
+				// refactor→red (the evidence is the just-finished behavior, not the requested one) —
+				// scoping there would filter out the very artifact the validator is willing to accept.
+				const scopeLookupByBehavior =
+					input.behaviorId !== undefined && transitionEnforcesBehaviorMatch(currentPhase, input.requestedPhase);
+
 				if (resolvedArtifactId === undefined && kindToLookUp !== undefined) {
 					const recent = yield* reader.listTddArtifactsForTask({
 						tddTaskId: input.tddTaskId,
 						artifactKind: kindToLookUp,
+						...(scopeLookupByBehavior && { behaviorId: input.behaviorId }),
 						limit: 1,
 					});
 					if (recent.length === 0) {

--- a/packages/sdk/__test__/validate-phase-transition.test.ts
+++ b/packages/sdk/__test__/validate-phase-transition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PhaseTransitionContext } from "../src/utils/validate-phase-transition.js";
-import { validatePhaseTransition } from "../src/utils/validate-phase-transition.js";
+import { transitionEnforcesBehaviorMatch, validatePhaseTransition } from "../src/utils/validate-phase-transition.js";
 
 const baseCtx = (overrides: Partial<PhaseTransitionContext> = {}): PhaseTransitionContext => ({
 	tdd_task_id: 1,
@@ -20,6 +20,22 @@ const baseCtx = (overrides: Partial<PhaseTransitionContext> = {}): PhaseTransiti
 	},
 	requested_behavior_id: null,
 	...overrides,
+});
+
+describe("transitionEnforcesBehaviorMatch", () => {
+	it("enforces behavior-match only for red→green and green→refactor", () => {
+		// The two transitions whose cited evidence must belong to the behavior being transitioned.
+		expect(transitionEnforcesBehaviorMatch("red", "green")).toBe(true);
+		expect(transitionEnforcesBehaviorMatch("green", "refactor")).toBe(true);
+	});
+
+	it("does not enforce behavior-match for red.triangulate→green or refactor→red (issue #115)", () => {
+		// red.triangulate→green cites a batch sibling's failing run; refactor→red cites the
+		// just-finished behavior's passing run — neither can match the requested behavior.
+		expect(transitionEnforcesBehaviorMatch("red.triangulate", "green")).toBe(false);
+		expect(transitionEnforcesBehaviorMatch("refactor", "red")).toBe(false);
+		expect(transitionEnforcesBehaviorMatch("spike", "red")).toBe(false);
+	});
 });
 
 describe("validatePhaseTransition", () => {
@@ -354,6 +370,191 @@ describe("validatePhaseTransition", () => {
 		expect(result.accepted).toBe(true);
 		if (result.accepted) {
 			expect(result.phase).toBe("red");
+		}
+	});
+
+	it("should deny red.triangulate→green with wrong_artifact_kind when the cited artifact is not a test_failed_run", () => {
+		// Given: a red.triangulate→green transition (a triangulation batch member advancing
+		// to green) whose cited artifact is a test_written, not a test_failed_run. Before
+		// issue #115, requiredArtifactForTransition only matched from === "red", so
+		// red.triangulate→green returned null and was accepted with ZERO evidence — the
+		// zero-evidence hole. The transition must require a test_failed_run just like
+		// plain red→green.
+		const result = validatePhaseTransition(
+			baseCtx({
+				current_phase: "red.triangulate",
+				requested_phase: "green",
+				cited_artifact: { ...baseCtx().cited_artifact, artifact_kind: "test_written" },
+			}),
+		);
+
+		// Then: denied with wrong_artifact_kind — the batch must still have produced a real
+		// failing run.
+		expect(result.accepted).toBe(false);
+		if (!result.accepted) {
+			expect(result.denialReason).toBe("wrong_artifact_kind");
+		}
+	});
+
+	it("should accept red.triangulate→green citing a batch failing run from an earlier behavior (skips phase-window and behavior-match)", () => {
+		// Given: behavior 2 is a later member of a triangulation batch. Its own test passed
+		// the moment the shared implementation (written for behavior 1) landed, so behavior 2
+		// never produced its own test_failed_run. The orchestrator cites the batch's real
+		// failing run — behavior 1's — which was authored BEFORE behavior 2's red.triangulate
+		// phase started and is bound to behavior_id 1, not the requested behavior_id 2.
+		const result = validatePhaseTransition(
+			baseCtx({
+				current_phase: "red.triangulate",
+				requested_phase: "green",
+				phase_started_at: "2026-04-29T00:05:00Z",
+				requested_behavior_id: 2,
+				cited_artifact: {
+					id: 100,
+					artifact_kind: "test_failed_run",
+					test_case_id: 50,
+					// authored during behavior 1's red phase — before behavior 2's phase started
+					test_case_created_turn_at: "2026-04-29T00:00:30Z",
+					test_case_authored_in_session: true,
+					test_run_id: 200,
+					test_first_failure_run_id: 200,
+					behavior_id: 1,
+				},
+			}),
+		);
+
+		// Then: accepted — for a triangulation batch, a real in-session failing run from any
+		// batch member is sufficient evidence; the per-behavior phase-window and behavior-match
+		// rules are skipped because later behaviors cannot produce their own failing run.
+		expect(result.accepted).toBe(true);
+		if (result.accepted) {
+			expect(result.phase).toBe("green");
+		}
+	});
+
+	it("should still deny red.triangulate→green when the cited failing run was already failing on main", () => {
+		// Given: a red.triangulate→green transition whose cited failing run was already failing
+		// before this session (test_first_failure_run_id !== test_run_id). Triangulation relaxes
+		// the phase-window and behavior-match rules, but NOT rule 3 — the batch's failing run
+		// must be a genuine in-session failure, not a pre-existing red on main.
+		const result = validatePhaseTransition(
+			baseCtx({
+				current_phase: "red.triangulate",
+				requested_phase: "green",
+				requested_behavior_id: 2,
+				cited_artifact: {
+					...baseCtx().cited_artifact,
+					behavior_id: 1,
+					test_run_id: 200,
+					test_first_failure_run_id: 5,
+				},
+			}),
+		);
+
+		// Then: denied — a pre-existing failure is never valid red evidence, triangulation or not.
+		expect(result.accepted).toBe(false);
+		if (!result.accepted) {
+			expect(result.denialReason).toBe("evidence_test_was_already_failing");
+		}
+	});
+
+	it("should still deny red.triangulate→green when the cited failing run has no specific test (test_case_id null)", () => {
+		// Given: a red.triangulate→green transition whose cited failing run is a run-level
+		// artifact (test_case_id null). Triangulation accepts a batch member's failing run,
+		// but that run must still bind to a specific failing test — a whole-suite failure
+		// with no test anchor is not sufficient.
+		const result = validatePhaseTransition(
+			baseCtx({
+				current_phase: "red.triangulate",
+				requested_phase: "green",
+				requested_behavior_id: 2,
+				cited_artifact: {
+					...baseCtx().cited_artifact,
+					behavior_id: 1,
+					test_case_id: null,
+					test_case_created_turn_at: null,
+				},
+			}),
+		);
+
+		// Then: denied with missing_artifact_evidence — the specific-test guarantee holds.
+		expect(result.accepted).toBe(false);
+		if (!result.accepted) {
+			expect(result.denialReason).toBe("missing_artifact_evidence");
+		}
+	});
+
+	it("should accept refactor→red re-targeting a new behavior, citing the prior behavior's test_passed_run (issue #115 Facet 2)", () => {
+		// Given: the orchestrator just finished behavior 1 (in refactor) and starts behavior 2.
+		// The canonical refactor→red evidence is a test_passed_run — which necessarily belongs to
+		// the JUST-FINISHED behavior (1), not the new target (2). Before issue #115, rule 2
+		// (behavior-match) rejected this because cited.behavior_id (1) !== requested_behavior_id (2),
+		// forcing a two-step refactor→red (no behaviorId) then red→red rebind dance.
+		const result = validatePhaseTransition(
+			baseCtx({
+				current_phase: "refactor",
+				requested_phase: "red",
+				requested_behavior_id: 2,
+				cited_artifact: {
+					id: 100,
+					artifact_kind: "test_passed_run",
+					test_case_id: 50,
+					test_case_created_turn_at: "2026-04-29T00:00:30Z",
+					test_case_authored_in_session: true,
+					test_run_id: 200,
+					test_first_failure_run_id: null,
+					behavior_id: 1,
+				},
+			}),
+		);
+
+		// Then: accepted in one step — behavior-match does not apply to refactor→red, because the
+		// evidence is the prior cycle's passing run by design.
+		expect(result.accepted).toBe(true);
+		if (result.accepted) {
+			expect(result.phase).toBe("red");
+		}
+	});
+
+	it("should still enforce behavior-match on red→green (rule 2 remains scoped, not removed)", () => {
+		// Regression guard: scoping rule 2 to red→green / green→refactor must NOT weaken red→green.
+		// A red→green transition for behavior 1 citing a failing run bound to behavior 2 is still denied.
+		const result = validatePhaseTransition(
+			baseCtx({
+				current_phase: "red",
+				requested_phase: "green",
+				requested_behavior_id: 1,
+				cited_artifact: { ...baseCtx().cited_artifact, behavior_id: 2 },
+			}),
+		);
+		expect(result.accepted).toBe(false);
+		if (!result.accepted) {
+			expect(result.denialReason).toBe("evidence_not_for_behavior");
+		}
+	});
+
+	it("should still enforce behavior-match on green→refactor (rule 2 remains scoped, not removed)", () => {
+		// Regression guard: green→refactor evidence must be for the behavior being refactored.
+		// A green→refactor for behavior 1 citing a passing run bound to behavior 2 is still denied.
+		const result = validatePhaseTransition(
+			baseCtx({
+				current_phase: "green",
+				requested_phase: "refactor",
+				requested_behavior_id: 1,
+				cited_artifact: {
+					id: 100,
+					artifact_kind: "test_passed_run",
+					test_case_id: 50,
+					test_case_created_turn_at: "2026-04-29T00:00:30Z",
+					test_case_authored_in_session: true,
+					test_run_id: 200,
+					test_first_failure_run_id: null,
+					behavior_id: 2,
+				},
+			}),
+		);
+		expect(result.accepted).toBe(false);
+		if (!result.accepted) {
+			expect(result.denialReason).toBe("evidence_not_for_behavior");
 		}
 	});
 

--- a/packages/sdk/src/utils/validate-phase-transition.ts
+++ b/packages/sdk/src/utils/validate-phase-transition.ts
@@ -91,6 +91,20 @@ export const requiredArtifactForTransition = (
 				"Run the failing test via run_tests, then record the test_failed_run artifact before requesting red→green.",
 		};
 	}
+	if (from === "red.triangulate" && to === "green") {
+		// Triangulation (issue #115): a batch of behaviors is satisfied by one
+		// shared implementation. Later behaviors in the batch never produce their
+		// own failing run (the shared code already passes them), so red.triangulate→green
+		// accepts the batch's failing run as evidence — but a real failing run must
+		// still exist. Returning test_failed_run here (rather than null) both engages
+		// auto-resolution and closes the zero-evidence hole. The validator relaxes the
+		// phase-window and behavior-match binding rules for this transition below.
+		return {
+			kind: "test_failed_run",
+			humanHint:
+				"A triangulation batch must still have produced at least one real failing run; record the batch's test_failed_run before requesting red.triangulate→green.",
+		};
+	}
 	if (from === "green" && to === "refactor") {
 		return {
 			kind: "test_passed_run",
@@ -107,6 +121,23 @@ export const requiredArtifactForTransition = (
 	}
 	return null;
 };
+/**
+ * Whether D2 binding rule 2 (behavior-match) applies to a given transition.
+ *
+ * Only the transitions whose cited evidence must belong to the behavior being
+ * transitioned enforce behavior-match: `red→green` (the failing test for this
+ * behavior) and `green→refactor` (its passing test). It deliberately excludes
+ * `red.triangulate→green` (the cited failing run belongs to an earlier batch
+ * behavior) and `refactor→red` (the required `test_passed_run` is the
+ * just-finished behavior's, never the new target). Exported so the MCP
+ * `tdd_phase_transition_request` tool scopes artifact auto-resolution by
+ * behavior on exactly the same transitions the validator will accept —
+ * keeping the two in lockstep (issue #115).
+ * @public
+ */
+export const transitionEnforcesBehaviorMatch = (from: Phase, to: Phase): boolean =>
+	(from === "red" && to === "green") || (from === "green" && to === "refactor");
+
 /** @public */
 export const validatePhaseTransition = (ctx: PhaseTransitionContext): PhaseTransitionResult => {
 	// Guard: green may only be entered from a red-family phase (red, red.triangulate)
@@ -132,6 +163,13 @@ export const validatePhaseTransition = (ctx: PhaseTransitionContext): PhaseTrans
 			},
 		};
 	}
+
+	// Triangulation (issue #115): red.triangulate→green accepts the batch's real failing
+	// run as evidence for a later batch member whose own test never failed. The kind,
+	// specific-test (test_case_id), session, and not-pre-existing (rule 3) guarantees still
+	// apply; only the per-behavior phase-window and behavior-match rules are relaxed, because
+	// the cited run legitimately belongs to an earlier behavior in the batch.
+	const isTriangulateGreen = ctx.current_phase === "red.triangulate" && ctx.requested_phase === "green";
 
 	const expected = requiredArtifactForTransition(ctx.current_phase, ctx.requested_phase);
 	if (expected === null) {
@@ -188,6 +226,7 @@ export const validatePhaseTransition = (ctx: PhaseTransitionContext): PhaseTrans
 	// was written in the red phase (which is the normal TDD pattern).
 	if (expected.kind === "test_failed_run") {
 		if (
+			!isTriangulateGreen &&
 			ctx.cited_artifact.test_case_created_turn_at !== null &&
 			ctx.cited_artifact.test_case_created_turn_at < ctx.phase_started_at
 		) {
@@ -218,8 +257,18 @@ export const validatePhaseTransition = (ctx: PhaseTransitionContext): PhaseTrans
 		}
 	}
 
-	// D2 binding rule 2: behavior match (if the orchestrator requests transitioning a specific behavior)
-	if (ctx.requested_behavior_id !== null && ctx.cited_artifact.behavior_id !== ctx.requested_behavior_id) {
+	// D2 binding rule 2: behavior match (if the orchestrator requests transitioning a specific behavior).
+	// Scoped (issue #115) to the transitions whose evidence must belong to the behavior being
+	// transitioned — red→green (the failing test for this behavior) and green→refactor (its passing
+	// test). It does NOT apply to:
+	//   - red.triangulate→green: the cited failing run legitimately belongs to an earlier batch behavior;
+	//   - refactor→red: the required test_passed_run is the just-finished behavior's, never the new one,
+	//     so enforcing behavior-match here is a category error that forced a two-step rebind dance.
+	if (
+		transitionEnforcesBehaviorMatch(ctx.current_phase, ctx.requested_phase) &&
+		ctx.requested_behavior_id !== null &&
+		ctx.cited_artifact.behavior_id !== ctx.requested_behavior_id
+	) {
 		return {
 			accepted: false,
 			phase: ctx.current_phase,

--- a/plugin/agents/tdd-task.md
+++ b/plugin/agents/tdd-task.md
@@ -136,11 +136,18 @@ The tool runs three classes of pre-checks before validating evidence:
 
 - **Goal validation**: `goalId` must exist and the goal status must be `in_progress` (call `tdd_goal (action: update)({ status: 'in_progress' })` before requesting transitions for a new goal). Denials use `denialReason: 'goal_not_found'` or `'goal_not_in_progress'`.
 - **Behavior validation** (when `behaviorId` is supplied): the behavior must exist and belong to the named goal. Denials use `denialReason: 'behavior_not_found'` or `'behavior_not_in_goal'`.
-- **D2 evidence binding**: the cited test must have been authored in the current phase window AND in this session, the artifact's `behavior_id` must match the requested behavior, and for `red→green` the test must not have been already-failing on main.
+- **D2 evidence binding**: the cited test must have been authored in the current phase window AND in this session, and for `red→green` the test must not have been already-failing on main. Behavior-match — the artifact's `behavior_id` must equal the requested `behaviorId` — is enforced only on `red→green` and `green→refactor`, the transitions whose evidence must belong to the behavior being transitioned. It is deliberately **not** enforced on `refactor→red` or `red.triangulate→green`; the latter also waives the phase-window check. See "Two accepted cross-behavior flows" below.
 
 When the transition is accepted AND a `behaviorId` was supplied AND the behavior is currently `pending`, the tool **auto-promotes the behavior to `in_progress`** in the same call. You do not need to call `tdd_behavior (action: update)` for the start-of-cycle transition; only for the final `done` / `abandoned` transitions.
 
 If the validator denies the transition, it returns a typed `denialReason` and a `remediation` shape. Read the remediation, do what it says, and retry.
+
+### Two accepted cross-behavior flows
+
+Two common orchestration moves used to require undocumented workarounds (issue #115). Both are now first-class — request them directly, in one call, with `citedArtifactId` omitted so auto-resolution finds the right row:
+
+- **Triangulation — close a batch of behaviors satisfied by one implementation.** When a shared implementation makes several behaviors pass at once, only the first behavior's test actually fails; later ones pass the moment the shared code lands and can never produce their own `test_failed_run`. Enter `red.triangulate` (not `red`) for each behavior in the batch. For each later member, request `red.triangulate→green` with that member's `behaviorId` and no `citedArtifactId`: auto-resolution finds the batch's real failing run (from an earlier member) and the validator accepts it — it skips the phase-window and behavior-match rules for this transition. The kind, specific-test, session, and not-already-failing-on-main guarantees still hold, so the batch must still have produced at least one genuine failing run. Do **not** fall back to skipping green with a `red→refactor` jump — that leaves no `green` phase row and depresses the phase-evidence metric.
+- **Cross a behavior boundary — start the next behavior after finishing one.** Request `refactor→red` in a single call with the **new** `behaviorId` and no `citedArtifactId`. The prior behavior's `test_passed_run` is auto-resolved and accepted, because `refactor→red` does not enforce behavior-match (its evidence is the just-finished cycle's passing run by design). The old two-step `refactor→red` (no `behaviorId`) then `red→red` rebind dance is no longer needed.
 
 ## Restricted Bash
 

--- a/plugin/skills/tdd/SKILL.md
+++ b/plugin/skills/tdd/SKILL.md
@@ -107,6 +107,11 @@ tdd_phase_transition_request({
 
 Phase boundaries without MCP confirmation do not exist in the database. The validator enforces evidence-binding rules (D2): the cited artifact must belong to the current phase window and session. If the validator denies, read the `remediation` field and act on it before retrying. Do not advance the phase unilaterally.
 
+Two cross-behavior moves are first-class — request each in one call with `citedArtifactId` omitted (auto-resolution finds the row):
+
+- **Triangulation.** When one implementation satisfies several behaviors, enter `red.triangulate` (not `red`) for each. Later members' tests pass immediately (no own failing run) — request `red.triangulate→green` with the member's `behaviorId`; the batch's real failing run is accepted (phase-window and behavior-match are waived for this transition). Do not skip green with a `red→refactor` jump.
+- **Next behavior.** Cross a behavior boundary with a single `refactor→red` carrying the **new** `behaviorId`; the prior behavior's `test_passed_run` is accepted because `refactor→red` does not enforce behavior-match. No `refactor→red`-then-`red→red` rebind dance.
+
 ---
 
 ## Observed Rationalizations (baseline session, 2026-05-04)

--- a/plugin/skills/tdd/SKILL.md
+++ b/plugin/skills/tdd/SKILL.md
@@ -100,6 +100,7 @@ Skipping this gate is the **UNRECORDED PHASE CHANGE** violation. At every RED→
 ```text
 tdd_phase_transition_request({
   tddTaskId: <id>,
+  goalId: <id>,
   requestedPhase: "green" | "refactor",
   citedArtifactId: <tdd_artifacts.id>
 })

--- a/website/docs/public/images/logo-horizontal-dark.svg
+++ b/website/docs/public/images/logo-horizontal-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="130" viewBox="0 0 800 130"><g transform="translate(2,7) scale(0.45)">
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="130" viewBox="0 0 800 130"><title>vitest-agent</title><g transform="translate(2,7) scale(0.45)">
   <polygon points="94,86 102,50 154,50 162,86" fill="#2A0820"/>
   <polygon points="134,55 117,73 127,73 121,84 139,63 129,63" fill="#FF6BD0"/>
   <rect x="50" y="86" width="156" height="140" rx="46" fill="#D6219B"/>

--- a/website/docs/public/images/logo-horizontal.svg
+++ b/website/docs/public/images/logo-horizontal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="130" viewBox="0 0 800 130"><g transform="translate(2,7) scale(0.45)">
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="130" viewBox="0 0 800 130"><title>vitest-agent</title><g transform="translate(2,7) scale(0.45)">
   <polygon points="94,86 102,50 154,50 162,86" fill="#2A0820"/>
   <polygon points="134,55 117,73 127,73 121,84 139,63 129,63" fill="#FF6BD0"/>
   <rect x="50" y="86" width="156" height="140" rx="46" fill="#D6219B"/>


### PR DESCRIPTION
## Summary

Fixes both facets of #115: `tdd_phase_transition_request` no longer forces undocumented workarounds for triangulation and behavior-boundary crossings. All changes are in the pure validator (`@vitest-agent/sdk`) and the MCP tool's artifact auto-resolution (`@vitest-agent/mcp`), driven test-first.

## Facet 1 — triangulated behaviors

- `requiredArtifactForTransition` gains a `red.triangulate→green` branch returning `test_failed_run`. This closes a latent hole: the transition previously matched no rule, returned `null`, and was accepted with **zero evidence**.
- For `red.triangulate→green`, the validator now accepts the batch's real failing run (from an earlier behavior) as evidence for later members whose own test never fails — it skips the phase-window and behavior-match rules but keeps the artifact-kind, specific-test (`test_case_id`), authored-in-session, and not-already-failing-on-main guarantees.

## Facet 2 — one-step behavior-boundary crossing

- Behavior-match (D2 rule 2) is scoped to only `red→green` and `green→refactor` — the transitions whose evidence must belong to the behavior being transitioned. `refactor→red` with the new `behaviorId` now works in a single call citing the prior behavior's `test_passed_run`, replacing the two-step `refactor→red` / `red→red` rebind dance.

## Auto-resolution fix

- `tdd_phase_transition_request` now passes `behaviorId` to `listTddArtifactsForTask` only when behavior-match applies, fixing a latent bug where it grabbed the newest artifact task-wide regardless of behavior, and leaves `red.triangulate→green` / `refactor→red` unscoped so batch/prior-behavior evidence is still found.
- A shared exported predicate `transitionEnforcesBehaviorMatch(from, to)` is the single source of truth gating both validator rule 2 and the auto-resolution scoping, so the two cannot drift apart.

No new `DenialReason` literals — the changes only remove denials (and close the zero-evidence hole).

## Docs

Decision D11, `components/mcp.md`, and `schemas.md` updated; the `tdd` skill and `tdd-task` agent now document both accepted flows.

## Testing

- `@vitest-agent/sdk`: 1005 passed (9 new validator/predicate cases)
- `@vitest-agent/mcp`: 205 passed (2 new auto-resolution cases; the "don't scope triangulation" guard verified by temporarily broadening then restoring the scope)
- `pnpm run typecheck` clean; biome + markdownlint clean

Changesets: `@vitest-agent/sdk` minor, `@vitest-agent/mcp` patch.

Closes #115

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>
https://claude.ai/code/session_01D33LMAuvmUNt1WxLkqoP5Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced TDD phase transition requests to support two cross-behavior workflows (triangulation and starting a new behavior in a single step).

* **Bug Fixes**
  * Improved auto-resolution of cited evidence to correctly scope artifact selection to the requested behavior when required.
  * Refined validation rules for `red.triangulate → green` and behavior-match enforcement (applies only to `red→green` and `green→refactor`).

* **Documentation**
  * Updated TDD docs for `tdd_phase_transition_request`, including the new `goalId` field and the accepted cross-behavior patterns.

* **Tests**
  * Added regression coverage for phase-transition auto-resolution and behavior scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->