### PR TITLE
fix(sdk): file-qualify test_history identity

### DIFF
--- a/.changeset/happy-foxes-soar.md
+++ b/.changeset/happy-foxes-soar.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/plugin": patch
+---
+
+## Dependencies
+
+| Dependency        | Type       | Action  | From   | To     |
+| ----------------- | ---------- | ------- | ------ | ------ |
+| workspaces-effect | dependency | updated | ^1.2.0 | ^1.3.0 |

--- a/.changeset/lucky-dogs-ponder.md
+++ b/.changeset/lucky-dogs-ponder.md
@@ -1,9 +1,0 @@
----
-"@vitest-agent/sdk": patch
----
-
-## Dependencies
-
-| Dependency | Type       | Action  | From   | To     |
-| ---------- | ---------- | ------- | ------ | ------ |
-| xdg-effect | dependency | updated | ^2.0.1 | ^2.1.0 |

--- a/.changeset/lucky-dogs-ponder.md
+++ b/.changeset/lucky-dogs-ponder.md
@@ -1,0 +1,9 @@
+---
+"@vitest-agent/sdk": patch
+---
+
+## Dependencies
+
+| Dependency | Type       | Action  | From   | To     |
+| ---------- | ---------- | ------- | ------ | ------ |
+| xdg-effect | dependency | updated | ^2.0.1 | ^2.1.0 |

--- a/.changeset/plain-wombats-drift.md
+++ b/.changeset/plain-wombats-drift.md
@@ -1,0 +1,7 @@
+---
+"@vitest-agent/plugin": patch
+---
+
+## Bug Fixes
+
+* The reporter now threads each test's module path into history writes and classification lookups, so identically-named tests in different files are tracked as independent history series instead of colliding (see the `@vitest-agent/sdk` fix for `test_history` identity)

--- a/.changeset/quiet-otters-listen.md
+++ b/.changeset/quiet-otters-listen.md
@@ -1,0 +1,25 @@
+---
+"@vitest-agent/sdk": minor
+---
+
+## Bug Fixes
+
+Test history is now keyed by file, not just by test name. Previously `test_history` rows were identified by `(project, fullName, timestamp)`, so two test files that happened to share a `describe > it` name collided on write (`UNIQUE constraint failed: test_history`) and were conflated on read — flaky/persistent/recovered detection could merge two unrelated tests into one series, potentially hiding a real persistent failure behind a same-named passing test in another file.
+
+* Added a `modulePath` column; history identity is now `(project, modulePath, fullName, timestamp)` end to end
+
+## Features
+
+* `TestHistory` schema and the `FlakyTest` / `PersistentFailure` interfaces gain a `modulePath` field
+* Exported `historyKey` from `HistoryTracker` — builds the composite `(modulePath, fullName)` key so consumers can key their own lookup maps consistently
+* `DataStore.writeHistory` gains a required `modulePath` parameter. Custom reporters or scripts that call `writeHistory` directly need to pass the test module's path:
+
+```ts
+// before
+yield* store.writeHistory(project, fullName, runId, timestamp, state);
+
+// after
+yield* store.writeHistory(project, fullName, modulePath, runId, timestamp, state);
+```
+
+Pre-2.0 note: this changes the `test_history` table shape. Delete your local `data.db` after upgrading (standing pre-2.0 policy — no incremental migration was written).

--- a/.changeset/silent-frogs-answer.md
+++ b/.changeset/silent-frogs-answer.md
@@ -1,0 +1,11 @@
+---
+"@vitest-agent/mcp": patch
+---
+
+## Bug Fixes
+
+* `test_history`'s "Recovered" detection previously compared the last two entries in `runs` as if the array were oldest-first; `runs` is actually ordered most-recent-first, so the comparison had it backwards. Fixed the ordering so recovered tests (previously failing, now passing) are detected correctly.
+
+## Features
+
+* `test_history` tool output rows (`FlakyTestRow`, `PersistentFailureRow`, `RecoveredTestRow`) and the generated markdown now include `modulePath`, so same-named tests in different files are distinguishable in the results

--- a/.changeset/swift-trees-rest.md
+++ b/.changeset/swift-trees-rest.md
@@ -1,0 +1,11 @@
+---
+"@vitest-agent/sdk": patch
+---
+
+## Dependencies
+
+| Dependency         | Type       | Action  | From   | To     |
+| ------------------ | ---------- | ------- | ------ | ------ |
+| config-file-effect | dependency | updated | ^0.2.3 | ^0.3.0 |
+| workspaces-effect  | dependency | updated | ^1.2.0 | ^1.3.0 |
+| xdg-effect         | dependency | updated | ^2.0.1 | ^2.1.0 |

--- a/.claude/design/refs.json
+++ b/.claude/design/refs.json
@@ -28,13 +28,13 @@
 		{
 			"source": "CLAUDE.md",
 			"target": ".claude/design/vitest-agent/data-flows.md",
-			"hash": "1a4a0332d97b6d4f420859aad6293f1d2125c74557f24c466536d9c763445745",
+			"hash": "eccaa0c60486dfc89e1d08afdf0568acb698c89bf10ed1b16fbaa1fcd9410b2f",
 			"recordedAt": "2026-07-01"
 		},
 		{
 			"source": "CLAUDE.md",
 			"target": ".claude/design/vitest-agent/decisions.md",
-			"hash": "5985f39aca762e14ba0dee17d1666d3f4862aa16613173c79f34dd422875b6f2",
+			"hash": "9ce52fb37feb6d198290e089d5850def89108bccb3165e1806598fa14feb4193",
 			"recordedAt": "2026-07-01"
 		},
 		{
@@ -46,7 +46,7 @@
 		{
 			"source": "CLAUDE.md",
 			"target": ".claude/design/vitest-agent/schemas.md",
-			"hash": "9bbf0fd96be8a4ae3e44f1f85c16dbc17115a98cc07384fb8f9202ac19fe8f30",
+			"hash": "d676943a909773643db739163632d799911c2086c3965bc467eccd381869f61a",
 			"recordedAt": "2026-07-01"
 		},
 		{
@@ -64,13 +64,13 @@
 		{
 			"source": "packages/cli/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/data-flows.md",
-			"hash": "1a4a0332d97b6d4f420859aad6293f1d2125c74557f24c466536d9c763445745",
+			"hash": "eccaa0c60486dfc89e1d08afdf0568acb698c89bf10ed1b16fbaa1fcd9410b2f",
 			"recordedAt": "2026-07-01"
 		},
 		{
 			"source": "packages/cli/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/schemas.md",
-			"hash": "9bbf0fd96be8a4ae3e44f1f85c16dbc17115a98cc07384fb8f9202ac19fe8f30",
+			"hash": "d676943a909773643db739163632d799911c2086c3965bc467eccd381869f61a",
 			"recordedAt": "2026-07-01"
 		},
 		{
@@ -82,19 +82,19 @@
 		{
 			"source": "packages/mcp/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/data-flows.md",
-			"hash": "1a4a0332d97b6d4f420859aad6293f1d2125c74557f24c466536d9c763445745",
+			"hash": "eccaa0c60486dfc89e1d08afdf0568acb698c89bf10ed1b16fbaa1fcd9410b2f",
 			"recordedAt": "2026-07-01"
 		},
 		{
 			"source": "packages/mcp/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/decisions.md",
-			"hash": "5985f39aca762e14ba0dee17d1666d3f4862aa16613173c79f34dd422875b6f2",
+			"hash": "9ce52fb37feb6d198290e089d5850def89108bccb3165e1806598fa14feb4193",
 			"recordedAt": "2026-07-01"
 		},
 		{
 			"source": "packages/mcp/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/schemas.md",
-			"hash": "9bbf0fd96be8a4ae3e44f1f85c16dbc17115a98cc07384fb8f9202ac19fe8f30",
+			"hash": "d676943a909773643db739163632d799911c2086c3965bc467eccd381869f61a",
 			"recordedAt": "2026-07-01"
 		},
 		{
@@ -112,13 +112,13 @@
 		{
 			"source": "packages/plugin/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/data-flows.md",
-			"hash": "1a4a0332d97b6d4f420859aad6293f1d2125c74557f24c466536d9c763445745",
+			"hash": "eccaa0c60486dfc89e1d08afdf0568acb698c89bf10ed1b16fbaa1fcd9410b2f",
 			"recordedAt": "2026-07-01"
 		},
 		{
 			"source": "packages/plugin/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/decisions.md",
-			"hash": "5985f39aca762e14ba0dee17d1666d3f4862aa16613173c79f34dd422875b6f2",
+			"hash": "9ce52fb37feb6d198290e089d5850def89108bccb3165e1806598fa14feb4193",
 			"recordedAt": "2026-07-01"
 		},
 		{
@@ -142,13 +142,13 @@
 		{
 			"source": "packages/reporter/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/decisions.md",
-			"hash": "5985f39aca762e14ba0dee17d1666d3f4862aa16613173c79f34dd422875b6f2",
+			"hash": "9ce52fb37feb6d198290e089d5850def89108bccb3165e1806598fa14feb4193",
 			"recordedAt": "2026-07-01"
 		},
 		{
 			"source": "packages/reporter/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/schemas.md",
-			"hash": "9bbf0fd96be8a4ae3e44f1f85c16dbc17115a98cc07384fb8f9202ac19fe8f30",
+			"hash": "d676943a909773643db739163632d799911c2086c3965bc467eccd381869f61a",
 			"recordedAt": "2026-07-01"
 		},
 		{
@@ -160,13 +160,13 @@
 		{
 			"source": "packages/sdk/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/components/sdk.md",
-			"hash": "f22eb2519e632166684b3ec0f472037cf84f15d2e7e6596ca603ef2a91b2b884",
-			"recordedAt": "2026-06-17"
+			"hash": "7b486281438fe4f118543db1a141bff7ad357d60011a7b9024c7d57b7fa1ee7a",
+			"recordedAt": "2026-07-01"
 		},
 		{
 			"source": "packages/sdk/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/decisions.md",
-			"hash": "5985f39aca762e14ba0dee17d1666d3f4862aa16613173c79f34dd422875b6f2",
+			"hash": "9ce52fb37feb6d198290e089d5850def89108bccb3165e1806598fa14feb4193",
 			"recordedAt": "2026-07-01"
 		},
 		{
@@ -178,7 +178,7 @@
 		{
 			"source": "packages/sdk/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/schemas.md",
-			"hash": "9bbf0fd96be8a4ae3e44f1f85c16dbc17115a98cc07384fb8f9202ac19fe8f30",
+			"hash": "d676943a909773643db739163632d799911c2086c3965bc467eccd381869f61a",
 			"recordedAt": "2026-07-01"
 		},
 		{
@@ -196,7 +196,7 @@
 		{
 			"source": "packages/sidecar/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/decisions.md",
-			"hash": "5985f39aca762e14ba0dee17d1666d3f4862aa16613173c79f34dd422875b6f2",
+			"hash": "9ce52fb37feb6d198290e089d5850def89108bccb3165e1806598fa14feb4193",
 			"recordedAt": "2026-07-01"
 		},
 		{
@@ -214,13 +214,13 @@
 		{
 			"source": "packages/ui/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/decisions.md",
-			"hash": "5985f39aca762e14ba0dee17d1666d3f4862aa16613173c79f34dd422875b6f2",
+			"hash": "9ce52fb37feb6d198290e089d5850def89108bccb3165e1806598fa14feb4193",
 			"recordedAt": "2026-07-01"
 		},
 		{
 			"source": "packages/ui/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/schemas.md",
-			"hash": "9bbf0fd96be8a4ae3e44f1f85c16dbc17115a98cc07384fb8f9202ac19fe8f30",
+			"hash": "d676943a909773643db739163632d799911c2086c3965bc467eccd381869f61a",
 			"recordedAt": "2026-07-01"
 		},
 		{
@@ -238,7 +238,7 @@
 		{
 			"source": "plugin/CLAUDE.md",
 			"target": ".claude/design/vitest-agent/decisions.md",
-			"hash": "5985f39aca762e14ba0dee17d1666d3f4862aa16613173c79f34dd422875b6f2",
+			"hash": "9ce52fb37feb6d198290e089d5850def89108bccb3165e1806598fa14feb4193",
 			"recordedAt": "2026-07-01"
 		},
 		{

--- a/.claude/design/vitest-agent/components/sdk.md
+++ b/.claude/design/vitest-agent/components/sdk.md
@@ -3,8 +3,8 @@ status: current
 module: vitest-agent
 category: architecture
 created: 2026-05-06
-updated: 2026-06-30
-last-synced: 2026-06-30
+updated: 2026-07-01
+last-synced: 2026-07-01
 completeness: 96
 related:
   - ../architecture.md
@@ -407,6 +407,7 @@ The non-obvious pieces:
   without sorting.
 - **`findActiveSubagentSession` resolves per-call subagent identity.** Returns the most-recently-started subagent session whose `parent_session_id` matches the supplied parent id and whose `ended_at IS NULL`. The MCP server's boot context names only the main agent; this reader call is how the `hypothesis (action: record)` handler attributes writes to the active `tdd-task` subagent instead of the main session.
 - **Flaky classification requires a fail-after-pass.** The `listFlakyTests` reader query (backing `HistoryTracker.classify`) changed to require that at least one failure occurred at or after the earliest pass — `MAX(timestamp WHERE failed) >= MIN(timestamp WHERE passed)`. A monotonic red-to-green cycle (all failures precede all passes) classifies as `recovered`, not `flaky`. Timestamps are ISO-8601 strings and compare lexicographically.
+- **History reads are file-qualified.** `getHistory`, `getFlaky` and `getPersistentFailures` group and partition by the composite `(project, module_path, full_name)` and return `modulePath` on each `TestHistory` / `FlakyTest` / `PersistentFailure`. This mirrors the file-qualified write identity (Decision D20) and fixes read-side conflation where a persistent failure could hide behind a same-named passing test in another file. `HistoryTrackerLive.classify` keys its `testMap` and returned classifications by the `historyKey(modulePath, fullName)` helper.
 
 ## Formatters
 

--- a/.claude/design/vitest-agent/data-flows.md
+++ b/.claude/design/vitest-agent/data-flows.md
@@ -122,8 +122,11 @@ async onTestRunEnd(testModules, unhandledErrors, reason)
   |     aggregate per-tag pass/fail/skip counts via TestReport.tags
   |     attach as report.tagCounts (Record<tag, { passed, failed, skipped }>)
   |     HistoryTracker.classify(project, outcomes, ts)
+  |       outcomes carry { modulePath, fullName, state };
+  |       classifications keyed by historyKey(modulePath, fullName)
   |       -> { history, classifications }
   |     attach classifications to TestReport.classification
+  |       (lookup via historyKey(mod.file, test.fullName))
   |     DataStore.writeRun -> runId
   |     DataStore.writeModules / writeSuites / writeTestCases
   |     For each error:
@@ -131,6 +134,7 @@ async onTestRunEnd(testModules, unhandledErrors, reason)
   |       DataStore.writeFailureSignature
   |     DataStore.writeErrors (carries signatureHash + frames)
   |     DataStore.writeCoverage / writeHistory / writeSourceMap
+  |       writeHistory keys each row by (project, modulePath, fullName)
   |     If full (non-scoped) run:
   |       computeTrend() -> DataStore.writeTrends
   |
@@ -140,7 +144,9 @@ async onTestRunEnd(testModules, unhandledErrors, reason)
   +-- DataReader.getTrends -> trendSummary
   +-- Resolve env / executor / format / detail via SDK pipeline services
   +-- Aggregate per-project classifications into a flat
-  |   Map<fullName, TestClassification>
+  |   Map<fullName, TestClassification> (bare-fullName convenience
+  |   index for ui/reporter consumers; the authoritative,
+  |   module-qualified classification lives on each TestReport)
   +-- buildReporterKit(...) -> run-end ReporterKit (health-aware;
   |     carries this.runEvents and post-run detail)
   |     stdOsc8 enabled when !noColor &&

--- a/.claude/design/vitest-agent/decisions.md
+++ b/.claude/design/vitest-agent/decisions.md
@@ -1645,6 +1645,14 @@ rewrites the top-level `anyOf` to `oneOf` and adds
 `x-discriminator: "action"` for consolidated tools, improving
 model-side tool-use accuracy without changing functional dispatch.
 
+### Decision D20: File-Qualified `test_history` Identity
+
+Vitest's `fullName` is only the describe-chain plus the test name — it is **not** file-qualified. Two test files in the same workspace package that share a `describe › it` name therefore produced the same `fullName`. On the write side the plain `INSERT` into `test_history` collided on the old `UNIQUE(project, full_name, timestamp)` key and threw `UNIQUE constraint failed`; on the read side the two distinct tests were conflated into one series, so a persistent failure in one file could hide behind a same-named passing test in another.
+
+The fix threads a project-relative `module_path` through the whole history path and makes the identity `(project, module_path, full_name)`. Concretely: `test_history` gains a `module_path TEXT NOT NULL` column, the uniqueness constraint and the lookup index both grow the `module_path` segment, `TestHistory` / `FlakyTest` / `PersistentFailure` carry `modulePath`, `DataStore.writeHistory` takes a `modulePath` param, and `DataReaderLive` groups/partitions `getHistory` / `getFlaky` / `getPersistentFailures` by the composite key. The classifier keys its in-memory maps via a shared `historyKey(modulePath, fullName)` helper (exported from `services/HistoryTracker.ts`) so identically-named tests classify independently. The reporter derives each test's `modulePath` from the enclosing `TestModule`'s `relativeModuleId` and passes it into both the classification lookup and `writeHistory`.
+
+The single flat `Map<fullName, TestClassification>` the reporter hands downstream stays keyed by bare `fullName` on purpose — it is a convenience index for `@vitest-agent/ui` consumers that only have a bare test name, while the authoritative, module-qualified classification lives on each `TestReport`. Per the pre-2.0 single-migration policy (Decision D9) this landed as an in-place edit to `0001_initial.ts`, not an incremental migration.
+
 ---
 
 ## Notes

--- a/.claude/design/vitest-agent/schemas.md
+++ b/.claude/design/vitest-agent/schemas.md
@@ -290,9 +290,7 @@ type still exists because the CLI and MCP surfaces speak it.
 
 ## Failure history
 
-`HistoryRecord` is the per-test sliding-window log. `TestHistory.runs` is
-capped at 10 entries per `fullName`. The DB is the authoritative store; this
-type is the in-memory shape for classification.
+`HistoryRecord` is the per-test sliding-window log. A test's identity is file-qualified: `TestHistory` carries both `modulePath` and `fullName`, and `runs` is capped at 10 entries per `(modulePath, fullName)` pair. Vitest's `fullName` is only the describe-chain plus test name, so two files in one package that share a `describe › it` name would otherwise collide; qualifying by module path keeps them distinct end to end (see Decision D20). The DB is the authoritative store; this type is the in-memory shape for classification.
 
 ## Failure signature
 
@@ -612,7 +610,7 @@ read the already-updated row and accumulate stale tokens.
 | `import_durations` | Module import timing |
 | `task_metadata` | Key-value metadata |
 | `console_logs` | Per-test stdout/stderr capture |
-| `test_history` | Per-test sliding-window history |
+| `test_history` | Per-test sliding-window history; identity is `UNIQUE(project, module_path, full_name, timestamp)` and the lookup index is `(project, module_path, full_name)` |
 | `coverage_baselines` | Auto-ratcheting high-water marks |
 | `coverage_trends` | Per-project trend entries |
 | `file_coverage` | Per-file coverage per run |

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/silk": "^1.3.6",
+		"@savvy-web/silk": "^1.3.7",
 		"@vitest-agent/cli": "workspace:*",
 		"@vitest-agent/mcp": "workspace:*",
 		"@vitest-agent/plugin": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
 		"effect": "catalog:silk"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",

--- a/packages/mcp/__test__/router.test.ts
+++ b/packages/mcp/__test__/router.test.ts
@@ -616,6 +616,9 @@ describe("MCP Router", () => {
 			expect(recoveredB).toBeDefined();
 			expect(recoveredA?.fullName).toBe("Suite > shared name");
 			expect(recoveredB?.fullName).toBe("Suite > shared name");
+			// recentRuns is oldest-first; each module recovered failed -> passed.
+			expect(recoveredA?.recentRuns).toEqual(["failed", "passed"]);
+			expect(recoveredB?.recentRuns).toEqual(["failed", "passed"]);
 		});
 	});
 

--- a/packages/mcp/__test__/router.test.ts
+++ b/packages/mcp/__test__/router.test.ts
@@ -523,6 +523,102 @@ describe("MCP Router", () => {
 		});
 	});
 
+	describe("test_history tool", () => {
+		it("keeps two recovered tests with the same fullName in different modules distinguishable by modulePath", async () => {
+			const store = await testRuntime.runPromise(Effect.map(DataStore, (s) => s));
+
+			await testRuntime.runPromise(
+				Effect.gen(function* () {
+					yield* store.writeSettings("history-recovered-hash", { vitestVersion: "3.2.0" }, {});
+					const runId = yield* store.writeRun({
+						invocationId: "inv-history-recovered",
+						project: "history-recovered-proj",
+						settingsHash: "history-recovered-hash",
+						timestamp: "2026-03-26T00:00:00.000Z",
+						commitSha: null,
+						branch: null,
+						reason: "passed",
+						duration: 100,
+						total: 2,
+						passed: 2,
+						failed: 0,
+						skipped: 0,
+						scoped: false,
+					});
+
+					// Two distinct files sharing a describe+test name; each recovers
+					// from a failure to a pass -- the "recovered" listing must keep
+					// them as two distinguishable entries, not one collapsed row.
+					yield* store.writeHistory(
+						"history-recovered-proj",
+						"Suite > shared name",
+						"src/a.test.ts",
+						runId,
+						"2026-03-25T00:00:00.000Z",
+						"failed",
+						10,
+						false,
+						0,
+						"boom A",
+					);
+					yield* store.writeHistory(
+						"history-recovered-proj",
+						"Suite > shared name",
+						"src/a.test.ts",
+						runId,
+						"2026-03-26T00:00:00.000Z",
+						"passed",
+						10,
+						false,
+						0,
+						null,
+					);
+					yield* store.writeHistory(
+						"history-recovered-proj",
+						"Suite > shared name",
+						"src/b.test.ts",
+						runId,
+						"2026-03-25T00:00:00.000Z",
+						"failed",
+						10,
+						false,
+						0,
+						"boom B",
+					);
+					yield* store.writeHistory(
+						"history-recovered-proj",
+						"Suite > shared name",
+						"src/b.test.ts",
+						runId,
+						"2026-03-26T00:00:00.000Z",
+						"passed",
+						10,
+						false,
+						0,
+						null,
+					);
+				}),
+			);
+
+			const caller = createTestCaller();
+			const result = await caller.test_history({ project: "history-recovered-proj" });
+
+			expect(result.history.tests).toHaveLength(2);
+			const moduleAEntry = result.history.tests.find((t) => t.modulePath === "src/a.test.ts");
+			const moduleBEntry = result.history.tests.find((t) => t.modulePath === "src/b.test.ts");
+			expect(moduleAEntry?.fullName).toBe("Suite > shared name");
+			expect(moduleBEntry?.fullName).toBe("Suite > shared name");
+
+			expect(result.recovered).toHaveLength(2);
+			const recoveredA = result.recovered.find((r) => r.modulePath === "src/a.test.ts");
+			const recoveredB = result.recovered.find((r) => r.modulePath === "src/b.test.ts");
+			expect(recoveredA).toBeDefined();
+			expect(recoveredB).toBeDefined();
+			expect(recoveredA?.fullName).toBe("Suite > shared name");
+			expect(recoveredB?.fullName).toBe("Suite > shared name");
+		});
+	});
+
 	describe("wrapup_prompt tool", () => {
 		it("returns hasContent=false for an unknown session", async () => {
 			const caller = createTestCaller();

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,7 +47,7 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",

--- a/packages/mcp/src/tools/history.ts
+++ b/packages/mcp/src/tools/history.ts
@@ -14,6 +14,9 @@ import { publicProcedure } from "../context.js";
 
 const FlakyTestRow = Schema.Struct({
 	fullName: Schema.String.annotations({ description: "Full hierarchical test name (`describe > it`)." }),
+	modulePath: Schema.String.annotations({
+		description: "Project-relative test module path -- disambiguates same-named tests across files.",
+	}),
 	project: Schema.String,
 	passCount: Schema.Number.annotations({ description: "Number of passing runs in the recent window." }),
 	failCount: Schema.Number.annotations({ description: "Number of failing runs in the recent window." }),
@@ -26,6 +29,9 @@ const FlakyTestRow = Schema.Struct({
 
 const PersistentFailureRow = Schema.Struct({
 	fullName: Schema.String,
+	modulePath: Schema.String.annotations({
+		description: "Project-relative test module path -- disambiguates same-named tests across files.",
+	}),
 	project: Schema.String,
 	consecutiveFailures: Schema.Number.annotations({
 		description: "Length of the current uninterrupted failure streak.",
@@ -41,6 +47,9 @@ const PersistentFailureRow = Schema.Struct({
 });
 
 const RecoveredTestRow = Schema.Struct({
+	modulePath: Schema.String.annotations({
+		description: "Project-relative test module path -- disambiguates same-named tests across files.",
+	}),
 	fullName: Schema.String,
 	recentRuns: Schema.Array(Schema.Literal("passed", "failed")).annotations({
 		description: "Last 10 run states for this test, oldest first.",
@@ -81,6 +90,7 @@ export const formatTestHistoryMarkdown = (data: TestHistoryResultType): string =
 			lines.push(
 				`### ⚠️ ${test.fullName}`,
 				"",
+				`- Module: \`${test.modulePath}\``,
 				`- Pass rate: ${passRate}% (${test.passCount}/${total})`,
 				`- Last state: ${test.lastState}`,
 				`- Last run: ${new Date(test.lastTimestamp).toLocaleString()}`,
@@ -95,6 +105,7 @@ export const formatTestHistoryMarkdown = (data: TestHistoryResultType): string =
 			lines.push(
 				`### ❌ ${failure.fullName}`,
 				"",
+				`- Module: \`${failure.modulePath}\``,
 				`- Consecutive failures: ${failure.consecutiveFailures}`,
 				`- First failed: ${new Date(failure.firstFailedAt).toLocaleString()}`,
 				`- Last failed: ${new Date(failure.lastFailedAt).toLocaleString()}`,
@@ -108,7 +119,7 @@ export const formatTestHistoryMarkdown = (data: TestHistoryResultType): string =
 		lines.push("## Recovered Tests", "", "Tests that previously failed but are now passing:", "");
 		for (const test of data.recovered) {
 			const runViz = test.recentRuns.map((s) => (s === "passed" ? "P" : "F")).join("");
-			lines.push(`- ✅ **${test.fullName}** — recent runs: \`${runViz}\``);
+			lines.push(`- ✅ **${test.fullName}** (${test.modulePath}) — recent runs: \`${runViz}\``);
 		}
 		lines.push("");
 	}
@@ -147,17 +158,29 @@ export const testHistory = publicProcedure
 						reader.getPersistentFailures(input.project),
 					]);
 
+					// t.runs is ordered most-recent-first (see classifyTest's documented
+					// "priorRuns" convention), so the current/most recent run is
+					// runs[0] and the one before it is runs[1].
 					const recovered = history.tests
 						.filter((t) => {
 							const runs = t.runs;
 							if (runs.length < 2) return false;
-							const last = runs[runs.length - 1];
-							const prev = runs[runs.length - 2];
-							return last !== undefined && prev !== undefined && last.state === "passed" && prev.state === "failed";
+							const mostRecent = runs[0];
+							const previous = runs[1];
+							return (
+								mostRecent !== undefined &&
+								previous !== undefined &&
+								mostRecent.state === "passed" &&
+								previous.state === "failed"
+							);
 						})
 						.map((t) => ({
+							modulePath: t.modulePath,
 							fullName: t.fullName,
-							recentRuns: t.runs.slice(-10).map((r) => r.state),
+							recentRuns: t.runs
+								.slice(0, 10)
+								.reverse()
+								.map((r) => r.state),
 						}));
 
 					const hasData = history.tests.length > 0 || flaky.length > 0 || persistent.length > 0;

--- a/packages/plugin/__test__/reporter.test.ts
+++ b/packages/plugin/__test__/reporter.test.ts
@@ -638,6 +638,62 @@ describe("AgentReporter", () => {
 
 			expect(fs.existsSync(path.join(tmpDir, "data.db"))).toBe(true);
 		});
+
+		it("writes distinct per-module test_history rows for two tests sharing a fullName in different modules", async () => {
+			const reporter = new AgentReporter({
+				cacheDir: tmpDir,
+				consoleMode: "silent",
+			});
+
+			const testA = makeTestCase({
+				name: "duplicate name",
+				fullName: "Suite > duplicate name",
+				state: "passed",
+				duration: 111,
+			});
+			const testB = makeTestCase({
+				name: "duplicate name",
+				fullName: "Suite > duplicate name",
+				state: "failed",
+				duration: 222,
+				errors: [{ message: "module B failure" }],
+			});
+
+			const moduleA = makeTestModule({ relativeModuleId: "src/a.test.ts", tests: [testA] });
+			const moduleB = makeTestModule({ relativeModuleId: "src/b.test.ts", state: "failed", tests: [testB] });
+
+			await reporter.onTestRunEnd([moduleA, moduleB], [], "failed");
+
+			const dbPath = path.join(tmpDir, "data.db");
+			const db = new Database(dbPath, { readonly: true });
+			const rows = db
+				.prepare(
+					`SELECT module_path, full_name, state, duration, error_message
+					 FROM test_history
+					 WHERE full_name = 'Suite > duplicate name'
+					 ORDER BY module_path`,
+				)
+				.all() as Array<{
+				module_path: string;
+				full_name: string;
+				state: string;
+				duration: number | null;
+				error_message: string | null;
+			}>;
+			db.close();
+
+			expect(rows).toHaveLength(2);
+			const rowA = rows.find((r) => r.module_path === "src/a.test.ts");
+			const rowB = rows.find((r) => r.module_path === "src/b.test.ts");
+			expect(rowA).toBeDefined();
+			expect(rowB).toBeDefined();
+			expect(rowA?.state).toBe("passed");
+			expect(rowA?.duration).toBe(111);
+			expect(rowA?.error_message).toBeNull();
+			expect(rowB?.state).toBe("failed");
+			expect(rowB?.duration).toBe(222);
+			expect(rowB?.error_message).toBe("module B failure");
+		});
 	});
 
 	describe("failure signatures", () => {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -45,10 +45,10 @@
 		"acorn-typescript": "^1.4.13",
 		"effect": "catalog:silk",
 		"magic-string": "^0.30.21",
-		"workspaces-effect": "^1.2.0"
+		"workspaces-effect": "^1.3.0"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",

--- a/packages/plugin/src/reporter.ts
+++ b/packages/plugin/src/reporter.ts
@@ -34,6 +34,7 @@ import {
 	computeTrend,
 	ensureMigrated,
 	formatFatalError,
+	historyKey,
 	isTimeoutError,
 	probeHostMetadataFromEnv,
 	resolveDataPath,
@@ -1640,13 +1641,16 @@ export class AgentReporter {
 					yield* store.writeErrors(runId, inputs);
 				}
 
-				// Extract test outcomes for history classification
+				// Extract test outcomes for history classification. modulePath comes
+				// from the enclosing TestModule's relativeModuleId so identically
+				// named tests in different files are tracked as distinct series.
 				const testOutcomes: TestOutcome[] = [];
 				for (const mod of projectModules) {
+					const modulePath = mod.relativeModuleId ?? "";
 					for (const testCase of mod.children.allTests()) {
 						const state = testCase.result()?.state;
 						if (state === "passed" || state === "failed") {
-							testOutcomes.push({ fullName: testCase.fullName, state });
+							testOutcomes.push({ modulePath, fullName: testCase.fullName, state });
 						}
 					}
 				}
@@ -1654,28 +1658,34 @@ export class AgentReporter {
 				// Classify tests via history and attach classifications to failed test reports
 				const { classifications } = yield* tracker.classify(project, testOutcomes, baseReport.timestamp);
 
-				// Build lookup maps for diagnostics and errors (avoids O(N²) nested loops)
+				// Build lookup maps for diagnostics and errors, keyed by the composite
+				// (modulePath, fullName) so cross-file duplicate fullNames don't clobber
+				// each other's diagnostics/errors (avoids O(N²) nested loops).
 				const diagMap = new Map<string, { duration?: number; flaky?: boolean }>();
 				const errorMap = new Map<string, string | null>();
 				for (const mod of projectModules) {
+					const modulePath = mod.relativeModuleId ?? "";
 					for (const tc of mod.children.allTests()) {
-						diagMap.set(tc.fullName, tc.diagnostic() ?? {});
+						const key = historyKey(modulePath, tc.fullName);
+						diagMap.set(key, tc.diagnostic() ?? {});
 						const tcResult = tc.result();
 						if (tcResult?.state === "failed") {
 							const errors = tcResult.errors;
-							errorMap.set(tc.fullName, errors?.[0]?.message ?? null);
+							errorMap.set(key, errors?.[0]?.message ?? null);
 						}
 					}
 				}
 
 				// Write individual history entries to DB
 				for (const outcome of testOutcomes) {
-					const diag = diagMap.get(outcome.fullName);
-					const errorMessage = outcome.state === "failed" ? (errorMap.get(outcome.fullName) ?? null) : null;
+					const key = historyKey(outcome.modulePath, outcome.fullName);
+					const diag = diagMap.get(key);
+					const errorMessage = outcome.state === "failed" ? (errorMap.get(key) ?? null) : null;
 
 					yield* store.writeHistory(
 						project,
 						outcome.fullName,
+						outcome.modulePath,
 						runId,
 						baseReport.timestamp,
 						outcome.state,
@@ -1690,7 +1700,7 @@ export class AgentReporter {
 				const failedWithClassifications = baseReport.failed.map((mod) => ({
 					...mod,
 					tests: mod.tests.map((test) => {
-						const cls = classifications.get(test.fullName);
+						const cls = classifications.get(historyKey(mod.file, test.fullName));
 						return cls ? { ...test, classification: cls } : test;
 					}),
 				}));
@@ -1857,6 +1867,11 @@ export class AgentReporter {
 			// Aggregate classifications into a flat lookup for the user reporter.
 			// Reports already carry classification on each test object; this
 			// Map gives reporters a global view without traversing reports.
+			// Keyed by plain fullName -- this flat Map is a convenience index for
+			// downstream reporter/ui consumers (e.g. @vitest-agent/ui's synthesize)
+			// that only have a bare test name available, not modulePath. The
+			// authoritative per-test classification (already disambiguated by
+			// (modulePath, fullName) above) lives on each TestReport itself.
 			const classifications = new Map<string, TestClassification>();
 			for (const report of reports) {
 				for (const mod of report.failed) {

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -44,7 +44,7 @@
 		"react": "catalog:silk"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/node": "catalog:silk",
 		"@types/react": "catalog:silk",

--- a/packages/sdk/__test__/DataReaderLive.test.ts
+++ b/packages/sdk/__test__/DataReaderLive.test.ts
@@ -159,6 +159,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"hist-proj",
 						"suite > test A",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T01:00:00.000Z",
 						"passed",
@@ -170,6 +171,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"hist-proj",
 						"suite > test A",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T02:00:00.000Z",
 						"failed",
@@ -181,6 +183,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"hist-proj",
 						"suite > test B",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T01:00:00.000Z",
 						"passed",
@@ -348,6 +351,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"flaky-proj",
 						"flaky test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T01:00:00.000Z",
 						"passed",
@@ -359,6 +363,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"flaky-proj",
 						"flaky test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T02:00:00.000Z",
 						"failed",
@@ -370,6 +375,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"flaky-proj",
 						"flaky test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T03:00:00.000Z",
 						"passed",
@@ -383,6 +389,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"flaky-proj",
 						"stable test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T01:00:00.000Z",
 						"passed",
@@ -394,6 +401,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"flaky-proj",
 						"stable test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T02:00:00.000Z",
 						"passed",
@@ -427,6 +435,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"recovery-proj",
 						"tdd test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T01:00:00.000Z",
 						"failed",
@@ -438,6 +447,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"recovery-proj",
 						"tdd test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T02:00:00.000Z",
 						"failed",
@@ -449,6 +459,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"recovery-proj",
 						"tdd test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T03:00:00.000Z",
 						"failed",
@@ -460,6 +471,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"recovery-proj",
 						"tdd test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T04:00:00.000Z",
 						"passed",
@@ -471,6 +483,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"recovery-proj",
 						"tdd test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T05:00:00.000Z",
 						"passed",
@@ -484,6 +497,91 @@ describe("DataReaderLive", () => {
 				}),
 			);
 			expect(result).toHaveLength(0);
+		});
+
+		it("keeps same-named tests in different modules as distinct series", async () => {
+			const result = await run(
+				Effect.gen(function* () {
+					const store = yield* DataStore;
+					const reader = yield* DataReader;
+
+					yield* store.writeSettings("qual-flaky-hash", settingsInput, {});
+					const runId = yield* store.writeRun({ ...runInput, settingsHash: "qual-flaky-hash" });
+
+					// Same fullName "dup" in two different files. The flaky.test.ts copy
+					// oscillates pass->fail->pass; the stable.test.ts copy always passes.
+					// If history grouped by full_name only (the pre-file-qualified bug),
+					// the two would merge into one 3-pass/1-fail series and report a
+					// single flaky row. File-qualified, only flaky.test.ts is flaky.
+					yield* store.writeHistory(
+						"qual-proj",
+						"dup",
+						"src/flaky.test.ts",
+						runId,
+						"2026-03-22T01:00:00.000Z",
+						"passed",
+						10,
+						false,
+						0,
+						null,
+					);
+					yield* store.writeHistory(
+						"qual-proj",
+						"dup",
+						"src/flaky.test.ts",
+						runId,
+						"2026-03-22T02:00:00.000Z",
+						"failed",
+						10,
+						false,
+						0,
+						"oops",
+					);
+					yield* store.writeHistory(
+						"qual-proj",
+						"dup",
+						"src/flaky.test.ts",
+						runId,
+						"2026-03-22T03:00:00.000Z",
+						"passed",
+						10,
+						false,
+						0,
+						null,
+					);
+					yield* store.writeHistory(
+						"qual-proj",
+						"dup",
+						"src/stable.test.ts",
+						runId,
+						"2026-03-22T01:00:00.000Z",
+						"passed",
+						10,
+						false,
+						0,
+						null,
+					);
+					yield* store.writeHistory(
+						"qual-proj",
+						"dup",
+						"src/stable.test.ts",
+						runId,
+						"2026-03-22T02:00:00.000Z",
+						"passed",
+						10,
+						false,
+						0,
+						null,
+					);
+
+					return yield* reader.getFlaky("qual-proj");
+				}),
+			);
+			expect(result).toHaveLength(1);
+			expect(result[0].fullName).toBe("dup");
+			expect(result[0].modulePath).toBe("src/flaky.test.ts");
+			expect(result[0].passCount).toBe(2);
+			expect(result[0].failCount).toBe(1);
 		});
 	});
 
@@ -511,6 +609,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"persist-proj",
 						"broken test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T01:00:00.000Z",
 						"passed",
@@ -522,6 +621,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"persist-proj",
 						"broken test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T02:00:00.000Z",
 						"failed",
@@ -533,6 +633,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"persist-proj",
 						"broken test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T03:00:00.000Z",
 						"failed",
@@ -544,6 +645,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"persist-proj",
 						"broken test",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T04:00:00.000Z",
 						"failed",
@@ -557,6 +659,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"persist-proj",
 						"one-time fail",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T01:00:00.000Z",
 						"passed",
@@ -568,6 +671,7 @@ describe("DataReaderLive", () => {
 					yield* store.writeHistory(
 						"persist-proj",
 						"one-time fail",
+						"src/history.test.ts",
 						runId,
 						"2026-03-22T02:00:00.000Z",
 						"failed",
@@ -585,6 +689,77 @@ describe("DataReaderLive", () => {
 			expect(result[0].fullName).toBe("broken test");
 			expect(result[0].consecutiveFailures).toBe(3);
 			expect(result[0].lastErrorMessage).toBe("error 3");
+		});
+
+		it("surfaces a persistent failure that a same-named passing test in another module would hide", async () => {
+			const result = await run(
+				Effect.gen(function* () {
+					const store = yield* DataStore;
+					const reader = yield* DataReader;
+
+					yield* store.writeSettings("qual-persist-hash", settingsInput, {});
+					const runId = yield* store.writeRun({ ...runInput, settingsHash: "qual-persist-hash" });
+
+					// Same fullName "dup" in two files. failing.test.ts fails twice;
+					// passing.test.ts passes twice at later timestamps. Grouped by
+					// full_name only, the recent passes would break the streak and hide
+					// the persistent failure. File-qualified, failing.test.ts is caught.
+					yield* store.writeHistory(
+						"qual-persist-proj",
+						"dup",
+						"src/failing.test.ts",
+						runId,
+						"2026-03-22T01:00:00.000Z",
+						"failed",
+						10,
+						false,
+						0,
+						"boom",
+					);
+					yield* store.writeHistory(
+						"qual-persist-proj",
+						"dup",
+						"src/failing.test.ts",
+						runId,
+						"2026-03-22T02:00:00.000Z",
+						"failed",
+						10,
+						false,
+						0,
+						"boom",
+					);
+					yield* store.writeHistory(
+						"qual-persist-proj",
+						"dup",
+						"src/passing.test.ts",
+						runId,
+						"2026-03-22T03:00:00.000Z",
+						"passed",
+						10,
+						false,
+						0,
+						null,
+					);
+					yield* store.writeHistory(
+						"qual-persist-proj",
+						"dup",
+						"src/passing.test.ts",
+						runId,
+						"2026-03-22T04:00:00.000Z",
+						"passed",
+						10,
+						false,
+						0,
+						null,
+					);
+
+					return yield* reader.getPersistentFailures("qual-persist-proj");
+				}),
+			);
+			expect(result).toHaveLength(1);
+			expect(result[0].fullName).toBe("dup");
+			expect(result[0].modulePath).toBe("src/failing.test.ts");
+			expect(result[0].consecutiveFailures).toBe(2);
 		});
 	});
 

--- a/packages/sdk/__test__/DataStoreLive.test.ts
+++ b/packages/sdk/__test__/DataStoreLive.test.ts
@@ -544,9 +544,7 @@ describe("DataStoreLive", () => {
 		});
 
 		it("allows the same (project, full_name, timestamp) key for two different module_path values, tracked as distinct history entries", async () => {
-			// RED: current writeHistory has no modulePath param -- this call shifts
-			// positional args and throws a SQLite3 bind-type error.
-			const TestLayer = makeTestLayer(":memory:");
+			const ModulePathTestLayer = makeTestLayer(":memory:");
 			const result = await Effect.runPromise(
 				Effect.provide(
 					Effect.gen(function* () {
@@ -588,7 +586,7 @@ describe("DataStoreLive", () => {
 
 						return yield* reader.getHistory("modpath-project");
 					}),
-					TestLayer,
+					ModulePathTestLayer,
 				),
 			);
 

--- a/packages/sdk/__test__/DataStoreLive.test.ts
+++ b/packages/sdk/__test__/DataStoreLive.test.ts
@@ -7,7 +7,9 @@ import { describe, expect, it } from "vitest";
 import { DataStoreLive } from "../src/layers/DataStoreLive.js";
 import migration0001 from "../src/migrations/0001_initial.js";
 
+import { DataReader } from "../src/services/DataReader.js";
 import { DataStore } from "../src/services/DataStore.js";
+import { makeTestLayer } from "../src/testing/layers.js";
 
 const SqliteLayer = sqliteClientLayer({ filename: ":memory:" });
 const PlatformLayer = NodeContext.layer;
@@ -521,6 +523,7 @@ describe("DataStoreLive", () => {
 					yield* store.writeHistory(
 						"my-project",
 						"suite > test one",
+						"src/suite.test.ts",
 						runId,
 						"2026-03-22T00:00:00.000Z",
 						"passed",
@@ -540,6 +543,110 @@ describe("DataStoreLive", () => {
 			);
 		});
 
+		it("allows the same (project, full_name, timestamp) key for two different module_path values, tracked as distinct history entries", async () => {
+			// RED: current writeHistory has no modulePath param -- this call shifts
+			// positional args and throws a SQLite3 bind-type error.
+			const TestLayer = makeTestLayer(":memory:");
+			const result = await Effect.runPromise(
+				Effect.provide(
+					Effect.gen(function* () {
+						const store = yield* DataStore;
+						const reader = yield* DataReader;
+						yield* store.writeSettings("hist-modpath-hash", settingsInput, {});
+						const runId = yield* store.writeRun({
+							...runInput,
+							project: "modpath-project",
+							settingsHash: "hist-modpath-hash",
+						});
+
+						// Same (project, full_name, timestamp) key, different module_path --
+						// two distinct test files that happen to share a describe+test name.
+						yield* store.writeHistory(
+							"modpath-project",
+							"suite > duplicate name",
+							"src/a.test.ts",
+							runId,
+							"2026-03-22T00:00:00.000Z",
+							"passed",
+							50,
+							false,
+							0,
+							null,
+						);
+						yield* store.writeHistory(
+							"modpath-project",
+							"suite > duplicate name",
+							"src/b.test.ts",
+							runId,
+							"2026-03-22T00:00:00.000Z",
+							"failed",
+							75,
+							false,
+							0,
+							"boom",
+						);
+
+						return yield* reader.getHistory("modpath-project");
+					}),
+					TestLayer,
+				),
+			);
+
+			expect(result.tests).toHaveLength(2);
+			const a = result.tests.find((t) => t.modulePath === "src/a.test.ts");
+			const b = result.tests.find((t) => t.modulePath === "src/b.test.ts");
+			expect(a).toBeDefined();
+			expect(b).toBeDefined();
+			expect(a?.fullName).toBe("suite > duplicate name");
+			expect(b?.fullName).toBe("suite > duplicate name");
+			expect(a?.runs).toHaveLength(1);
+			expect(b?.runs).toHaveLength(1);
+			expect(a?.runs[0].state).toBe("passed");
+			expect(b?.runs[0].state).toBe("failed");
+		});
+
+		it("still throws a UNIQUE constraint violation for the exact same (project, module_path, full_name, timestamp) composite key", async () => {
+			// Triangulated by behavior 12's schema/writeHistory implementation.
+			await expect(
+				run(
+					Effect.gen(function* () {
+						const store = yield* DataStore;
+						yield* store.writeSettings("hist-exact-dup-hash", settingsInput, {});
+						const runId = yield* store.writeRun({ ...runInput, settingsHash: "hist-exact-dup-hash" });
+
+						yield* store.writeHistory(
+							"exact-dup-project",
+							"suite > exact duplicate",
+							"src/exact.test.ts",
+							runId,
+							"2026-03-22T00:00:00.000Z",
+							"passed",
+							50,
+							false,
+							0,
+							null,
+						);
+
+						// Identical (project, module_path, full_name, timestamp) key --
+						// this is a genuine duplicate, not a cross-file collision, and
+						// must still violate the UNIQUE constraint.
+						yield* store.writeHistory(
+							"exact-dup-project",
+							"suite > exact duplicate",
+							"src/exact.test.ts",
+							runId,
+							"2026-03-22T00:00:00.000Z",
+							"failed",
+							75,
+							false,
+							1,
+							"boom",
+						);
+					}),
+				),
+			).rejects.toThrow();
+		});
+
 		it("respects 10-entry sliding window", async () => {
 			await run(
 				Effect.gen(function* () {
@@ -552,6 +659,7 @@ describe("DataStoreLive", () => {
 						yield* store.writeHistory(
 							"window-proj",
 							"windowed test",
+							"src/windowed.test.ts",
 							runId,
 							`2026-03-22T${String(i).padStart(2, "0")}:00:00.000Z`,
 							"passed",
@@ -567,6 +675,59 @@ describe("DataStoreLive", () => {
 						id: number;
 					}>`SELECT id FROM test_history WHERE project = 'window-proj' AND full_name = 'windowed test'`;
 					expect(rows).toHaveLength(10);
+				}),
+			);
+		});
+
+		it("prunes the 10-entry window independently per module_path, not shared across files with the same full_name", async () => {
+			await run(
+				Effect.gen(function* () {
+					const store = yield* DataStore;
+					yield* store.writeSettings("hist-win-isolated-hash", settingsInput, {});
+					const runId = yield* store.writeRun({ ...runInput, settingsHash: "hist-win-isolated-hash" });
+
+					// 12 entries for module A -- should prune to 10.
+					for (let i = 0; i < 12; i++) {
+						yield* store.writeHistory(
+							"window-isolated-proj",
+							"windowed test",
+							"src/a.test.ts",
+							runId,
+							`2026-03-22T${String(i).padStart(2, "0")}:00:00.000Z`,
+							"passed",
+							10,
+							false,
+							0,
+							null,
+						);
+					}
+
+					// 3 entries for module B, same full_name -- must stay untouched by
+					// module A's retention window, and not itself be pruned.
+					for (let i = 0; i < 3; i++) {
+						yield* store.writeHistory(
+							"window-isolated-proj",
+							"windowed test",
+							"src/b.test.ts",
+							runId,
+							`2026-03-23T${String(i).padStart(2, "0")}:00:00.000Z`,
+							"passed",
+							10,
+							false,
+							0,
+							null,
+						);
+					}
+
+					const sql = yield* SqlClient;
+					const rowsA = yield* sql<{
+						id: number;
+					}>`SELECT id FROM test_history WHERE project = 'window-isolated-proj' AND module_path = 'src/a.test.ts' AND full_name = 'windowed test'`;
+					const rowsB = yield* sql<{
+						id: number;
+					}>`SELECT id FROM test_history WHERE project = 'window-isolated-proj' AND module_path = 'src/b.test.ts' AND full_name = 'windowed test'`;
+					expect(rowsA).toHaveLength(10);
+					expect(rowsB).toHaveLength(3);
 				}),
 			);
 		});

--- a/packages/sdk/__test__/History.test.ts
+++ b/packages/sdk/__test__/History.test.ts
@@ -32,6 +32,7 @@ describe("TestRun", () => {
 describe("TestHistory", () => {
 	it("accepts valid history entry", () => {
 		const input = {
+			modulePath: "src/suite.test.ts",
 			fullName: "Suite > test name",
 			runs: [
 				{ timestamp: "2026-03-21T00:00:00.000Z", state: "passed" },
@@ -43,7 +44,7 @@ describe("TestHistory", () => {
 	});
 
 	it("accepts empty runs array", () => {
-		const input = { fullName: "test", runs: [] };
+		const input = { modulePath: "src/suite.test.ts", fullName: "test", runs: [] };
 		const result = Schema.decodeUnknownSync(TestHistory)(input);
 		expect(result.runs).toEqual([]);
 	});
@@ -56,6 +57,7 @@ describe("HistoryRecord", () => {
 			updatedAt: "2026-03-21T00:00:00.000Z",
 			tests: [
 				{
+					modulePath: "src/suite.test.ts",
 					fullName: "Suite > test",
 					runs: [{ timestamp: "2026-03-21T00:00:00.000Z", state: "passed" }],
 				},

--- a/packages/sdk/__test__/HistoryTrackerLive.test.ts
+++ b/packages/sdk/__test__/HistoryTrackerLive.test.ts
@@ -10,7 +10,7 @@ import { HistoryTrackerLive } from "../src/layers/HistoryTrackerLive.js";
 import migration0001 from "../src/migrations/0001_initial.js";
 import type { DataReader } from "../src/services/DataReader.js";
 import { DataStore } from "../src/services/DataStore.js";
-import { HistoryTracker } from "../src/services/HistoryTracker.js";
+import { HistoryTracker, historyKey } from "../src/services/HistoryTracker.js";
 
 const SqliteLayer = sqliteClientLayer({ filename: ":memory:" });
 const PlatformLayer = NodeContext.layer;
@@ -47,7 +47,11 @@ const SETTINGS_INPUT = {
  * Returns the runId for further use.
  */
 function seedHistoryEntries(
-	entries: ReadonlyArray<{ fullName: string; runs: ReadonlyArray<{ timestamp: string; state: "passed" | "failed" }> }>,
+	entries: ReadonlyArray<{
+		modulePath?: string;
+		fullName: string;
+		runs: ReadonlyArray<{ timestamp: string; state: "passed" | "failed" }>;
+	}>,
 ) {
 	return Effect.gen(function* () {
 		const store = yield* DataStore;
@@ -78,6 +82,7 @@ function seedHistoryEntries(
 				yield* store.writeHistory(
 					PROJECT,
 					entry.fullName,
+					entry.modulePath ?? "src/history.test.ts",
 					runId,
 					histRun.timestamp,
 					histRun.state,
@@ -96,11 +101,11 @@ function seedHistoryEntries(
 describe("HistoryTrackerLive", () => {
 	describe("stable -- all passing, no prior history", () => {
 		it("classifies passing tests with no prior history as stable", async () => {
-			const outcomes = [{ fullName: "Suite > test one", state: "passed" as const }];
+			const outcomes = [{ modulePath: "src/history.test.ts", fullName: "Suite > test one", state: "passed" as const }];
 
 			const result = await run(Effect.flatMap(HistoryTracker, (svc) => svc.classify(PROJECT, outcomes, TS)));
 
-			expect(result.classifications.get("Suite > test one")).toBe("stable");
+			expect(result.classifications.get(historyKey("src/history.test.ts", "Suite > test one"))).toBe("stable");
 		});
 
 		it("classifies passing tests with all prior runs passed as stable", async () => {
@@ -108,6 +113,7 @@ describe("HistoryTrackerLive", () => {
 				Effect.gen(function* () {
 					yield* seedHistoryEntries([
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > test one",
 							runs: [
 								{ timestamp: "2026-03-19T00:00:00.000Z", state: "passed" },
@@ -117,21 +123,27 @@ describe("HistoryTrackerLive", () => {
 					]);
 
 					const tracker = yield* HistoryTracker;
-					return yield* tracker.classify(PROJECT, [{ fullName: "Suite > test one", state: "passed" }], TS);
+					return yield* tracker.classify(
+						PROJECT,
+						[{ modulePath: "src/history.test.ts", fullName: "Suite > test one", state: "passed" }],
+						TS,
+					);
 				}),
 			);
 
-			expect(result.classifications.get("Suite > test one")).toBe("stable");
+			expect(result.classifications.get(historyKey("src/history.test.ts", "Suite > test one"))).toBe("stable");
 		});
 	});
 
 	describe("new-failure -- failing with no prior history", () => {
 		it("classifies failing test with no prior runs as new-failure", async () => {
-			const outcomes = [{ fullName: "Suite > broken test", state: "failed" as const }];
+			const outcomes = [
+				{ modulePath: "src/history.test.ts", fullName: "Suite > broken test", state: "failed" as const },
+			];
 
 			const result = await run(Effect.flatMap(HistoryTracker, (svc) => svc.classify(PROJECT, outcomes, TS)));
 
-			expect(result.classifications.get("Suite > broken test")).toBe("new-failure");
+			expect(result.classifications.get(historyKey("src/history.test.ts", "Suite > broken test"))).toBe("new-failure");
 		});
 	});
 
@@ -141,6 +153,7 @@ describe("HistoryTrackerLive", () => {
 				Effect.gen(function* () {
 					yield* seedHistoryEntries([
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > now failing",
 							runs: [
 								{ timestamp: "2026-03-19T00:00:00.000Z", state: "passed" },
@@ -151,11 +164,15 @@ describe("HistoryTrackerLive", () => {
 					]);
 
 					const tracker = yield* HistoryTracker;
-					return yield* tracker.classify(PROJECT, [{ fullName: "Suite > now failing", state: "failed" }], TS);
+					return yield* tracker.classify(
+						PROJECT,
+						[{ modulePath: "src/history.test.ts", fullName: "Suite > now failing", state: "failed" }],
+						TS,
+					);
 				}),
 			);
 
-			expect(result.classifications.get("Suite > now failing")).toBe("new-failure");
+			expect(result.classifications.get(historyKey("src/history.test.ts", "Suite > now failing"))).toBe("new-failure");
 		});
 	});
 
@@ -165,6 +182,7 @@ describe("HistoryTrackerLive", () => {
 				Effect.gen(function* () {
 					yield* seedHistoryEntries([
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > persistent failure",
 							runs: [
 								{ timestamp: "2026-03-19T00:00:00.000Z", state: "failed" },
@@ -174,11 +192,17 @@ describe("HistoryTrackerLive", () => {
 					]);
 
 					const tracker = yield* HistoryTracker;
-					return yield* tracker.classify(PROJECT, [{ fullName: "Suite > persistent failure", state: "failed" }], TS);
+					return yield* tracker.classify(
+						PROJECT,
+						[{ modulePath: "src/history.test.ts", fullName: "Suite > persistent failure", state: "failed" }],
+						TS,
+					);
 				}),
 			);
 
-			expect(result.classifications.get("Suite > persistent failure")).toBe("persistent");
+			expect(result.classifications.get(historyKey("src/history.test.ts", "Suite > persistent failure"))).toBe(
+				"persistent",
+			);
 		});
 
 		it("classifies failing test as persistent when all prior runs also failed", async () => {
@@ -186,6 +210,7 @@ describe("HistoryTrackerLive", () => {
 				Effect.gen(function* () {
 					yield* seedHistoryEntries([
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > always fails",
 							runs: [
 								{ timestamp: "2026-03-19T00:00:00.000Z", state: "failed" },
@@ -195,11 +220,15 @@ describe("HistoryTrackerLive", () => {
 					]);
 
 					const tracker = yield* HistoryTracker;
-					return yield* tracker.classify(PROJECT, [{ fullName: "Suite > always fails", state: "failed" }], TS);
+					return yield* tracker.classify(
+						PROJECT,
+						[{ modulePath: "src/history.test.ts", fullName: "Suite > always fails", state: "failed" }],
+						TS,
+					);
 				}),
 			);
 
-			expect(result.classifications.get("Suite > always fails")).toBe("persistent");
+			expect(result.classifications.get(historyKey("src/history.test.ts", "Suite > always fails"))).toBe("persistent");
 		});
 	});
 
@@ -209,6 +238,7 @@ describe("HistoryTrackerLive", () => {
 				Effect.gen(function* () {
 					yield* seedHistoryEntries([
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > flaky test",
 							runs: [
 								{ timestamp: "2026-03-19T00:00:00.000Z", state: "passed" },
@@ -219,12 +249,16 @@ describe("HistoryTrackerLive", () => {
 					]);
 
 					const tracker = yield* HistoryTracker;
-					return yield* tracker.classify(PROJECT, [{ fullName: "Suite > flaky test", state: "failed" }], TS);
+					return yield* tracker.classify(
+						PROJECT,
+						[{ modulePath: "src/history.test.ts", fullName: "Suite > flaky test", state: "failed" }],
+						TS,
+					);
 				}),
 			);
 
 			// priorRuns[0].state = "passed" (not failed), and there are prior failures => flaky
-			expect(result.classifications.get("Suite > flaky test")).toBe("flaky");
+			expect(result.classifications.get(historyKey("src/history.test.ts", "Suite > flaky test"))).toBe("flaky");
 		});
 	});
 
@@ -234,6 +268,7 @@ describe("HistoryTrackerLive", () => {
 				Effect.gen(function* () {
 					yield* seedHistoryEntries([
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > recovered test",
 							runs: [
 								{ timestamp: "2026-03-19T00:00:00.000Z", state: "failed" },
@@ -243,11 +278,15 @@ describe("HistoryTrackerLive", () => {
 					]);
 
 					const tracker = yield* HistoryTracker;
-					return yield* tracker.classify(PROJECT, [{ fullName: "Suite > recovered test", state: "passed" }], TS);
+					return yield* tracker.classify(
+						PROJECT,
+						[{ modulePath: "src/history.test.ts", fullName: "Suite > recovered test", state: "passed" }],
+						TS,
+					);
 				}),
 			);
 
-			expect(result.classifications.get("Suite > recovered test")).toBe("recovered");
+			expect(result.classifications.get(historyKey("src/history.test.ts", "Suite > recovered test"))).toBe("recovered");
 		});
 	});
 
@@ -257,6 +296,7 @@ describe("HistoryTrackerLive", () => {
 				Effect.gen(function* () {
 					yield* seedHistoryEntries([
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > stable test",
 							runs: Array.from({ length: 10 }, (_, i) => ({
 								timestamp: `2026-03-${String(10 + i).padStart(2, "0")}T00:00:00.000Z`,
@@ -266,7 +306,11 @@ describe("HistoryTrackerLive", () => {
 					]);
 
 					const tracker = yield* HistoryTracker;
-					return yield* tracker.classify(PROJECT, [{ fullName: "Suite > stable test", state: "passed" }], TS);
+					return yield* tracker.classify(
+						PROJECT,
+						[{ modulePath: "src/history.test.ts", fullName: "Suite > stable test", state: "passed" }],
+						TS,
+					);
 				}),
 			);
 
@@ -283,6 +327,7 @@ describe("HistoryTrackerLive", () => {
 				Effect.gen(function* () {
 					yield* seedHistoryEntries([
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > test",
 							runs: Array.from({ length: 9 }, (_, i) => ({
 								timestamp: `2026-03-${String(10 + i).padStart(2, "0")}T00:00:00.000Z`,
@@ -292,7 +337,11 @@ describe("HistoryTrackerLive", () => {
 					]);
 
 					const tracker = yield* HistoryTracker;
-					return yield* tracker.classify(PROJECT, [{ fullName: "Suite > test", state: "passed" }], TS);
+					return yield* tracker.classify(
+						PROJECT,
+						[{ modulePath: "src/history.test.ts", fullName: "Suite > test", state: "passed" }],
+						TS,
+					);
 				}),
 			);
 
@@ -309,17 +358,22 @@ describe("HistoryTrackerLive", () => {
 				Effect.gen(function* () {
 					yield* seedHistoryEntries([
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > existing test",
 							runs: [{ timestamp: "2026-03-19T00:00:00.000Z", state: "passed" }],
 						},
 					]);
 
 					const tracker = yield* HistoryTracker;
-					return yield* tracker.classify(PROJECT, [{ fullName: "Suite > brand new test", state: "passed" }], TS);
+					return yield* tracker.classify(
+						PROJECT,
+						[{ modulePath: "src/history.test.ts", fullName: "Suite > brand new test", state: "passed" }],
+						TS,
+					);
 				}),
 			);
 
-			expect(result.classifications.get("Suite > brand new test")).toBe("stable");
+			expect(result.classifications.get(historyKey("src/history.test.ts", "Suite > brand new test"))).toBe("stable");
 			const newEntry = result.history.tests.find((t) => t.fullName === "Suite > brand new test");
 			expect(newEntry).toBeDefined();
 			if (!newEntry) return;
@@ -333,10 +387,12 @@ describe("HistoryTrackerLive", () => {
 				Effect.gen(function* () {
 					yield* seedHistoryEntries([
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > test A",
 							runs: [{ timestamp: "2026-03-19T00:00:00.000Z", state: "passed" }],
 						},
 						{
+							modulePath: "src/history.test.ts",
 							fullName: "Suite > test B",
 							runs: [{ timestamp: "2026-03-19T00:00:00.000Z", state: "failed" }],
 						},
@@ -344,7 +400,11 @@ describe("HistoryTrackerLive", () => {
 
 					const tracker = yield* HistoryTracker;
 					// Only test A in current run; test B should stay in history
-					return yield* tracker.classify(PROJECT, [{ fullName: "Suite > test A", state: "passed" }], TS);
+					return yield* tracker.classify(
+						PROJECT,
+						[{ modulePath: "src/history.test.ts", fullName: "Suite > test A", state: "passed" }],
+						TS,
+					);
 				}),
 			);
 
@@ -362,7 +422,7 @@ describe("HistoryTrackerLive", () => {
 
 	describe("history record output", () => {
 		it("returns updated history with correct project and timestamp", async () => {
-			const outcomes = [{ fullName: "test", state: "passed" as const }];
+			const outcomes = [{ modulePath: "src/history.test.ts", fullName: "test", state: "passed" as const }];
 
 			const result = await run(Effect.flatMap(HistoryTracker, (svc) => svc.classify(PROJECT, outcomes, TS)));
 
@@ -371,7 +431,7 @@ describe("HistoryTrackerLive", () => {
 		});
 
 		it("includes the current run in returned history", async () => {
-			const outcomes = [{ fullName: "new test", state: "failed" as const }];
+			const outcomes = [{ modulePath: "src/history.test.ts", fullName: "new test", state: "failed" as const }];
 
 			const result = await run(Effect.flatMap(HistoryTracker, (svc) => svc.classify(PROJECT, outcomes, TS)));
 
@@ -379,6 +439,51 @@ describe("HistoryTrackerLive", () => {
 			expect(entry).toBeDefined();
 			if (!entry) return;
 			expect(entry.runs[0]).toEqual({ timestamp: TS, state: "failed" });
+		});
+	});
+
+	describe("composite (modulePath, fullName) keying", () => {
+		it("keeps two tests with the same fullName in different modulePaths as distinct classification entries", async () => {
+			const result = await run(
+				Effect.gen(function* () {
+					// Prior failing history exists only for module A's copy of this
+					// shared test name -- module B has never been observed.
+					yield* seedHistoryEntries([
+						{
+							modulePath: "src/a.test.ts",
+							fullName: "Suite > shared name",
+							runs: [{ timestamp: "2026-03-19T00:00:00.000Z", state: "failed" }],
+						},
+					]);
+
+					const tracker = yield* HistoryTracker;
+					return yield* tracker.classify(
+						PROJECT,
+						[
+							{ modulePath: "src/a.test.ts", fullName: "Suite > shared name", state: "failed" },
+							{ modulePath: "src/b.test.ts", fullName: "Suite > shared name", state: "failed" },
+						],
+						TS,
+					);
+				}),
+			);
+
+			// Module A's failure is persistent (prior run also failed); module B's
+			// is a new-failure (no prior history for that module_path). If the two
+			// were keyed by fullName alone they would collide onto one entry.
+			expect(result.classifications.get(historyKey("src/a.test.ts", "Suite > shared name"))).toBe("persistent");
+			expect(result.classifications.get(historyKey("src/b.test.ts", "Suite > shared name"))).toBe("new-failure");
+
+			const entryA = result.history.tests.find(
+				(t) => t.modulePath === "src/a.test.ts" && t.fullName === "Suite > shared name",
+			);
+			const entryB = result.history.tests.find(
+				(t) => t.modulePath === "src/b.test.ts" && t.fullName === "Suite > shared name",
+			);
+			expect(entryA).toBeDefined();
+			expect(entryB).toBeDefined();
+			expect(entryA?.runs).toHaveLength(2);
+			expect(entryB?.runs).toHaveLength(1);
 		});
 	});
 });

--- a/packages/sdk/__test__/assemblers.test.ts
+++ b/packages/sdk/__test__/assemblers.test.ts
@@ -15,14 +15,34 @@ describe("assembleManifest", () => {
 });
 
 describe("assembleHistoryRecord", () => {
-	it("groups history rows by full_name", () => {
+	it("groups history rows by the composite (module_path, full_name) key", () => {
 		const rows = [
-			{ full_name: "test A", timestamp: "2026-03-22T00:00:00Z", state: "passed" },
-			{ full_name: "test A", timestamp: "2026-03-21T00:00:00Z", state: "failed" },
-			{ full_name: "test B", timestamp: "2026-03-22T00:00:00Z", state: "passed" },
+			{ module_path: "src/a.test.ts", full_name: "test A", timestamp: "2026-03-22T00:00:00Z", state: "passed" },
+			{ module_path: "src/a.test.ts", full_name: "test A", timestamp: "2026-03-21T00:00:00Z", state: "failed" },
+			{ module_path: "src/a.test.ts", full_name: "test B", timestamp: "2026-03-22T00:00:00Z", state: "passed" },
 		];
 		const record = assembleHistoryRecord(rows);
 		expect(Object.keys(record)).toHaveLength(2);
-		expect(record["test A"].runs).toHaveLength(2);
+		const testA = Object.values(record).find((e) => e.fullName === "test A");
+		expect(testA?.runs).toHaveLength(2);
+		expect(testA?.modulePath).toBe("src/a.test.ts");
+	});
+
+	it("keeps two rows with the same full_name in different module_path values as distinct entries", () => {
+		const rows = [
+			{ module_path: "src/a.test.ts", full_name: "shared name", timestamp: "2026-03-22T00:00:00Z", state: "passed" },
+			{ module_path: "src/b.test.ts", full_name: "shared name", timestamp: "2026-03-22T00:00:00Z", state: "failed" },
+		];
+		const record = assembleHistoryRecord(rows);
+		expect(Object.keys(record)).toHaveLength(2);
+
+		const entryA = Object.values(record).find((e) => e.modulePath === "src/a.test.ts");
+		const entryB = Object.values(record).find((e) => e.modulePath === "src/b.test.ts");
+		expect(entryA?.fullName).toBe("shared name");
+		expect(entryB?.fullName).toBe("shared name");
+		expect(entryA?.runs).toHaveLength(1);
+		expect(entryB?.runs).toHaveLength(1);
+		expect(entryA?.runs[0].state).toBe("passed");
+		expect(entryB?.runs[0].state).toBe("failed");
 	});
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -47,7 +47,7 @@
 		"effect": "catalog:silk",
 		"std-env": "^4.1.0",
 		"workspaces-effect": "^1.2.0",
-		"xdg-effect": "^2.0.1"
+		"xdg-effect": "^2.1.0"
 	},
 	"devDependencies": {
 		"@savvy-web/bundler": "^1.1.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -43,14 +43,14 @@
 		"acorn": "^8.17.0",
 		"acorn-typescript": "^1.4.13",
 		"ajv": "^8.20.0",
-		"config-file-effect": "^0.2.3",
+		"config-file-effect": "^0.3.0",
 		"effect": "catalog:silk",
 		"std-env": "^4.1.0",
-		"workspaces-effect": "^1.2.0",
+		"workspaces-effect": "^1.3.0",
 		"xdg-effect": "^2.1.0"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",

--- a/packages/sdk/src/layers/DataReaderLive.ts
+++ b/packages/sdk/src/layers/DataReaderLive.ts
@@ -35,6 +35,7 @@ import type {
 } from "../services/DataReader.js";
 import { DataReader } from "../services/DataReader.js";
 import type { ArtifactKind, ChangeKind, Phase } from "../services/DataStore.js";
+import { historyKey } from "../services/HistoryTracker.js";
 /** @public */
 export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.effect(
 	DataReader,
@@ -375,7 +376,7 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 				for (const row of rows) {
 					// Only include passed/failed states per HistoryRecord schema
 					if (row.state !== "passed" && row.state !== "failed") continue;
-					const key = `${row.module_path} ${row.full_name}`;
+					const key = historyKey(row.module_path, row.full_name);
 					const existing = testsMap.get(key);
 					if (existing) {
 						existing.runs.push({ timestamp: row.timestamp, state: row.state });

--- a/packages/sdk/src/layers/DataReaderLive.ts
+++ b/packages/sdk/src/layers/DataReaderLive.ts
@@ -357,28 +357,39 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 			Effect.gen(function* () {
 				yield* Effect.logDebug("getHistory").pipe(Effect.annotateLogs({ project }));
 				const rows = yield* sql<{
+					module_path: string;
 					full_name: string;
 					timestamp: string;
 					state: string;
-				}>`SELECT full_name, timestamp, state
+				}>`SELECT module_path, full_name, timestamp, state
 					FROM test_history
 					WHERE project = ${project}
-					ORDER BY full_name, timestamp DESC`;
+					ORDER BY module_path, full_name, timestamp DESC`;
 
-				// Group by full_name
-				const testsMap = new Map<string, Array<{ timestamp: string; state: "passed" | "failed" }>>();
+				// Group by the composite (module_path, full_name) key so identically
+				// named tests in different files are tracked as distinct series.
+				const testsMap = new Map<
+					string,
+					{ modulePath: string; fullName: string; runs: Array<{ timestamp: string; state: "passed" | "failed" }> }
+				>();
 				for (const row of rows) {
 					// Only include passed/failed states per HistoryRecord schema
 					if (row.state !== "passed" && row.state !== "failed") continue;
-					const existing = testsMap.get(row.full_name);
+					const key = `${row.module_path} ${row.full_name}`;
+					const existing = testsMap.get(key);
 					if (existing) {
-						existing.push({ timestamp: row.timestamp, state: row.state });
+						existing.runs.push({ timestamp: row.timestamp, state: row.state });
 					} else {
-						testsMap.set(row.full_name, [{ timestamp: row.timestamp, state: row.state }]);
+						testsMap.set(key, {
+							modulePath: row.module_path,
+							fullName: row.full_name,
+							runs: [{ timestamp: row.timestamp, state: row.state }],
+						});
 					}
 				}
 
-				const tests = Array.from(testsMap.entries()).map(([fullName, runs]) => ({
+				const tests = Array.from(testsMap.values()).map(({ modulePath, fullName, runs }) => ({
+					modulePath,
 					fullName,
 					runs,
 				}));
@@ -512,6 +523,7 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 				yield* Effect.logDebug("getFlaky").pipe(Effect.annotateLogs({ project }));
 				const rows = yield* sql<{
 					full_name: string;
+					module_path: string;
 					project: string;
 					pass_count: number;
 					fail_count: number;
@@ -519,29 +531,33 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 					last_timestamp: string;
 				}>`SELECT
 						th1.full_name,
+						th1.module_path,
 						th1.project,
 						SUM(CASE WHEN th1.state = 'passed' THEN 1 ELSE 0 END) as pass_count,
 						SUM(CASE WHEN th1.state = 'failed' THEN 1 ELSE 0 END) as fail_count,
 						(SELECT state FROM test_history th2
 						 WHERE th2.full_name = th1.full_name
+						   AND th2.module_path = th1.module_path
 						   AND th2.project = th1.project
 						 ORDER BY timestamp DESC LIMIT 1) as last_state,
 						MAX(th1.timestamp) as last_timestamp
 					FROM test_history th1
 					WHERE th1.project = ${project}
-					GROUP BY th1.full_name, th1.project
+					GROUP BY th1.full_name, th1.module_path, th1.project
 					-- Flaky means oscillation, not a clean recovery. A test with both
 						-- passes and fails is only flaky when at least one failure occurs at
 						-- or after the earliest pass (a fail-after-pass regression). A
 						-- monotonic red->green cycle — every failure precedes every pass — is
 						-- a recovery, not flakiness, so it is excluded here. ISO-8601
-						-- timestamps compare lexicographically.
+						-- timestamps compare lexicographically. Grouping keys on module_path
+						-- so same-named tests in different files stay distinct series.
 						HAVING pass_count > 0 AND fail_count > 0
 							AND MAX(CASE WHEN th1.state = 'failed' THEN th1.timestamp END)
 								>= MIN(CASE WHEN th1.state = 'passed' THEN th1.timestamp END)`;
 
 				return rows.map((r) => ({
 					fullName: r.full_name,
+					modulePath: r.module_path,
 					project: r.project,
 					passCount: r.pass_count,
 					failCount: r.fail_count,
@@ -562,44 +578,47 @@ export const DataReaderLive: Layer.Layer<DataReader, never, SqlClient> = Layer.e
 				// trailing failures (replaces previous N+1 pattern)
 				const rows = yield* sql<{
 					full_name: string;
+					module_path: string;
 					project: string;
 					consecutive_failures: number;
 					first_failed_at: string;
 					last_failed_at: string;
 					last_error_message: string | null;
 				}>`WITH ranked AS (
-					SELECT full_name, project, state, timestamp, error_message,
+					SELECT full_name, module_path, project, state, timestamp, error_message,
 						ROW_NUMBER() OVER (
-							PARTITION BY project, full_name
+							PARTITION BY project, module_path, full_name
 							ORDER BY timestamp DESC
 						) as rn
 					FROM test_history
 					WHERE project = ${project}
 				),
 				streak AS (
-					SELECT full_name, project, state, timestamp, error_message, rn,
+					SELECT full_name, module_path, project, state, timestamp, error_message, rn,
 						MIN(CASE WHEN state != 'failed' THEN rn END) OVER (
-							PARTITION BY project, full_name
+							PARTITION BY project, module_path, full_name
 						) as first_pass_rn
 					FROM ranked
 				)
 				SELECT
-					full_name, project,
+					full_name, module_path, project,
 					COUNT(*) as consecutive_failures,
 					MIN(timestamp) as first_failed_at,
 					MAX(timestamp) as last_failed_at,
 					(SELECT error_message FROM streak s2
 					 WHERE s2.full_name = streak.full_name
+					   AND s2.module_path = streak.module_path
 					   AND s2.project = streak.project
 					   AND s2.rn = 1) as last_error_message
 				FROM streak
 				WHERE state = 'failed'
 					AND (first_pass_rn IS NULL OR rn < first_pass_rn)
-				GROUP BY full_name, project
+				GROUP BY full_name, module_path, project
 				HAVING consecutive_failures >= 2`;
 
 				return rows.map((row) => ({
 					fullName: row.full_name,
+					modulePath: row.module_path,
 					project: row.project,
 					consecutiveFailures: row.consecutive_failures,
 					firstFailedAt: row.first_failed_at,

--- a/packages/sdk/src/layers/DataStoreLive.ts
+++ b/packages/sdk/src/layers/DataStoreLive.ts
@@ -277,6 +277,7 @@ export const DataStoreLive: Layer.Layer<DataStore, never, SqlClient> = Layer.eff
 		const writeHistory = (
 			project: string,
 			fullName: string,
+			modulePath: string,
 			runId: number,
 			timestamp: string,
 			state: string,
@@ -286,11 +287,11 @@ export const DataStoreLive: Layer.Layer<DataStore, never, SqlClient> = Layer.eff
 			errorMessage: string | null,
 		): Effect.Effect<void, DataStoreError> =>
 			Effect.gen(function* () {
-				yield* Effect.logDebug("writeHistory").pipe(Effect.annotateLogs({ project, runId }));
-				yield* sql`INSERT INTO test_history (run_id, project, full_name, timestamp, state, duration, flaky, retry_count, error_message) VALUES (${runId}, ${project}, ${fullName}, ${timestamp}, ${state}, ${duration}, ${flaky ? 1 : 0}, ${retryCount}, ${errorMessage})`;
+				yield* Effect.logDebug("writeHistory").pipe(Effect.annotateLogs({ project, modulePath, runId }));
+				yield* sql`INSERT INTO test_history (run_id, project, module_path, full_name, timestamp, state, duration, flaky, retry_count, error_message) VALUES (${runId}, ${project}, ${modulePath}, ${fullName}, ${timestamp}, ${state}, ${duration}, ${flaky ? 1 : 0}, ${retryCount}, ${errorMessage})`;
 
-				// Delete oldest entries beyond 10-entry window per (project, fullName)
-				yield* sql`DELETE FROM test_history WHERE id NOT IN (SELECT id FROM test_history WHERE project = ${project} AND full_name = ${fullName} ORDER BY timestamp DESC LIMIT 10) AND project = ${project} AND full_name = ${fullName}`;
+				// Delete oldest entries beyond 10-entry window per (project, module_path, fullName)
+				yield* sql`DELETE FROM test_history WHERE id NOT IN (SELECT id FROM test_history WHERE project = ${project} AND module_path = ${modulePath} AND full_name = ${fullName} ORDER BY timestamp DESC LIMIT 10) AND project = ${project} AND module_path = ${modulePath} AND full_name = ${fullName}`;
 			}).pipe(
 				Effect.annotateLogs("service", "DataStore"),
 				Effect.mapError(

--- a/packages/sdk/src/layers/HistoryTrackerLive.ts
+++ b/packages/sdk/src/layers/HistoryTrackerLive.ts
@@ -2,10 +2,11 @@ import { Effect, Layer } from "effect";
 import type { TestClassification } from "../schemas/Common.js";
 import type { TestRun } from "../schemas/History.js";
 import { DataReader } from "../services/DataReader.js";
-import { HistoryTracker } from "../services/HistoryTracker.js";
+import { HistoryTracker, historyKey } from "../services/HistoryTracker.js";
 import { classifyTest } from "../utils/classify-test.js";
 
 interface MutableTestHistory {
+	modulePath: string;
 	fullName: string;
 	runs: Array<TestRun>;
 }
@@ -22,22 +23,23 @@ export const HistoryTrackerLive: Layer.Layer<HistoryTracker, never, DataReader> 
 					const existing = yield* reader.getHistory(project);
 					const testMap = new Map<string, MutableTestHistory>();
 					for (const entry of existing.tests) {
-						testMap.set(entry.fullName, { ...entry, runs: [...entry.runs] });
+						testMap.set(historyKey(entry.modulePath, entry.fullName), { ...entry, runs: [...entry.runs] });
 					}
 
 					const classifications = new Map<string, TestClassification>();
 
 					for (const outcome of testOutcomes) {
-						let entry = testMap.get(outcome.fullName);
+						const key = historyKey(outcome.modulePath, outcome.fullName);
+						let entry = testMap.get(key);
 						if (!entry) {
-							entry = { fullName: outcome.fullName, runs: [] };
-							testMap.set(outcome.fullName, entry);
+							entry = { modulePath: outcome.modulePath, fullName: outcome.fullName, runs: [] };
+							testMap.set(key, entry);
 						}
 
 						const priorRuns = entry.runs;
 						entry.runs = [{ timestamp, state: outcome.state }, ...priorRuns].slice(0, WINDOW_SIZE);
 
-						classifications.set(outcome.fullName, classifyTest(outcome.state, priorRuns));
+						classifications.set(key, classifyTest(outcome.state, priorRuns));
 					}
 
 					return {

--- a/packages/sdk/src/migrations/0001_initial.ts
+++ b/packages/sdk/src/migrations/0001_initial.ts
@@ -379,6 +379,7 @@ const migration = Effect.gen(function* () {
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			run_id INTEGER NOT NULL REFERENCES test_runs(id) ON DELETE CASCADE,
 			project TEXT NOT NULL,
+			module_path TEXT NOT NULL,
 			full_name TEXT NOT NULL,
 			timestamp TEXT NOT NULL,
 			state TEXT NOT NULL CHECK (state IN ('passed', 'failed', 'skipped', 'pending')),
@@ -386,10 +387,10 @@ const migration = Effect.gen(function* () {
 			flaky INTEGER CHECK (flaky IN (0, 1)),
 			retry_count INTEGER DEFAULT 0,
 			error_message TEXT,
-			UNIQUE(project, full_name, timestamp)
+			UNIQUE(project, module_path, full_name, timestamp)
 		)
 	`;
-	yield* sql`CREATE INDEX idx_test_history_lookup ON test_history(project, full_name)`;
+	yield* sql`CREATE INDEX idx_test_history_lookup ON test_history(project, module_path, full_name)`;
 	yield* sql`CREATE INDEX idx_test_history_full_name ON test_history(full_name, timestamp)`;
 	yield* sql`CREATE INDEX idx_test_history_run ON test_history(run_id)`;
 

--- a/packages/sdk/src/schemas/History.ts
+++ b/packages/sdk/src/schemas/History.ts
@@ -16,6 +16,7 @@ export type TestRun = typeof TestRun.Type;
  * @public
  */
 export const TestHistory = Schema.Struct({
+	modulePath: Schema.String,
 	fullName: Schema.String,
 	runs: Schema.Array(TestRun),
 }).annotations({ identifier: "TestHistory" });

--- a/packages/sdk/src/services/DataReader.ts
+++ b/packages/sdk/src/services/DataReader.ts
@@ -24,6 +24,7 @@ export interface ProjectRunSummary {
 /** @public */
 export interface FlakyTest {
 	readonly fullName: string;
+	readonly modulePath: string;
 	readonly project: string;
 	readonly passCount: number;
 	readonly failCount: number;
@@ -33,6 +34,7 @@ export interface FlakyTest {
 /** @public */
 export interface PersistentFailure {
 	readonly fullName: string;
+	readonly modulePath: string;
 	readonly project: string;
 	readonly consecutiveFailures: number;
 	readonly firstFailedAt: string;

--- a/packages/sdk/src/services/DataStore.ts
+++ b/packages/sdk/src/services/DataStore.ts
@@ -414,6 +414,7 @@ export class DataStore extends Context.Tag("vitest-agent/DataStore")<
 		readonly writeHistory: (
 			project: string,
 			fullName: string,
+			modulePath: string,
 			runId: number,
 			timestamp: string,
 			state: string,

--- a/packages/sdk/src/services/HistoryTracker.ts
+++ b/packages/sdk/src/services/HistoryTracker.ts
@@ -9,9 +9,18 @@ import type { HistoryRecord } from "../schemas/History.js";
  * @public
  */
 export interface TestOutcome {
+	readonly modulePath: string;
 	readonly fullName: string;
 	readonly state: "passed" | "failed";
 }
+
+/**
+ * Builds the composite (modulePath, fullName) key used to key the internal
+ * testMap and the returned classifications Map, so identically-named tests
+ * in different files classify independently instead of colliding.
+ * @public
+ */
+export const historyKey = (modulePath: string, fullName: string): string => `${modulePath} ${fullName}`;
 /** @public */
 export class HistoryTracker extends Context.Tag("vitest-agent/HistoryTracker")<
 	HistoryTracker,

--- a/packages/sdk/src/services/HistoryTracker.ts
+++ b/packages/sdk/src/services/HistoryTracker.ts
@@ -18,9 +18,14 @@ export interface TestOutcome {
  * Builds the composite (modulePath, fullName) key used to key the internal
  * testMap and the returned classifications Map, so identically-named tests
  * in different files classify independently instead of colliding.
+ *
+ * Uses `JSON.stringify` for an injective encoding: a plain delimiter such as
+ * a space is not collision-proof (e.g. `("a b", "c")` and `("a", "b c")` would
+ * both yield `"a b c"`), which would reintroduce the very collision class this
+ * key exists to prevent.
  * @public
  */
-export const historyKey = (modulePath: string, fullName: string): string => `${modulePath} ${fullName}`;
+export const historyKey = (modulePath: string, fullName: string): string => JSON.stringify([modulePath, fullName]);
 /** @public */
 export class HistoryTracker extends Context.Tag("vitest-agent/HistoryTracker")<
 	HistoryTracker,

--- a/packages/sdk/src/sql/assemblers.ts
+++ b/packages/sdk/src/sql/assemblers.ts
@@ -1,5 +1,6 @@
 import type { CacheManifest, CacheManifestEntry } from "../schemas/CacheManifest.js";
 import type { TestRun } from "../schemas/History.js";
+import { historyKey } from "../services/HistoryTracker.js";
 
 // ---------------------------------------------------------------------------
 // Input row types (minimal -- only the fields each assembler needs)
@@ -33,7 +34,7 @@ export interface HistoryRow {
 
 /**
  * A `Record<compositeKey, { modulePath, fullName, runs: TestRun[] }>` keyed by
- * the composite `${modulePath} ${fullName}` string, so identically-named
+ * the injective `historyKey(modulePath, fullName)` string, so identically-named
  * tests in different files are tracked as distinct entries.
  *
  * This is the internal representation returned by `assembleHistoryRecord`.
@@ -118,7 +119,7 @@ export function assembleHistoryRecord(rows: HistoryRow[]): AssembledHistoryRecor
 		const state = row.state === "passed" || row.state === "failed" ? row.state : null;
 		if (state === null) continue;
 
-		const key = `${row.module_path} ${row.full_name}`;
+		const key = historyKey(row.module_path, row.full_name);
 		if (!record[key]) {
 			record[key] = { modulePath: row.module_path, fullName: row.full_name, runs: [] };
 		}

--- a/packages/sdk/src/sql/assemblers.ts
+++ b/packages/sdk/src/sql/assemblers.ts
@@ -21,6 +21,7 @@ export interface ManifestRow {
  * @public
  */
 export interface HistoryRow {
+	module_path: string;
 	full_name: string;
 	timestamp: string;
 	state: string;
@@ -31,7 +32,9 @@ export interface HistoryRow {
 // ---------------------------------------------------------------------------
 
 /**
- * A `Record<fullName, { runs: TestRun[] }>` keyed by test full name.
+ * A `Record<compositeKey, { modulePath, fullName, runs: TestRun[] }>` keyed by
+ * the composite `${modulePath} ${fullName}` string, so identically-named
+ * tests in different files are tracked as distinct entries.
  *
  * This is the internal representation returned by `assembleHistoryRecord`.
  * Callers that need the Effect Schema `HistoryRecord` type should adapt this
@@ -39,7 +42,7 @@ export interface HistoryRow {
  * @public
  */
 export interface AssembledHistoryRecord {
-	[fullName: string]: { runs: TestRun[] };
+	[compositeKey: string]: { modulePath: string; fullName: string; runs: TestRun[] };
 }
 
 // ---------------------------------------------------------------------------
@@ -96,10 +99,13 @@ export function assembleManifest(rows: ManifestRow[], dbPath: string): CacheMani
 // ---------------------------------------------------------------------------
 
 /**
- * Groups test_history rows by `full_name` into a keyed record.
+ * Groups test_history rows by the composite (module_path, full_name) key
+ * into a keyed record.
  *
- * Returns `Record<fullName, { runs: TestRun[] }>` where `runs` are the
- * accumulated test runs for that test, in the order they appear in `rows`.
+ * Returns `Record<compositeKey, { modulePath, fullName, runs: TestRun[] }>`
+ * where `runs` are the accumulated test runs for that test, in the order
+ * they appear in `rows`. Two rows sharing `full_name` but differing
+ * `module_path` are tracked as distinct entries rather than merged.
  *
  * Only rows with state `"passed"` or `"failed"` are included in runs
  * (matching the `TestRun` schema constraint).
@@ -112,11 +118,12 @@ export function assembleHistoryRecord(rows: HistoryRow[]): AssembledHistoryRecor
 		const state = row.state === "passed" || row.state === "failed" ? row.state : null;
 		if (state === null) continue;
 
-		if (!record[row.full_name]) {
-			record[row.full_name] = { runs: [] };
+		const key = `${row.module_path} ${row.full_name}`;
+		if (!record[key]) {
+			record[key] = { modulePath: row.module_path, fullName: row.full_name, runs: [] };
 		}
 
-		(record[row.full_name] as { runs: TestRun[] }).runs.push({
+		record[key].runs.push({
 			timestamp: row.timestamp,
 			state,
 		});

--- a/packages/sdk/src/sql/rows.ts
+++ b/packages/sdk/src/sql/rows.ts
@@ -147,6 +147,7 @@ export const TestHistoryRow = Schema.Struct({
 	id: Schema.Number,
 	run_id: Schema.Number,
 	project: Schema.String,
+	module_path: Schema.String,
 	full_name: Schema.String,
 	timestamp: Schema.String,
 	state: Schema.String,

--- a/packages/sdk/src/testing/index.ts
+++ b/packages/sdk/src/testing/index.ts
@@ -271,6 +271,7 @@ export function flaky(filename: string) {
 		yield* store.writeHistory(
 			"default",
 			"async > resolves within timeout",
+			"src/async.test.ts",
 			runId1,
 			"2025-12-31T23:00:00.000Z",
 			"passed",
@@ -282,6 +283,7 @@ export function flaky(filename: string) {
 		yield* store.writeHistory(
 			"default",
 			"async > resolves within timeout",
+			"src/async.test.ts",
 			runId1,
 			"2026-01-01T00:00:00.000Z",
 			"failed",
@@ -293,6 +295,7 @@ export function flaky(filename: string) {
 		yield* store.writeHistory(
 			"default",
 			"async > rejects on error",
+			"src/async.test.ts",
 			runId1,
 			"2026-01-01T00:00:00.000Z",
 			"passed",
@@ -341,6 +344,7 @@ export function flaky(filename: string) {
 		yield* store.writeHistory(
 			"default",
 			"async > resolves within timeout",
+			"src/async.test.ts",
 			runId2,
 			"2026-01-01T01:00:00.000Z",
 			"passed",
@@ -352,6 +356,7 @@ export function flaky(filename: string) {
 		yield* store.writeHistory(
 			"default",
 			"async > rejects on error",
+			"src/async.test.ts",
 			runId2,
 			"2026-01-01T01:00:00.000Z",
 			"passed",

--- a/packages/sidecar-darwin-arm64/package.json
+++ b/packages/sidecar-darwin-arm64/package.json
@@ -26,7 +26,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",

--- a/packages/sidecar-linux-arm64/package.json
+++ b/packages/sidecar-linux-arm64/package.json
@@ -26,7 +26,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",

--- a/packages/sidecar-linux-x64/package.json
+++ b/packages/sidecar-linux-x64/package.json
@@ -26,7 +26,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",

--- a/packages/sidecar-win32-x64/package.json
+++ b/packages/sidecar-win32-x64/package.json
@@ -26,7 +26,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest-agent/sdk": "workspace:*",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -31,7 +31,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "catalog:silk",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,7 @@
 		"effect": "catalog:silk"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/node": "catalog:silk",
 		"@types/react": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",

--- a/playground/package.json
+++ b/playground/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"devDependencies": {
-		"@savvy-web/bundler": "^1.1.0",
+		"@savvy-web/bundler": "^1.1.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"typescript": "catalog:silk",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,8 +426,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       xdg-effect:
-        specifier: ^2.0.1
-        version: 2.0.1(4b99e7aa355a094dc1986218f72d3bb6)
+        specifier: ^2.1.0
+        version: 2.1.0(ebbd840a9936fee4732a1f63bb937b99)
     devDependencies:
       '@savvy-web/bundler':
         specifier: ^1.1.0
@@ -644,7 +644,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       rspress-plugin-api-extractor:
         specifier: ^0.3.4
-        version: 0.3.4(0b02decd7456a4081d21d29f5cce3857)
+        version: 0.3.4(d1b0a3604daa2e3f99fd40747ad1d3be)
       rspress-plugin-mermaid:
         specifier: ^1.0.1
         version: 1.0.1(@rspress/core@2.0.15(@rspack/core@2.1.2(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2))
@@ -2364,6 +2364,17 @@ packages:
       '@effect/platform-node':
         optional: true
 
+  config-file-effect@0.3.0:
+    resolution: {integrity: sha512-Uwv6SqbeaV61glVsBQ4F4LkiIGptieTucWirfLAX/GGYvs8TbXxiBI/gRvpG/6KopuM5Zwno+2Xiog7MysUAgg==}
+    engines: {node: '>=24.11.0'}
+    peerDependencies:
+      '@effect/platform': ^0.96.0
+      '@effect/platform-node': ^0.107.0
+      effect: ^3.21.0
+    peerDependenciesMeta:
+      '@effect/platform-node':
+        optional: true
+
   consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
 
@@ -2733,8 +2744,8 @@ packages:
   effect@3.21.4:
     resolution: {integrity: sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==}
 
-  electron-to-chromium@1.5.382:
-    resolution: {integrity: sha512-8ETaWbV6SZOrno+G93Ffd9ENsMtetqdnqj4nlfxFW90Sm5GgnuV28Kf62hqQVD6VUgzm7qFQKsTsAPmeUiU3Ug==}
+  electron-to-chromium@1.5.383:
+    resolution: {integrity: sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==}
 
   elkjs@0.9.3:
     resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
@@ -3516,6 +3527,17 @@ packages:
       '@effect/platform': '>=0.96.0'
       '@effect/platform-node': '>=0.107.0'
       effect: '>=3.21.0'
+    peerDependenciesMeta:
+      '@effect/platform-node':
+        optional: true
+
+  json-schema-effect@0.3.0:
+    resolution: {integrity: sha512-Qwd/A5n9gjQKFByCJf7mPQKNbU/Rkd9nORdvWZ9tFlT+xh2dHqtUJ/Qe/aSDPq0R4mx8h4pgXmvlMyWyayVd+w==}
+    engines: {node: '>=24.11.0'}
+    peerDependencies:
+      '@effect/platform': ^0.96.0
+      '@effect/platform-node': ^0.107.0
+      effect: ^3.21.0
     peerDependenciesMeta:
       '@effect/platform-node':
         optional: true
@@ -5353,24 +5375,21 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
-  xdg-effect@2.0.1:
-    resolution: {integrity: sha512-Hht3HThHBsXwR/WU1xxPDZ65BBsYNYGIAJ3+RmTmkz4CVS9QdmZxtHd9NiJM1IYb4CuYxiuiIQNsvXD5th4f5Q==}
+  xdg-effect@2.1.0:
+    resolution: {integrity: sha512-7qG1kRbYftwhQdnMxXHFE4NwoKg4xIeBLARqhVVnp2n5uhlDO0tVKGj5CflGw1BB9ZzjTDJB6ypwBZQtek4V5A==}
     engines: {node: '>=24.11.0'}
     peerDependencies:
-      '@effect/platform': '>=0.96.0'
-      '@effect/platform-node': '>=0.107.0'
-      '@effect/sql': '>=0.51.0'
-      '@effect/sql-sqlite-node': '>=0.52.0'
-      ajv: ^8.20.0
-      effect: '>=3.21.0'
+      '@effect/platform': ^0.96.0
+      '@effect/platform-node': ^0.107.0
+      '@effect/sql': ^0.51.0
+      '@effect/sql-sqlite-node': ^0.52.0
+      effect: ^3.21.0
     peerDependenciesMeta:
       '@effect/platform-node':
         optional: true
       '@effect/sql':
         optional: true
       '@effect/sql-sqlite-node':
-        optional: true
-      ajv:
         optional: true
 
   y18n@5.0.8:
@@ -7163,7 +7182,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001800
-      electron-to-chromium: 1.5.382
+      electron-to-chromium: 1.5.383
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
@@ -7325,6 +7344,14 @@ snapshots:
   compute-scroll-into-view@3.1.1: {}
 
   config-file-effect@0.2.3(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4):
+    dependencies:
+      '@effect/platform': 0.96.2(effect@3.21.4)
+      effect: 3.21.4
+      smol-toml: 1.7.0
+    optionalDependencies:
+      '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+
+  config-file-effect@0.3.0(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4):
     dependencies:
       '@effect/platform': 0.96.2(effect@3.21.4)
       effect: 3.21.4
@@ -7714,7 +7741,7 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  electron-to-chromium@1.5.382: {}
+  electron-to-chromium@1.5.383: {}
 
   elkjs@0.9.3: {}
 
@@ -8596,6 +8623,14 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-effect@0.2.4(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4):
+    dependencies:
+      '@effect/platform': 0.96.2(effect@3.21.4)
+      ajv: 8.20.0
+      effect: 3.21.4
+    optionalDependencies:
+      '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+
+  json-schema-effect@0.3.0(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4):
     dependencies:
       '@effect/platform': 0.96.2(effect@3.21.4)
       ajv: 8.20.0
@@ -10132,7 +10167,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rspress-plugin-api-extractor@0.3.4(0b02decd7456a4081d21d29f5cce3857):
+  rspress-plugin-api-extractor@0.3.4(d1b0a3604daa2e3f99fd40747ad1d3be):
     dependencies:
       '@effect/platform': 0.96.2(effect@3.21.4)
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -10156,7 +10191,7 @@ snapshots:
       react-markdown: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       semver-effect: 0.2.1(effect@3.21.4)
       shiki: 4.3.0
-      type-registry-effect: 1.0.0(84c3ad6b0fce19f3e4c842b196f23b5c)
+      type-registry-effect: 1.0.0(bedc38fdc91c0970fc9718bb97a99cb9)
       typescript: 6.0.3
       unist-util-visit: 5.1.0
     transitivePeerDependencies:
@@ -10167,7 +10202,6 @@ snapshots:
       - '@types/react'
       - '@typescript/native-preview'
       - '@typescript/vfs'
-      - ajv
       - bufferutil
       - supports-color
       - utf-8-validate
@@ -10639,21 +10673,20 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  type-registry-effect@1.0.0(84c3ad6b0fce19f3e4c842b196f23b5c):
+  type-registry-effect@1.0.0(bedc38fdc91c0970fc9718bb97a99cb9):
     dependencies:
       '@effect/platform': 0.96.2(effect@3.21.4)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
       semver-effect: 0.2.1(effect@3.21.4)
-      xdg-effect: 2.0.1(25b9704aa4d79592a73797150f6a19d5)
+      xdg-effect: 2.1.0(ebbd840a9936fee4732a1f63bb937b99)
     optionalDependencies:
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@typescript/vfs': 1.6.4(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@effect/experimental'
-      - ajv
 
   typescript@5.9.3: {}
 
@@ -10950,29 +10983,16 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  xdg-effect@2.0.1(25b9704aa4d79592a73797150f6a19d5):
+  xdg-effect@2.1.0(ebbd840a9936fee4732a1f63bb937b99):
     dependencies:
       '@effect/platform': 0.96.2(effect@3.21.4)
-      config-file-effect: 0.2.3(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      config-file-effect: 0.3.0(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
-      json-schema-effect: 0.2.4(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      json-schema-effect: 0.3.0(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
     optionalDependencies:
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
-      ajv: 8.18.0
-
-  xdg-effect@2.0.1(4b99e7aa355a094dc1986218f72d3bb6):
-    dependencies:
-      '@effect/platform': 0.96.2(effect@3.21.4)
-      config-file-effect: 0.2.3(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
-      effect: 3.21.4
-      json-schema-effect: 0.2.4(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
-    optionalDependencies:
-      '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
-      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
-      '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
-      ajv: 8.20.0
 
   y18n@5.0.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
   .:
     devDependencies:
       '@savvy-web/silk':
-        specifier: ^1.3.6
-        version: 1.3.6(a60760d85d0f04002b6fe284b1c7d7af)
+        specifier: ^1.3.7
+        version: 1.3.7(5e32bfc918828ce478a89eafefed0cb6)
       '@vitest-agent/cli':
         specifier: workspace:*
         version: link:packages/cli/dist/dev/pkg
@@ -152,8 +152,8 @@ importers:
         version: 3.21.4
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/node':
         specifier: catalog:silk
         version: 26.0.1
@@ -208,8 +208,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/node':
         specifier: catalog:silk
         version: 26.0.1
@@ -272,12 +272,12 @@ importers:
         specifier: ^0.30.21
         version: 0.30.21
       workspaces-effect:
-        specifier: ^1.2.0
-        version: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+        specifier: ^1.3.0
+        version: 1.3.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -347,8 +347,8 @@ importers:
         version: 19.2.7
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -414,8 +414,8 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
       config-file-effect:
-        specifier: ^0.2.3
-        version: 0.2.3(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+        specifier: ^0.3.0
+        version: 0.3.0(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       effect:
         specifier: catalog:silk
         version: 3.21.4
@@ -423,15 +423,15 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       workspaces-effect:
-        specifier: ^1.2.0
-        version: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+        specifier: ^1.3.0
+        version: 1.3.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       xdg-effect:
         specifier: ^2.1.0
         version: 2.1.0(ebbd840a9936fee4732a1f63bb937b99)
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/node':
         specifier: catalog:silk
         version: 26.0.1
@@ -452,8 +452,8 @@ importers:
   packages/sidecar:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/node':
         specifier: catalog:silk
         version: 26.0.1
@@ -487,8 +487,8 @@ importers:
   packages/sidecar-darwin-arm64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/node':
         specifier: catalog:silk
         version: 26.0.1
@@ -506,8 +506,8 @@ importers:
   packages/sidecar-linux-arm64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/node':
         specifier: catalog:silk
         version: 26.0.1
@@ -525,8 +525,8 @@ importers:
   packages/sidecar-linux-x64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/node':
         specifier: catalog:silk
         version: 26.0.1
@@ -544,8 +544,8 @@ importers:
   packages/sidecar-win32-x64:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/node':
         specifier: catalog:silk
         version: 26.0.1
@@ -570,8 +570,8 @@ importers:
         version: 3.21.4
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/node':
         specifier: catalog:silk
         version: 26.0.1
@@ -601,8 +601,8 @@ importers:
   playground:
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^1.1.0
-        version: 1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)
+        specifier: ^1.1.1
+        version: 1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)
       '@types/node':
         specifier: catalog:silk
         version: 26.0.1
@@ -1649,8 +1649,8 @@ packages:
   '@rushstack/ts-command-line@5.3.10':
     resolution: {integrity: sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==}
 
-  '@savvy-web/bundler@1.1.0':
-    resolution: {integrity: sha512-QZFXML/X2MCP7RRBKyu8NDpOXYtAV2oJk15DciWv3yQkWEbqhKLL2m5YaOzHMuotksyAEiM1vz3GmDv/em29Xg==}
+  '@savvy-web/bundler@1.1.1':
+    resolution: {integrity: sha512-X9MstbGL71yFcEE4DpbF19c06Nqh0xTJ0nO5RuJuvCg0XfLhMYhsgqyOl/2u9lE/pzPVXRCUP0LhRuyRb9IDvw==}
     peerDependencies:
       '@types/node': ^26.0.0
       '@types/react': ^19.2.0
@@ -1669,29 +1669,29 @@ packages:
       react-dom:
         optional: true
 
-  '@savvy-web/cli@1.3.5':
-    resolution: {integrity: sha512-3npVx0yJblD6OU8HwOQfEvQUV3hfShLOcrRwjm2geS8NEn1+teHKDXvHfuhDqklH1PVfBr1y+Go8p8VSKx5Xaw==}
+  '@savvy-web/cli@1.3.6':
+    resolution: {integrity: sha512-H/pWTZWAs4fnXsWteUnHRRwGfArxxfOahCKKsLLJaPza1g5KWC5cSXrTAntVHPKZJ6baNJasUovtna0FNbiR+Q==}
     hasBin: true
 
-  '@savvy-web/mcp@1.4.0':
-    resolution: {integrity: sha512-/a7UzpyU5JuqHcFJDV9p0gtDuu0uSXrJc6fEAc11IZctXUz4HoqdnHuYxlTw8CFlPzqzQ8+r2ZEd4qKlF69qgA==}
+  '@savvy-web/mcp@1.5.0':
+    resolution: {integrity: sha512-AIBC8lOcW0a7yv5XSi6/UppQsEFNuXy+R9Qw4Asqjl2NJ2eOWxKSCZ6CJrBoGW40m5+FXmERSPqLyrsFZ0+biw==}
     hasBin: true
 
-  '@savvy-web/silk-effects@1.5.2':
-    resolution: {integrity: sha512-0PSBEfdfI84YlK+H2urVnw/4AjAU0dodBZ056EzMSiF3DE0vMRlemHifakKSip5Wm6/r1FB4mSBTsv/0b0kTAw==}
+  '@savvy-web/silk-effects@1.6.0':
+    resolution: {integrity: sha512-GuWO6mYKPTxoFf764ZM3He8MgfCramXZDWXSn8kYaG+p//vdOLsX8p74vdAFU3Vo1em5+93bMZP4X17GAlW+uQ==}
     peerDependencies:
       '@effect/platform': ^0.96.0
       effect: ^3.21.0
 
-  '@savvy-web/silk@1.3.6':
-    resolution: {integrity: sha512-VC2jgN0YgAbnblcvMR4fUNucPu2IZM83gSzJSHZ5guLaaZ+WOgbAVBJrNFospEC2cZm7FLf0cBQNxtJu1EYGaQ==}
+  '@savvy-web/silk@1.3.7':
+    resolution: {integrity: sha512-sDoMIRbAbZdfjCgN104ThuDtlvim1QHbObIe9W29x6bTm4webrUKcEbfY6badS4xyVu8Id3fbcNmGFo13ul2WA==}
     peerDependencies:
       '@biomejs/biome': ~2.5.0
       '@changesets/cli': ^2.31.0
       '@commitlint/cli': ^21.1.0
       '@commitlint/config-conventional': ^21.1.0
-      '@savvy-web/cli': 1.3.5
-      '@savvy-web/mcp': 1.4.0
+      '@savvy-web/cli': 1.3.6
+      '@savvy-web/mcp': 1.5.0
       '@types/node': ^26.0.0
       '@typescript/native-preview': ^7.0.0-dev.20260612.1
       commitizen: ^4.3.0
@@ -1705,8 +1705,8 @@ packages:
       '@biomejs/biome':
         optional: true
 
-  '@savvy-web/tsdown-plugins@1.1.0':
-    resolution: {integrity: sha512-oLdbUgzb5pCU2BDn4zvDQQRtz9+uEEepkCSwmNHezsHkdFWGTIj2retuBz9Epp5OUbCnvZqUkv4iBY2KnNqYHA==}
+  '@savvy-web/tsdown-plugins@1.1.1':
+    resolution: {integrity: sha512-HYMFqOLKov0U9TWXJEzWFsyd/m7J7IY0irUUTHK1izNjqyUGWvLHQWlu/T+tsUdm6QRi0vPnBbyMpVwJ6KD9cg==}
     peerDependencies:
       effect: ^3.21.0
 
@@ -2352,17 +2352,6 @@ packages:
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
-
-  config-file-effect@0.2.3:
-    resolution: {integrity: sha512-C2ra/HWV0y+8VrXhquY2zkYYgJryyQf/wCBbp6oddePfiTXE+iOTMnJ96jOBgcopJuASpgM88SyASBH0MWp/WA==}
-    engines: {node: '>=24.11.0'}
-    peerDependencies:
-      '@effect/platform': '>=0.96.0'
-      '@effect/platform-node': '>=0.107.0'
-      effect: '>=3.21.0'
-    peerDependenciesMeta:
-      '@effect/platform-node':
-        optional: true
 
   config-file-effect@0.3.0:
     resolution: {integrity: sha512-Uwv6SqbeaV61glVsBQ4F4LkiIGptieTucWirfLAX/GGYvs8TbXxiBI/gRvpG/6KopuM5Zwno+2Xiog7MysUAgg==}
@@ -3520,17 +3509,6 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  json-schema-effect@0.2.4:
-    resolution: {integrity: sha512-V41IEP57ikplMbrXy45FH4KKJGZxAd/PYqqdRmF3GXIsTg0p+o2Ay3c9tcnsoAIlV3NfGIzE5DNnw7JSqlUXqg==}
-    engines: {node: '>=24.11.0'}
-    peerDependencies:
-      '@effect/platform': '>=0.96.0'
-      '@effect/platform-node': '>=0.107.0'
-      effect: '>=3.21.0'
-    peerDependenciesMeta:
-      '@effect/platform-node':
-        optional: true
-
   json-schema-effect@0.3.0:
     resolution: {integrity: sha512-Qwd/A5n9gjQKFByCJf7mPQKNbU/Rkd9nORdvWZ9tFlT+xh2dHqtUJ/Qe/aSDPq0R4mx8h4pgXmvlMyWyayVd+w==}
     engines: {node: '>=24.11.0'}
@@ -3553,10 +3531,11 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonc-effect@0.2.1:
-    resolution: {integrity: sha512-gqxLlEStGJwmrRJZ3VyJbeb3m3yL+zptGGJrL30x0pxu2XgaWHbwM+YyruJtx4e3qXctWG79Fqyx8+VE/zNOUg==}
+  jsonc-effect@0.3.0:
+    resolution: {integrity: sha512-V0T5h2lP00K9xwdT2Js2OBdb/glCwOAerzOgvmRnF9jF+6ZezhpvRJAjx2QrlJHSd3vlb9gXXmIroQOYB2RSKg==}
+    engines: {node: '>=24.11.0'}
     peerDependencies:
-      effect: '>=3.21.0'
+      effect: ^3.21.0
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
@@ -4676,6 +4655,12 @@ packages:
     peerDependencies:
       effect: '>=3.21.0'
 
+  semver-effect@0.3.0:
+    resolution: {integrity: sha512-Gq1eOi6jn2+L1KrZVo53PkSHN8I7v4FiCp3XkRwAvPQCkHLt9+vbpUUUwUxC+jgln/g6MByvkaZW7POwnwVqCQ==}
+    engines: {node: '>=24.11.0'}
+    peerDependencies:
+      effect: ^3.21.0
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -5333,12 +5318,12 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workspaces-effect@1.2.0:
-    resolution: {integrity: sha512-roGCO4U0E9zRQaE4m6/FE+oIk9BjutOKRh0ICXpZFUhaIMYUaNozGo80lHx9vEXfOBeOuIYEe1SspXPnEz/lXQ==}
-    engines: {node: '>=24.0.0'}
+  workspaces-effect@1.3.0:
+    resolution: {integrity: sha512-cGR73JVQAhCW5z8a4Z4iGOVRGQJmL9DWYkfQMDmB3DyetrpD1yLjrBZXPujsgnBpeAsXh1PfvrgPVGwYJtmdyA==}
+    engines: {node: '>=24.11.0'}
     peerDependencies:
-      '@effect/platform': '>=0.96.0'
-      effect: '>=3.21.0'
+      '@effect/platform': ^0.96.0
+      effect: ^3.21.0
 
   wrap-ansi@10.0.0:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
@@ -5399,10 +5384,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml-effect@0.6.0:
-    resolution: {integrity: sha512-vsJasLU7QlbGLgPuFRVxnM58pXH07TXLpUMDWT0LUHNhnLDYbr2k9CWucfmRfX56qNEWL051I/SDGkhM8xzUfw==}
+  yaml-effect@0.7.0:
+    resolution: {integrity: sha512-KYPnOOWzZSLKJX4qneqI3bnTxLf/AHojnimrqTSQ9R9JU1Qgisy55pBwvqO5fJA0uG5sknu2RUa3k1lmHEDvhw==}
+    engines: {node: '>=24.11.0'}
     peerDependencies:
-      effect: '>=3.21.0'
+      effect: ^3.21.0
 
   yaml-lint@1.7.0:
     resolution: {integrity: sha512-zeBC/kskKQo4zuoGQ+IYjw6C9a/YILr2SXoEZA9jM0COrSwvwVbfTiFegT8qYBSBgOwLMWGL8sY137tOmFXGnQ==}
@@ -6542,9 +6528,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@savvy-web/bundler@1.1.0(8d50a91ef08f3ce83cd119b1b8b7f868)':
+  '@savvy-web/bundler@1.1.1(8d50a91ef08f3ce83cd119b1b8b7f868)':
     dependencies:
-      '@savvy-web/tsdown-plugins': 1.1.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.1)(effect@3.21.4)
+      '@savvy-web/tsdown-plugins': 1.1.1(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.1)(effect@3.21.4)
       '@tsdown/exe': 0.22.3(tsdown@0.22.3)
       '@types/node': 26.0.1
       '@typescript/native-preview': 7.0.0-dev.20260701.1
@@ -6575,7 +6561,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@savvy-web/cli@1.3.5(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
+  '@savvy-web/cli@1.3.6(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
     dependencies:
       '@effect/cli': 0.75.2(@effect/platform@0.96.2(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/cluster': 0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -6583,10 +6569,10 @@ snapshots:
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
-      '@savvy-web/silk-effects': 1.5.2(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      '@savvy-web/silk-effects': 1.6.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
-      jsonc-effect: 0.2.1(effect@3.21.4)
-      workspaces-effect: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      jsonc-effect: 0.3.0(effect@3.21.4)
+      workspaces-effect: 1.3.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@effect/experimental'
@@ -6598,7 +6584,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/mcp@1.4.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
+  '@savvy-web/mcp@1.5.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))':
     dependencies:
       '@effect/cluster': 0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/platform': 0.96.2(effect@3.21.4)
@@ -6606,9 +6592,9 @@ snapshots:
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@savvy-web/silk-effects': 1.5.2(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      '@savvy-web/silk-effects': 1.6.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
-      workspaces-effect: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      workspaces-effect: 1.3.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -6619,7 +6605,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/silk-effects@1.5.2(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)':
+  '@savvy-web/silk-effects@1.6.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/config': 3.1.4
@@ -6628,37 +6614,37 @@ snapshots:
       '@effect/platform': 0.96.2(effect@3.21.4)
       '@manypkg/get-packages': 1.1.3
       effect: 3.21.4
-      jsonc-effect: 0.2.1(effect@3.21.4)
+      jsonc-effect: 0.3.0(effect@3.21.4)
       mdast-util-heading-range: 4.0.0
       mdast-util-to-string: 4.0.0
       prettier: 3.9.4
       remark-gfm: 4.0.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
-      semver-effect: 0.2.1(effect@3.21.4)
+      semver-effect: 0.3.0(effect@3.21.4)
       shell-quote: 1.9.0
       sort-package-json: 4.0.0
       tinyglobby: 0.2.17
       unified: 11.0.5
       unified-lint-rule: 3.0.1
       unist-util-visit: 5.1.0
-      workspaces-effect: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      workspaces-effect: 1.3.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       yaml: 2.9.0
-      yaml-effect: 0.6.0(effect@3.21.4)
+      yaml-effect: 0.7.0(effect@3.21.4)
       yaml-lint: 1.7.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@savvy-web/silk@1.3.6(a60760d85d0f04002b6fe284b1c7d7af)':
+  '@savvy-web/silk@1.3.7(5e32bfc918828ce478a89eafefed0cb6)':
     dependencies:
       '@changesets/cli': 2.31.0(@types/node@26.0.1)
       '@commitlint/cli': 21.2.0(@types/node@26.0.1)(typescript@6.0.3)
       '@commitlint/config-conventional': 21.2.0
       '@effect/platform': 0.96.2(effect@3.21.4)
-      '@savvy-web/cli': 1.3.5(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
-      '@savvy-web/mcp': 1.4.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
-      '@savvy-web/silk-effects': 1.5.2(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      '@savvy-web/cli': 1.3.6(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
+      '@savvy-web/mcp': 1.5.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))
+      '@savvy-web/silk-effects': 1.6.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       '@types/node': 26.0.1
       '@typescript/native-preview': 7.0.0-dev.20260701.1
       commitizen: 4.3.2(@types/node@26.0.1)(typescript@6.0.3)
@@ -6674,7 +6660,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@savvy-web/tsdown-plugins@1.1.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.1)(effect@3.21.4)':
+  '@savvy-web/tsdown-plugins@1.1.1(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@types/node@26.0.1)(effect@3.21.4)':
     dependencies:
       '@changesets/get-release-plan': 4.0.16
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -6684,12 +6670,12 @@ snapshots:
       '@microsoft/tsdoc-config': 0.18.1
       deep-equal: 2.2.3
       effect: 3.21.4
-      json-schema-effect: 0.2.4(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      json-schema-effect: 0.3.0(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       picocolors: 1.1.1
       sort-package-json: 4.0.0
       std-env: 4.1.0
       typescript: 6.0.3
-      workspaces-effect: 1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
+      workspaces-effect: 1.3.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
     transitivePeerDependencies:
       - '@effect/cluster'
       - '@effect/platform'
@@ -7342,14 +7328,6 @@ snapshots:
       - typescript
 
   compute-scroll-into-view@3.1.1: {}
-
-  config-file-effect@0.2.3(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4):
-    dependencies:
-      '@effect/platform': 0.96.2(effect@3.21.4)
-      effect: 3.21.4
-      smol-toml: 1.7.0
-    optionalDependencies:
-      '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
 
   config-file-effect@0.3.0(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4):
     dependencies:
@@ -8622,14 +8600,6 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-schema-effect@0.2.4(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4):
-    dependencies:
-      '@effect/platform': 0.96.2(effect@3.21.4)
-      ajv: 8.20.0
-      effect: 3.21.4
-    optionalDependencies:
-      '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
-
   json-schema-effect@0.3.0(@effect/platform-node@0.107.0(@effect/cluster@0.59.0(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4):
     dependencies:
       '@effect/platform': 0.96.2(effect@3.21.4)
@@ -8644,7 +8614,7 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonc-effect@0.2.1(effect@3.21.4):
+  jsonc-effect@0.3.0(effect@3.21.4):
     dependencies:
       effect: 3.21.4
 
@@ -10286,6 +10256,10 @@ snapshots:
     dependencies:
       effect: 3.21.4
 
+  semver-effect@0.3.0(effect@3.21.4):
+    dependencies:
+      effect: 3.21.4
+
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -10937,7 +10911,7 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workspaces-effect@1.2.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4):
+  workspaces-effect@1.3.0(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4):
     dependencies:
       '@effect/platform': 0.96.2(effect@3.21.4)
       '@pnpm/catalogs.config': 1100.0.2
@@ -10945,10 +10919,10 @@ snapshots:
       '@pnpm/catalogs.resolver': 1100.0.0
       '@pnpm/catalogs.types': 1100.0.0
       effect: 3.21.4
-      jsonc-effect: 0.2.1(effect@3.21.4)
+      jsonc-effect: 0.3.0(effect@3.21.4)
       minimatch: 10.2.5
-      semver-effect: 0.2.1(effect@3.21.4)
-      yaml-effect: 0.6.0(effect@3.21.4)
+      semver-effect: 0.3.0(effect@3.21.4)
+      yaml-effect: 0.7.0(effect@3.21.4)
 
   wrap-ansi@10.0.0:
     dependencies:
@@ -10998,7 +10972,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml-effect@0.6.0(effect@3.21.4):
+  yaml-effect@0.7.0(effect@3.21.4):
     dependencies:
       effect: 3.21.4
 

--- a/website/docs/en/sdk/database-architecture.mdx
+++ b/website/docs/en/sdk/database-architecture.mdx
@@ -92,7 +92,7 @@ Three tables hold coverage data per run:
 
 ### Failure history and signatures
 
-`test_history` is a sliding-window log of pass/fail outcomes per test full name. `failure_signatures` deduplicate structurally identical failures across runs using a 16-character SHA-256 hash over the error name, normalized assertion shape, top-frame function name, and function-boundary line. Each `test_errors` row carries a `signature_hash` FK so you can join directly from an error to its recurrence history.
+`test_history` is a sliding-window log of pass/fail outcomes per test, keyed by module path plus full name so two tests that share a `describe › it` name in different files stay distinct series rather than colliding. `failure_signatures` deduplicate structurally identical failures across runs using a 16-character SHA-256 hash over the error name, normalized assertion shape, top-frame function name, and function-boundary line. Each `test_errors` row carries a `signature_hash` FK so you can join directly from an error to its recurrence history.
 
 See [Classification](/guide/classification) for how the history and signatures feed the `stable / new-failure / persistent / flaky / recovered` labels.
 


### PR DESCRIPTION
## Problem

Vitest's `fullName` is only the describe chain + test name — it is not file-qualified. So two test files in the same workspace package that shared a `describe › it` name collided on the old `test_history` identity `(project, full_name, timestamp)`:

- **Write side:** the second `INSERT` threw `UNIQUE constraint failed: test_history`.
- **Read side:** the two independent tests were conflated into one history series, so a pair could read as a single flaky/persistent test — and a real persistent failure could hide behind a same-named passing test in another file.

## Fix

Add a `module_path` column and make the identity `(project, module_path, full_name, timestamp)` end to end:

- **Schema/migration:** `test_history` gains `module_path`; `UNIQUE` and lookup index re-keyed (edited in place per the pre-2.0 single-migration policy).
- **Write:** `DataStore.writeHistory` takes a `modulePath` param; INSERT and the 10-entry retention window re-key on `(project, module_path, full_name)`.
- **Read:** `getHistory`, `getFlaky`, and `getPersistentFailures` group/partition by the composite key and return `modulePath`.
- **Classifier:** `HistoryTracker.classify` keys via a new exported `historyKey(modulePath, fullName)` helper.
- **Reporter:** threads each test's project-relative module path through the history/classification maps.
- **MCP:** the `test_history` tool output rows and markdown surface `modulePath`; a pre-existing ordering bug in the "recovered" filter is fixed.
- Public types `TestHistory` / `FlakyTest` / `PersistentFailure` gain a `modulePath` field.

Also bumps `xdg-effect` to `^2.1.0` in `@vitest-agent/sdk`.

## Changesets

- `@vitest-agent/sdk` **minor** — history fix + public `modulePath` surface
- `@vitest-agent/mcp` **patch** — `modulePath` in tool output + recovered ordering fix
- `@vitest-agent/plugin` **patch** — reporter module-path threading
- `@vitest-agent/sdk` **patch** — `xdg-effect` dependency bump

## Verification

sdk 1012 ✓, mcp 206 ✓, coverage meets thresholds, `types:check` clean, biome + markdownlint + commitlint pass.

> Pre-2.0 note: the schema changed, so anyone upgrading must delete their local `data.db`.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test history and reports now distinguish identically named tests from different files and include the file path for each history entry.
  * Updated the reporting output to show module path alongside flaky/persistent/recovered classifications.
* **Bug Fixes**
  * Prevented history collisions by scoping history, lookups, and SQLite pruning to `(modulePath, fullName)`, including correct recovered “recent runs” ordering.
* **Documentation**
  * Clarified database architecture docs for module-aware `test_history` keying.
* **Tests**
  * Added/updated coverage to verify distinct rows, classifications, and module-specific sliding-window/pruning behavior.
* **Chores**
  * Minor dev dependency version bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->